### PR TITLE
style: apply rustfmt formatting to tool_input_tests.rs

### DIFF
--- a/tests/tool_input_tests.rs
+++ b/tests/tool_input_tests.rs
@@ -551,8 +551,8 @@ fn test_parse_tool_result_error_message() {
 #[test]
 fn test_parse_tool_result_structured_content() {
     let json_str = include_str!("../test_cases/tool_use_captures/tool_result_structured.json");
-    let output: ClaudeOutput =
-        serde_json::from_str(json_str).expect("Failed to parse tool result with structured content");
+    let output: ClaudeOutput = serde_json::from_str(json_str)
+        .expect("Failed to parse tool result with structured content");
 
     // Verify it's a user message with tool_result content
     if let ClaudeOutput::User(user) = output {
@@ -573,7 +573,10 @@ fn test_parse_tool_result_structured_content() {
                 assert!(text.is_some());
                 assert!(text.unwrap().contains("React"));
             } else {
-                panic!("Expected Structured content in tool result, got: {:?}", result.content);
+                panic!(
+                    "Expected Structured content in tool result, got: {:?}",
+                    result.content
+                );
             }
         } else {
             panic!("Expected ToolResult content block");
@@ -587,8 +590,8 @@ fn test_parse_tool_result_structured_content() {
 #[test]
 fn test_parse_tool_result_multi_text_structured() {
     let json_str = include_str!("../test_cases/tool_use_captures/tool_result_multi_text.json");
-    let output: ClaudeOutput =
-        serde_json::from_str(json_str).expect("Failed to parse tool result with multi-text content");
+    let output: ClaudeOutput = serde_json::from_str(json_str)
+        .expect("Failed to parse tool result with multi-text content");
 
     // Verify it's a user message with tool_result content
     if let ClaudeOutput::User(user) = output {
@@ -614,7 +617,10 @@ fn test_parse_tool_result_multi_text_structured() {
                 let agent_text = second.get("text").and_then(|v| v.as_str()).unwrap();
                 assert!(agent_text.contains("agentId"));
             } else {
-                panic!("Expected Structured content in tool result, got: {:?}", result.content);
+                panic!(
+                    "Expected Structured content in tool result, got: {:?}",
+                    result.content
+                );
             }
         } else {
             panic!("Expected ToolResult content block");


### PR DESCRIPTION
## Summary
- Applies rustfmt formatting to `tests/tool_input_tests.rs`
- Fixes CI formatting check failure on main

## Test plan
- [x] `cargo fmt --check` passes locally
- [x] CI should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)