### PR TITLE
feat: add ClaudeOutput::Unparsed variant for malformed output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`ClaudeOutput::Unparsed` variant for malformed output** - New variant that captures raw content when the Claude CLI emits data that can't be parsed as a known message type. This allows the stream to continue processing without failing on corrupted or unexpected data.
+
+  ```rust
+  use claude_codes::ClaudeOutput;
+
+  // Parse permissively - never fails, returns Unparsed for bad data
+  let output = ClaudeOutput::parse_json_permissive("not valid json");
+
+  if let ClaudeOutput::Unparsed(unparsed) = output {
+      eprintln!("Unparsed content: {}", unparsed.raw);
+      if let Some(ref err) = unparsed.error {
+          eprintln!("Parse error: {}", err);
+      }
+  }
+  ```
+
+  Helper methods:
+  - `ClaudeOutput::parse_json_permissive(s)` - Parse that never fails, returns `Unparsed` on error
+  - `ClaudeOutput::is_unparsed()` - Check if this is unparsed content
+  - `ClaudeOutput::as_unparsed()` - Get the `UnparsedOutput` if this is one
+
 ## [2.1.17] - 2026-01-25
 
 ### Added

--- a/examples/basic_repl.rs
+++ b/examples/basic_repl.rs
@@ -245,5 +245,12 @@ fn handle_output(output: ClaudeOutput) {
                 eprintln!("   Request ID: {}", req_id);
             }
         }
+        ClaudeOutput::Unparsed(unparsed) => {
+            eprintln!("\n⚠️  UNPARSED OUTPUT:");
+            eprintln!("   Raw: {}", unparsed.raw);
+            if let Some(ref err) = unparsed.error {
+                eprintln!("   Error: {}", err);
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ pub mod version;
 pub use error::{Error, Result};
 pub use io::{
     AnthropicError, AnthropicErrorDetails, AssistantMessageContent, ClaudeInput, ClaudeOutput,
-    ParseError,
+    ParseError, UnparsedOutput,
 };
 pub use messages::*;
 pub use protocol::{MessageEnvelope, Protocol};


### PR DESCRIPTION
## Summary

Adds a new `ClaudeOutput::Unparsed` variant that captures raw content when the Claude CLI emits data that can't be parsed as a known message type. This allows the stream to continue processing without failing on corrupted or unexpected data.

### Changes
- Add `UnparsedOutput` struct with `raw` content and optional `error` message
- Add `ClaudeOutput::Unparsed` variant (skipped in serde to avoid serialization conflicts)
- Add `parse_json_permissive()` method that never fails - returns `Unparsed` on error
- Add `is_unparsed()` and `as_unparsed()` helper methods
- Update `basic_repl` example to handle the new variant
- Add comprehensive tests

### Motivation

This addresses issues where raw code fragments or other non-JSON data appear in the stdout stream (as seen in parse-error-new.txt logs), causing the client to fail. With permissive parsing, consumers can continue processing the stream while logging/handling the malformed data.

## Test plan
- [x] Unit tests for `parse_json_permissive` with invalid JSON
- [x] Unit tests for `parse_json_permissive` with unknown type
- [x] Unit tests for `parse_json_permissive` with valid input
- [x] Test simulating raw code fragment scenario
- [x] All 102 existing tests pass