### PR TITLE
chore: update Cargo.lock to 2.1.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.16"
+version = "2.1.17"
 dependencies = [
  "anyhow",
  "base64",


### PR DESCRIPTION
Updates Cargo.lock to reflect version 2.1.17.