### PR TITLE
feat: add typed system message subtypes (status, compact_boundary)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,9 @@ pub use io::{
     McpMessageRequest, PermissionResult, ToolPermissionRequest, ToolUseBlock,
 };
 
+// System message subtype types
+pub use io::{CompactBoundaryMessage, CompactMetadata, InitMessage, StatusMessage, SystemMessage};
+
 // Typed tool input types
 pub use tool_inputs::{
     AllowedPrompt, AskUserQuestionInput, BashInput, EditInput, EnterPlanModeInput,


### PR DESCRIPTION
## Summary

- Adds proper type definitions for system message subtypes (`status`, `compact_boundary`, `init`)
- Replaces the generic `Value` approach with a tagged enum for type-safe handling
- Unknown subtypes fall back to `Other` variant for forward compatibility

## New Types

```rust
pub enum SystemMessage {
    Init(InitSystemMessage),
    Status(StatusSystemMessage),
    CompactBoundary(CompactBoundaryMessage),
    Other,  // Fallback for unknown subtypes
}

pub struct StatusSystemMessage {
    pub session_id: Option<String>,
    pub status: Option<String>,  // e.g., "compacting" or null
    pub uuid: Option<String>,
}

pub struct CompactBoundaryMessage {
    pub session_id: Option<String>,
    pub compact_metadata: CompactMetadata,
    pub uuid: Option<String>,
}

pub struct CompactMetadata {
    pub pre_tokens: u64,
    pub trigger: String,  // "auto" or "manual"
}
```

## Test plan

- [x] Added unit tests for deserializing status messages
- [x] Added unit tests for deserializing compact_boundary messages
- [x] Added unit tests for deserializing init messages
- [x] Added unit tests for unknown subtype fallback
- [x] All existing tests pass
- [x] Clippy passes with no warnings

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)