### PR TITLE
feat: add errors field to ResultMessage

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -439,6 +439,13 @@ pub struct ResultMessage {
     #[serde(default)]
     pub permission_denials: Vec<Value>,
 
+    /// Error messages when `is_error` is true.
+    ///
+    /// Contains human-readable error strings (e.g., "No conversation found with session ID: ...").
+    /// This allows typed access to error conditions without needing to serialize to JSON and search.
+    #[serde(default)]
+    pub errors: Vec<String>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uuid: Option<String>,
 }
@@ -1075,6 +1082,77 @@ mod tests {
 
         let output: ClaudeOutput = serde_json::from_str(json).unwrap();
         assert!(!output.is_error());
+    }
+
+    #[test]
+    fn test_deserialize_result_message_with_errors() {
+        let json = r#"{
+            "type": "result",
+            "subtype": "error_during_execution",
+            "duration_ms": 0,
+            "duration_api_ms": 0,
+            "is_error": true,
+            "num_turns": 0,
+            "session_id": "27934753-425a-4182-892c-6b1c15050c3f",
+            "total_cost_usd": 0,
+            "errors": ["No conversation found with session ID: d56965c9-c855-4042-a8f5-f12bbb14d6f6"],
+            "permission_denials": []
+        }"#;
+
+        let output: ClaudeOutput = serde_json::from_str(json).unwrap();
+        assert!(output.is_error());
+
+        if let ClaudeOutput::Result(res) = output {
+            assert!(res.is_error);
+            assert_eq!(res.errors.len(), 1);
+            assert!(res.errors[0].contains("No conversation found"));
+        } else {
+            panic!("Expected Result message");
+        }
+    }
+
+    #[test]
+    fn test_deserialize_result_message_errors_defaults_empty() {
+        // Test that errors field defaults to empty Vec when not present
+        let json = r#"{
+            "type": "result",
+            "subtype": "success",
+            "is_error": false,
+            "duration_ms": 100,
+            "duration_api_ms": 200,
+            "num_turns": 1,
+            "session_id": "123",
+            "total_cost_usd": 0.01
+        }"#;
+
+        let output: ClaudeOutput = serde_json::from_str(json).unwrap();
+        if let ClaudeOutput::Result(res) = output {
+            assert!(res.errors.is_empty());
+        } else {
+            panic!("Expected Result message");
+        }
+    }
+
+    #[test]
+    fn test_result_message_errors_roundtrip() {
+        let json = r#"{
+            "type": "result",
+            "subtype": "error_during_execution",
+            "is_error": true,
+            "duration_ms": 0,
+            "duration_api_ms": 0,
+            "num_turns": 0,
+            "session_id": "test-session",
+            "total_cost_usd": 0.0,
+            "errors": ["Error 1", "Error 2"]
+        }"#;
+
+        let output: ClaudeOutput = serde_json::from_str(json).unwrap();
+        let reserialized = serde_json::to_string(&output).unwrap();
+
+        // Verify the errors are preserved
+        assert!(reserialized.contains("Error 1"));
+        assert!(reserialized.contains("Error 2"));
     }
 
     // ============================================================================


### PR DESCRIPTION
## Summary
- Add `errors: Vec<String>` field to `ResultMessage` struct
- Field captures error messages when `is_error` is true (e.g., "No conversation found with session ID: ...")
- Defaults to empty Vec when not present in JSON, maintaining backwards compatibility

## Use Case
When resuming a Claude session that no longer exists, Claude returns an error with the errors array populated. This change allows typed access to detect and handle specific error conditions:

```rust
if let ClaudeOutput::Result(res) = &output {
    if res.errors.iter().any(|e| e.contains("No conversation found")) {
        // handle session not found - restart fresh
    }
}
```

## Test plan
- [x] All existing 67 unit tests pass
- [x] All 23 integration tests pass
- [x] New test `test_deserialize_result_message_with_errors` validates parsing JSON with errors
- [x] New test `test_deserialize_result_message_errors_defaults_empty` validates default behavior
- [x] New test `test_result_message_errors_roundtrip` validates serialization roundtrip

Closes #36
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)