### PR TITLE
Add codex-codes crate with Codex SDK types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-codes"
+version = "0.0.1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["codex-codes"]
+
 [package]
 name = "claude-codes"
 version = "2.1.46"

--- a/claude.md
+++ b/claude.md
@@ -201,6 +201,10 @@ When updating the version number in `Cargo.toml`:
 
 This ensures the lockfile stays in sync with the version number.
 
+## Publishing
+- **NEVER use `cargo publish --allow-dirty`** — ensure the working tree is clean before publishing
+- If there are untracked files, either `.gitignore` them or clean them up first
+
 ## Dependency Management
 When adding or updating dependencies:
 - **ALWAYS use `cargo add` or `cargo remove` commands** instead of manually editing `Cargo.toml`

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "codex-codes"
+version = "0.0.1"
+edition = "2021"
+rust-version = "1.85"
+authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
+description = "A tightly typed Rust interface for the OpenAI Codex CLI JSON protocol"
+documentation = "https://docs.rs/codex-codes"
+homepage = "https://github.com/meawoppl/rust-claude-codes"
+repository = "https://github.com/meawoppl/rust-claude-codes"
+license = "Apache-2.0"
+readme = "README.md"
+keywords = ["codex", "openai", "ai", "json", "protocol"]
+categories = ["api-bindings", "encoding", "parsing"]
+exclude = [
+    "test_cases/",
+    ".claude/",
+    "*.sh",
+]
+
+[dependencies]
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.143"
+thiserror = "2.0.16"
+
+[dev-dependencies]
+serde_json = "1.0.143"

