### PR TITLE
feat: add resume session interface to clients

### DIFF
--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -70,6 +70,39 @@ impl AsyncClient {
         Self::new(child)
     }
 
+    /// Resume a previous session by UUID
+    /// This creates a new client that resumes an existing session
+    pub async fn resume_session(session_uuid: Uuid) -> Result<Self> {
+        let child = ClaudeCliBuilder::new()
+            .resume(Some(session_uuid.to_string()))
+            .spawn()
+            .await?;
+
+        info!("Resuming Claude session with UUID: {}", session_uuid);
+        let mut client = Self::new(child)?;
+        // Pre-populate the session UUID since we're resuming
+        client.session_uuid = Some(session_uuid);
+        Ok(client)
+    }
+
+    /// Resume a previous session with a specific model
+    pub async fn resume_session_with_model(session_uuid: Uuid, model: &str) -> Result<Self> {
+        let child = ClaudeCliBuilder::new()
+            .model(model)
+            .resume(Some(session_uuid.to_string()))
+            .spawn()
+            .await?;
+
+        info!(
+            "Resuming Claude session with UUID: {} and model: {}",
+            session_uuid, model
+        );
+        let mut client = Self::new(child)?;
+        // Pre-populate the session UUID since we're resuming
+        client.session_uuid = Some(session_uuid);
+        Ok(client)
+    }
+
     /// Send a query and collect all responses until Result message
     /// This is the simplified version that collects all responses
     pub async fn query(&mut self, text: &str) -> Result<Vec<ClaudeOutput>> {

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -49,6 +49,39 @@ impl SyncClient {
         Self::new(child)
     }
 
+    /// Resume a previous session by UUID
+    /// This creates a new client that resumes an existing session
+    pub fn resume_session(session_uuid: Uuid) -> Result<Self> {
+        let child = ClaudeCliBuilder::new()
+            .resume(Some(session_uuid.to_string()))
+            .spawn_sync()
+            .map_err(Error::Io)?;
+
+        debug!("Resuming Claude session with UUID: {}", session_uuid);
+        let mut client = Self::new(child)?;
+        // Pre-populate the session UUID since we're resuming
+        client.session_uuid = Some(session_uuid);
+        Ok(client)
+    }
+
+    /// Resume a previous session with a specific model
+    pub fn resume_session_with_model(session_uuid: Uuid, model: &str) -> Result<Self> {
+        let child = ClaudeCliBuilder::new()
+            .model(model)
+            .resume(Some(session_uuid.to_string()))
+            .spawn_sync()
+            .map_err(Error::Io)?;
+
+        debug!(
+            "Resuming Claude session with UUID: {} and model: {}",
+            session_uuid, model
+        );
+        let mut client = Self::new(child)?;
+        // Pre-populate the session UUID since we're resuming
+        client.session_uuid = Some(session_uuid);
+        Ok(client)
+    }
+
     /// Send a query and collect all responses
     pub fn query(&mut self, input: ClaudeInput) -> Result<Vec<ClaudeOutput>> {
         let mut responses = Vec::new();


### PR DESCRIPTION
- Add resume_session() method to both AsyncClient and SyncClient
- Add resume_session_with_model() for resuming with specific model
- Methods take UUID parameter and use --resume flag in CLI builder
- Pre-populate session_uuid field when resuming

🤖 Generated with [Claude Code](https://claude.ai/code)