### PR TITLE
Release v2.1.3 - sync versioning with Claude CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.0.76"
+version = "2.1.3"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ claude-codes = { version = "2", default-features = false, features = ["sync-clie
 claude-codes = { version = "2", default-features = false, features = ["async-client"] }
 ```
 
+### WASM Support
+
+The `types` feature is fully compatible with `wasm32-unknown-unknown`, making it suitable for sharing Claude message types between native and browser/WASM code:
+
+```toml
+[dependencies]
+claude-codes = { version = "2", default-features = false, features = ["types"] }
+```
+
+This gives you access to all the typed message structures (`ClaudeInput`, `ClaudeOutput`, `ContentBlock`, etc.) without pulling in tokio or other native-only dependencies. Useful for:
+
+- Frontend applications that communicate with a Claude proxy
+- Shared type definitions across native backend and WASM frontend
+- Any WASM context needing Claude protocol types
+
 ## Usage
 
 ### Async Client
@@ -135,7 +150,7 @@ let serialized = Protocol::serialize(&output)?;
 
 ## Compatibility
 
-**Tested version:** Claude CLI 2.0.76
+**Tested version:** Claude CLI 2.1.3
 
 If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-claude-codes/issues

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@
 //! ⚠️ **Important**: The Claude CLI protocol is unstable and evolving. This crate
 //! automatically checks your Claude CLI version and warns if it's newer than tested.
 //!
-//! Current tested version: **2.0.76**
+//! Current tested version: **2.1.3**
 //!
 //! Report compatibility issues at: <https://github.com/meawoppl/rust-claude-codes/pulls>
 //!


### PR DESCRIPTION
## Summary
- Update version to 2.1.3 to match current Claude CLI version
- Add WASM support documentation to README explaining the `types` feature works with `wasm32-unknown-unknown`

## Test plan
- [ ] CI passes (feature matrix, WASM compatibility)
- [ ] Integration tests pass