--- a/codex-codes/README.md
+++ b/codex-codes/README.md
@@ -1,0 +1,53 @@
+# codex-codes
+
+A tightly typed Rust interface for the [OpenAI Codex CLI](https://github.com/openai/codex) JSON protocol.
+
+This crate provides type-safe Rust representations of the Codex CLI's JSONL output format, mirroring the structure of the official [TypeScript SDK](https://github.com/openai/codex/tree/main/sdk/typescript).
+
+## Types
+
+### Events (`ThreadEvent`)
+
+Discriminated union of all events emitted during thread execution:
+
+- `thread.started` — Thread initialized with an ID
+- `turn.started` / `turn.completed` / `turn.failed` — Turn lifecycle
+- `item.started` / `item.updated` / `item.completed` — Item lifecycle
+- `error` — Thread-level error
+
+### Items (`ThreadItem`)
+
+Discriminated union of all agent action items:
+
+- `agent_message` — Text output from the model
+- `reasoning` — Chain-of-thought reasoning
+- `command_execution` — Shell command with output and exit code
+- `file_change` — File modifications (add/delete/update)
+- `mcp_tool_call` — MCP tool invocation
+- `web_search` — Web search query
+- `todo_list` — Task tracking list
+- `error` — Error item
+
+### Options
+
+- `ThreadOptions` — Per-thread configuration
+- `ApprovalMode` — Tool execution approval policy
+- `SandboxMode` — File system access control
+- `ModelReasoningEffort` — Reasoning effort level
+- `WebSearchMode` — Web search behavior
+
+## Example
+
+```rust
+use codex_codes::{ThreadEvent, ThreadItem};
+
+let event_json = r#"{"type":"thread.started","thread_id":"th_abc"}"#;
+let event: ThreadEvent = serde_json::from_str(event_json).unwrap();
+
+let item_json = r#"{"type":"agent_message","id":"msg_1","text":"Hello!"}"#;
+let item: ThreadItem = serde_json::from_str(item_json).unwrap();
+```
+
+## License
+
+Apache-2.0

--- a/codex-codes/src/io/events.rs
+++ b/codex-codes/src/io/events.rs
@@ -1,0 +1,156 @@
+use serde::{Deserialize, Serialize};
+
+use super::items::ThreadItem;
+
+/// Token usage statistics for a completed turn.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Usage {
+    pub input_tokens: u64,
+    pub cached_input_tokens: u64,
+    pub output_tokens: u64,
+}
+
+/// Error information from a thread.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThreadError {
+    pub message: String,
+}
+
+/// Event indicating a thread has started.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThreadStartedEvent {
+    pub thread_id: String,
+}
+
+/// Event indicating a turn has started.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TurnStartedEvent {}
+
+/// Event indicating a turn has completed successfully.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TurnCompletedEvent {
+    pub usage: Usage,
+}
+
+/// Event indicating a turn has failed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TurnFailedEvent {
+    pub error: ThreadError,
+}
+
+/// Event indicating an item has started processing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ItemStartedEvent {
+    pub item: ThreadItem,
+}
+
+/// Event indicating an item has been updated.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ItemUpdatedEvent {
+    pub item: ThreadItem,
+}
+
+/// Event indicating an item has completed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ItemCompletedEvent {
+    pub item: ThreadItem,
+}
+
+/// A thread-level error event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThreadErrorEvent {
+    pub message: String,
+}
+
+/// All possible events emitted during a Codex thread execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ThreadEvent {
+    #[serde(rename = "thread.started")]
+    ThreadStarted(ThreadStartedEvent),
+    #[serde(rename = "turn.started")]
+    TurnStarted(TurnStartedEvent),
+    #[serde(rename = "turn.completed")]
+    TurnCompleted(TurnCompletedEvent),
+    #[serde(rename = "turn.failed")]
+    TurnFailed(TurnFailedEvent),
+    #[serde(rename = "item.started")]
+    ItemStarted(ItemStartedEvent),
+    #[serde(rename = "item.updated")]
+    ItemUpdated(ItemUpdatedEvent),
+    #[serde(rename = "item.completed")]
+    ItemCompleted(ItemCompletedEvent),
+    Error(ThreadErrorEvent),
+}
+
+impl ThreadEvent {
+    /// Returns the event type string.
+    pub fn event_type(&self) -> &str {
+        match self {
+            ThreadEvent::ThreadStarted(_) => "thread.started",
+            ThreadEvent::TurnStarted(_) => "turn.started",
+            ThreadEvent::TurnCompleted(_) => "turn.completed",
+            ThreadEvent::TurnFailed(_) => "turn.failed",
+            ThreadEvent::ItemStarted(_) => "item.started",
+            ThreadEvent::ItemUpdated(_) => "item.updated",
+            ThreadEvent::ItemCompleted(_) => "item.completed",
+            ThreadEvent::Error(_) => "error",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_thread_started() {
+        let json = r#"{"type":"thread.started","thread_id":"th_abc123"}"#;
+        let event: ThreadEvent = serde_json::from_str(json).unwrap();
+        assert!(matches!(event, ThreadEvent::ThreadStarted(ref e) if e.thread_id == "th_abc123"));
+        assert_eq!(event.event_type(), "thread.started");
+    }
+
+    #[test]
+    fn test_deserialize_turn_started() {
+        let json = r#"{"type":"turn.started"}"#;
+        let event: ThreadEvent = serde_json::from_str(json).unwrap();
+        assert!(matches!(event, ThreadEvent::TurnStarted(_)));
+    }
+
+    #[test]
+    fn test_deserialize_turn_completed() {
+        let json = r#"{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":50,"output_tokens":200}}"#;
+        let event: ThreadEvent = serde_json::from_str(json).unwrap();
+        if let ThreadEvent::TurnCompleted(e) = &event {
+            assert_eq!(e.usage.input_tokens, 100);
+            assert_eq!(e.usage.cached_input_tokens, 50);
+            assert_eq!(e.usage.output_tokens, 200);
+        } else {
+            panic!("Expected TurnCompleted");
+        }
+    }
+
+    #[test]
+    fn test_deserialize_turn_failed() {
+        let json = r#"{"type":"turn.failed","error":{"message":"rate limited"}}"#;
+        let event: ThreadEvent = serde_json::from_str(json).unwrap();
+        assert!(
+            matches!(event, ThreadEvent::TurnFailed(ref e) if e.error.message == "rate limited")
+        );
+    }
+
+    #[test]
+    fn test_deserialize_item_started() {
+        let json = r#"{"type":"item.started","item":{"type":"agent_message","id":"msg_1","text":"Starting..."}}"#;
+        let event: ThreadEvent = serde_json::from_str(json).unwrap();
+        assert!(matches!(event, ThreadEvent::ItemStarted(_)));
+    }
+
+    #[test]
+    fn test_deserialize_error_event() {
+        let json = r#"{"type":"error","message":"connection lost"}"#;
+        let event: ThreadEvent = serde_json::from_str(json).unwrap();
+        assert!(matches!(event, ThreadEvent::Error(ref e) if e.message == "connection lost"));
+    }
+}

--- a/codex-codes/src/io/items.rs
+++ b/codex-codes/src/io/items.rs
@@ -1,0 +1,209 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Status of a command execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandExecutionStatus {
+    InProgress,
+    Completed,
+    Failed,
+}
+
+/// A command execution item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandExecutionItem {
+    pub id: String,
+    pub command: String,
+    pub aggregated_output: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    pub status: CommandExecutionStatus,
+}
+
+/// Kind of patch change applied to a file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PatchChangeKind {
+    Add,
+    Delete,
+    Update,
+}
+
+/// A single file update within a file change item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileUpdateChange {
+    pub path: String,
+    pub kind: PatchChangeKind,
+}
+
+/// Status of a patch apply operation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PatchApplyStatus {
+    Completed,
+    Failed,
+}
+
+/// A file change item representing one or more file modifications.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileChangeItem {
+    pub id: String,
+    pub changes: Vec<FileUpdateChange>,
+    pub status: PatchApplyStatus,
+}
+
+/// Status of an MCP tool call.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpToolCallStatus {
+    InProgress,
+    Completed,
+    Failed,
+}
+
+/// Result of an MCP tool call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpToolCallResult {
+    pub content: Vec<Value>,
+    pub structured_content: Value,
+}
+
+/// Error from an MCP tool call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpToolCallError {
+    pub message: String,
+}
+
+/// An MCP tool call item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpToolCallItem {
+    pub id: String,
+    pub server: String,
+    pub tool: String,
+    pub arguments: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<McpToolCallResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<McpToolCallError>,
+    pub status: McpToolCallStatus,
+}
+
+/// An agent message item containing text output.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentMessageItem {
+    pub id: String,
+    pub text: String,
+}
+
+/// A reasoning item containing the model's chain-of-thought.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReasoningItem {
+    pub id: String,
+    pub text: String,
+}
+
+/// A web search item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebSearchItem {
+    pub id: String,
+    pub query: String,
+}
+
+/// An error item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorItem {
+    pub id: String,
+    pub message: String,
+}
+
+/// A single todo entry within a todo list.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TodoItem {
+    pub text: String,
+    pub completed: bool,
+}
+
+/// A todo list item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TodoListItem {
+    pub id: String,
+    pub items: Vec<TodoItem>,
+}
+
+/// All possible thread item types emitted by the Codex CLI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ThreadItem {
+    AgentMessage(AgentMessageItem),
+    Reasoning(ReasoningItem),
+    CommandExecution(CommandExecutionItem),
+    FileChange(FileChangeItem),
+    McpToolCall(McpToolCallItem),
+    WebSearch(WebSearchItem),
+    TodoList(TodoListItem),
+    Error(ErrorItem),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_agent_message() {
+        let json = r#"{"type":"agent_message","id":"msg_1","text":"Hello world"}"#;
+        let item: ThreadItem = serde_json::from_str(json).unwrap();
+        assert!(matches!(item, ThreadItem::AgentMessage(ref m) if m.text == "Hello world"));
+    }
+
+    #[test]
+    fn test_deserialize_command_execution() {
+        let json = r#"{"type":"command_execution","id":"cmd_1","command":"ls -la","aggregated_output":"total 0","exit_code":0,"status":"completed"}"#;
+        let item: ThreadItem = serde_json::from_str(json).unwrap();
+        assert!(matches!(item, ThreadItem::CommandExecution(ref c) if c.exit_code == Some(0)));
+    }
+
+    #[test]
+    fn test_deserialize_file_change() {
+        let json = r#"{"type":"file_change","id":"fc_1","changes":[{"path":"src/main.rs","kind":"update"}],"status":"completed"}"#;
+        let item: ThreadItem = serde_json::from_str(json).unwrap();
+        assert!(
+            matches!(item, ThreadItem::FileChange(ref f) if f.changes[0].kind == PatchChangeKind::Update)
+        );
+    }
+
+    #[test]
+    fn test_deserialize_todo_list() {
+        let json = r#"{"type":"todo_list","id":"td_1","items":[{"text":"Fix bug","completed":false},{"text":"Write tests","completed":true}]}"#;
+        let item: ThreadItem = serde_json::from_str(json).unwrap();
+        assert!(matches!(item, ThreadItem::TodoList(ref t) if t.items.len() == 2));
+    }
+
+    #[test]
+    fn test_deserialize_error() {
+        let json = r#"{"type":"error","id":"err_1","message":"something went wrong"}"#;
+        let item: ThreadItem = serde_json::from_str(json).unwrap();
+        assert!(matches!(item, ThreadItem::Error(ref e) if e.message == "something went wrong"));
+    }
+
+    #[test]
+    fn test_deserialize_reasoning() {
+        let json = r#"{"type":"reasoning","id":"r_1","text":"Let me think about this..."}"#;
+        let item: ThreadItem = serde_json::from_str(json).unwrap();
+        assert!(matches!(item, ThreadItem::Reasoning(ref r) if r.text.contains("think")));
+    }
+
+    #[test]
+    fn test_deserialize_web_search() {
+        let json = r#"{"type":"web_search","id":"ws_1","query":"rust serde tutorial"}"#;
+        let item: ThreadItem = serde_json::from_str(json).unwrap();
+        assert!(matches!(item, ThreadItem::WebSearch(ref w) if w.query == "rust serde tutorial"));
+    }
+
+    #[test]
+    fn test_deserialize_mcp_tool_call() {
+        let json = r#"{"type":"mcp_tool_call","id":"mcp_1","server":"my-server","tool":"my-tool","arguments":{"key":"value"},"status":"completed","result":{"content":[],"structured_content":null}}"#;
+        let item: ThreadItem = serde_json::from_str(json).unwrap();
+        assert!(matches!(item, ThreadItem::McpToolCall(ref m) if m.tool == "my-tool"));
+    }
+}

