### PR TITLE
Bump version to 2.1.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.45] - 2026-02-18
+
+### Added
+
+- **Expanded `InitMessage` fields** - Added typed fields for `slash_commands`, `agents`, `plugins`, `skills`, `claude_code_version`, `api_key_source`, `output_style`, and `permission_mode`
+- **`PluginInfo` struct** - Typed representation of plugin entries with `name` and `path` fields
+- **`allow_recursion()` on `ClaudeCliBuilder`** - Enables spawning Claude CLI from within a Claude Code session by unsetting `CLAUDECODE` env var
+- **`/clear` integration test** - Verifies session ID resets after `/clear` command
+
+### Changed
+
+- Updated `TESTED_VERSION` to `2.1.47`
+- All integration tests now use `allow_recursion()` for reliable execution inside Claude Code sessions
+
 ## [2.1.20] - 2026-02-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.20"
+version = "2.1.45"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.20"
+version = "2.1.45"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/src/version.rs
+++ b/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.0.76";
+const TESTED_VERSION: &str = "2.1.47";
 
 /// Ensures version warning is only shown once per session
 static VERSION_CHECK: Once = Once::new();


### PR DESCRIPTION
## Summary
- Bump crate version from 2.1.20 to 2.1.45
- Update TESTED_VERSION from 2.0.76 to 2.1.47
- Add CHANGELOG entry for 2.1.45 covering all changes since 2.1.20