### PR TITLE
feat: add slash command tests and ping method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]


### PR DESCRIPTION
- Fixed num_turns field to be i32 (can be -1 for slash commands)
- Added parse_json_tolerant method to handle ANSI escape codes
- Added comprehensive tests for /help, /status, /cost slash commands
- Added ping() method to both AsyncClient and SyncClient for connectivity testing
- Bumped version to 0.2.1