--- a/codex-codes/src/io/mod.rs
+++ b/codex-codes/src/io/mod.rs
@@ -1,0 +1,3 @@
+pub mod events;
+pub mod items;
+pub mod options;

--- a/codex-codes/src/io/options.rs
+++ b/codex-codes/src/io/options.rs
@@ -1,0 +1,106 @@
+use serde::{Deserialize, Serialize};
+
+/// Approval mode for tool execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ApprovalMode {
+    Never,
+    OnRequest,
+    OnFailure,
+    Untrusted,
+}
+
+/// Sandbox mode controlling file system access.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SandboxMode {
+    ReadOnly,
+    WorkspaceWrite,
+    DangerFullAccess,
+}
+
+/// Model reasoning effort level.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelReasoningEffort {
+    Minimal,
+    Low,
+    Medium,
+    High,
+    Xhigh,
+}
+
+/// Web search mode.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WebSearchMode {
+    Disabled,
+    Cached,
+    Live,
+}
+
+/// Per-thread options controlling model, sandbox, and behavior.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ThreadOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sandbox_mode: Option<SandboxMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub working_directory: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skip_git_repo_check: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_reasoning_effort: Option<ModelReasoningEffort>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network_access_enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub web_search_mode: Option<WebSearchMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub web_search_enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval_policy: Option<ApprovalMode>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub additional_directories: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_thread_options_default() {
+        let opts = ThreadOptions::default();
+        assert!(opts.model.is_none());
+        assert!(opts.sandbox_mode.is_none());
+        assert!(opts.additional_directories.is_empty());
+    }
+
+    #[test]
+    fn test_approval_mode_serde() {
+        let json = r#""on-request""#;
+        let mode: ApprovalMode = serde_json::from_str(json).unwrap();
+        assert_eq!(mode, ApprovalMode::OnRequest);
+    }
+
+    #[test]
+    fn test_sandbox_mode_serde() {
+        let json = r#""workspace-write""#;
+        let mode: SandboxMode = serde_json::from_str(json).unwrap();
+        assert_eq!(mode, SandboxMode::WorkspaceWrite);
+    }
+
+    #[test]
+    fn test_reasoning_effort_serde() {
+        let json = r#""xhigh""#;
+        let effort: ModelReasoningEffort = serde_json::from_str(json).unwrap();
+        assert_eq!(effort, ModelReasoningEffort::Xhigh);
+    }
+
+    #[test]
+    fn test_web_search_mode_serde() {
+        let json = r#""live""#;
+        let mode: WebSearchMode = serde_json::from_str(json).unwrap();
+        assert_eq!(mode, WebSearchMode::Live);
+    }
+}

