### PR TITLE
Bump version to 2.1.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.46] - 2026-02-20
+
+### Fixed
+
+- **`RateLimitInfo.overage_status`** now `Option<String>` — `allowed_warning` events omit this field, previously causing deserialization failures
+
+### Added
+
+- **`RateLimitInfo.utilization`** — `Option<f64>` capturing rate limit usage (0.0–1.0)
+
 ## [2.1.45] - 2026-02-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.45"
+version = "2.1.46"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.45"
+version = "2.1.46"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]


### PR DESCRIPTION
## Summary
- Bump crate version from 2.1.45 to 2.1.46
- Add CHANGELOG entry for rate limit field fixes