### PR TITLE
feat: type the usage field in AssistantMessageContent

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -276,7 +276,47 @@ pub struct AssistantMessageContent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_sequence: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub usage: Option<serde_json::Value>,
+    pub usage: Option<AssistantUsage>,
+}
+
+/// Usage information for assistant messages
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssistantUsage {
+    /// Number of input tokens
+    #[serde(default)]
+    pub input_tokens: u32,
+
+    /// Number of output tokens
+    #[serde(default)]
+    pub output_tokens: u32,
+
+    /// Tokens used to create cache
+    #[serde(default)]
+    pub cache_creation_input_tokens: u32,
+
+    /// Tokens read from cache
+    #[serde(default)]
+    pub cache_read_input_tokens: u32,
+
+    /// Service tier used (e.g., "standard")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
+
+    /// Detailed cache creation breakdown
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_creation: Option<CacheCreationDetails>,
+}
+
+/// Detailed cache creation information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheCreationDetails {
+    /// Ephemeral 1-hour input tokens
+    #[serde(default)]
+    pub ephemeral_1h_input_tokens: u32,
+
+    /// Ephemeral 5-minute input tokens
+    #[serde(default)]
+    pub ephemeral_5m_input_tokens: u32,
 }
 
 /// Content blocks for messages

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,9 @@ pub use io::{
 // System message subtype types
 pub use io::{CompactBoundaryMessage, CompactMetadata, InitMessage, StatusMessage, SystemMessage};
 
+// Usage types
+pub use io::{AssistantUsage, CacheCreationDetails};
+
 // Typed tool input types
 pub use tool_inputs::{
     AllowedPrompt, AskUserQuestionInput, BashInput, EditInput, EnterPlanModeInput,


### PR DESCRIPTION
## Summary

Replace `Option<serde_json::Value>` with typed `Option<AssistantUsage>` for the usage field in `AssistantMessageContent`.

## New Types

```rust
pub struct AssistantUsage {
    pub input_tokens: u32,
    pub output_tokens: u32,
    pub cache_creation_input_tokens: u32,
    pub cache_read_input_tokens: u32,
    pub service_tier: Option<String>,
    pub cache_creation: Option<CacheCreationDetails>,
}

pub struct CacheCreationDetails {
    pub ephemeral_1h_input_tokens: u32,
    pub ephemeral_5m_input_tokens: u32,
}
```

## Test plan
- [x] All 54 library tests pass
- [x] All 23 integration tests pass (including real captured messages)

Closes #22

🤖 Generated with [Claude Code](https://claude.ai/code)