--- a/codex-codes/src/lib.rs
+++ b/codex-codes/src/lib.rs
@@ -1,0 +1,46 @@
+//! A tightly typed Rust interface for the OpenAI Codex CLI JSON protocol.
+//!
+//! This crate provides type-safe representations of the Codex CLI's JSONL output,
+//! mirroring the structure of the official TypeScript SDK (`@openai/codex-sdk`).
+//!
+//! # Message Types
+//!
+//! The protocol uses two primary discriminated unions:
+//!
+//! - [`ThreadEvent`] — Events emitted during thread execution (thread/turn/item lifecycle)
+//! - [`ThreadItem`] — Data items representing agent actions (messages, commands, file changes, etc.)
+//!
+//! # Configuration Types
+//!
+//! - [`ThreadOptions`] — Per-thread settings (model, sandbox mode, approval policy)
+//! - [`ApprovalMode`], [`SandboxMode`], [`ModelReasoningEffort`], [`WebSearchMode`] — Typed enums
+//!
+//! # Example
+//!
+//! ```
+//! use codex_codes::{ThreadEvent, ThreadItem};
+//!
+//! let json = r#"{"type":"thread.started","thread_id":"th_abc"}"#;
+//! let event: ThreadEvent = serde_json::from_str(json).unwrap();
+//! ```
+
+mod io;
+
+// Events
+pub use io::events::{
+    ItemCompletedEvent, ItemStartedEvent, ItemUpdatedEvent, ThreadError, ThreadErrorEvent,
+    ThreadEvent, ThreadStartedEvent, TurnCompletedEvent, TurnFailedEvent, TurnStartedEvent, Usage,
+};
+
+// Items
+pub use io::items::{
+    AgentMessageItem, CommandExecutionItem, CommandExecutionStatus, ErrorItem, FileChangeItem,
+    FileUpdateChange, McpToolCallError, McpToolCallItem, McpToolCallResult, McpToolCallStatus,
+    PatchApplyStatus, PatchChangeKind, ReasoningItem, ThreadItem, TodoItem, TodoListItem,
+    WebSearchItem,
+};
+
+// Options
+pub use io::options::{
+    ApprovalMode, ModelReasoningEffort, SandboxMode, ThreadOptions, WebSearchMode,
+};


### PR DESCRIPTION
## Summary
- Set up Cargo workspace to publish two crates from this repo
- Add `codex-codes` crate (v0.0.1) with typed Rust representations of the OpenAI Codex CLI JSON protocol
- Types mirror the official TypeScript SDK (`@openai/codex-sdk`): `ThreadEvent`, `ThreadItem`, `ThreadOptions`, and all associated enums
- 19 unit tests covering deserialization of all event and item types
- All existing `claude-codes` tests continue to pass