### PR TITLE
feat: re-export io module content block types at crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,12 @@ pub use messages::*;
 pub use protocol::{MessageEnvelope, Protocol};
 pub use types::*;
 
+// Content block types for message parsing
+pub use io::{
+    ContentBlock, ImageBlock, ImageSource, TextBlock, ThinkingBlock, ToolResultBlock,
+    ToolResultContent,
+};
+
 // Control protocol types for tool permission handling
 pub use io::{
     ControlRequest, ControlRequestMessage, ControlRequestPayload, ControlResponse,


### PR DESCRIPTION
## Summary

Re-export commonly used content block types for easier access:
- `ContentBlock`, `TextBlock`, `ToolResultBlock`
- `ImageBlock`, `ImageSource`, `ThinkingBlock`
- `ToolResultContent`

## Before
```rust
use claude_codes::io::{ContentBlock, ToolResultContent};
```

## After
```rust
use claude_codes::{ContentBlock, ToolResultContent};
```

## Test plan
- [x] All 54 tests pass

Closes #21

🤖 Generated with [Claude Code](https://claude.ai/code)