### PR TITLE
Add root README, update crate READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# rust-code-agent-sdks
+
+Typed Rust interfaces for AI code agent CLI protocols.
+
+This workspace provides two independent crates for interacting with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [OpenAI Codex](https://github.com/openai/codex) via their JSON/JSONL streaming protocols.
+
+## Crates
+
+| Crate | Version | Docs | CI | WASM |
+|-------|---------|------|----|------|
+| [`claude-codes`](./claude-codes/) | [![Crates.io](https://img.shields.io/crates/v/claude-codes.svg)](https://crates.io/crates/claude-codes) | [![docs.rs](https://docs.rs/claude-codes/badge.svg)](https://docs.rs/claude-codes) | [![CI](https://github.com/meawoppl/rust-code-agent-sdks/actions/workflows/ci.yml/badge.svg)](https://github.com/meawoppl/rust-code-agent-sdks/actions/workflows/ci.yml) | [![Feature Matrix](https://github.com/meawoppl/rust-code-agent-sdks/actions/workflows/feature-matrix.yml/badge.svg)](https://github.com/meawoppl/rust-code-agent-sdks/actions/workflows/feature-matrix.yml) |
+| [`codex-codes`](./codex-codes/) | [![Crates.io](https://img.shields.io/crates/v/codex-codes.svg)](https://crates.io/crates/codex-codes) | [![docs.rs](https://docs.rs/codex-codes/badge.svg)](https://docs.rs/codex-codes) | [![CI](https://github.com/meawoppl/rust-code-agent-sdks/actions/workflows/ci.yml/badge.svg)](https://github.com/meawoppl/rust-code-agent-sdks/actions/workflows/ci.yml) | [![Feature Matrix](https://github.com/meawoppl/rust-code-agent-sdks/actions/workflows/feature-matrix.yml/badge.svg)](https://github.com/meawoppl/rust-code-agent-sdks/actions/workflows/feature-matrix.yml) |
+
+## Versioning
+
+Each crate's version tracks the CLI it wraps:
+
+- **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.46` is tested against Claude CLI `2.1.47`.
+- **`codex-codes`** version will track Codex CLI releases as the protocol stabilizes. Currently at `0.90.0`, tested against Codex CLI `0.104.0`.
+
+Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.
+
+## Feature Flags
+
+### claude-codes
+
+`claude-codes` is structured into three feature flags to control dependency weight:
+
+| Feature | Description | WASM-compatible |
+|---------|-------------|-----------------|
+| `types` | Core message types and protocol structs only | Yes |
+| `sync-client` | Synchronous client with blocking I/O | No |
+| `async-client` | Asynchronous client using tokio | No |
+
+All features are enabled by default. For WASM or type-sharing use cases:
+
+```toml
+[dependencies]
+claude-codes = { version = "2", default-features = false, features = ["types"] }
+```
+
+### codex-codes
+
+`codex-codes` is a pure types crate with no feature flags. It is WASM-compatible out of the box.
+
+```toml
+[dependencies]
+codex-codes = "0.90"
+```
+
+## Testing Approach
+
+Both crates share the same testing philosophy:
+
+1. **Unit tests** validate serde round-tripping for every type variant against hand-crafted JSON.
+2. **Integration tests** deserialize real JSONL captures from actual CLI sessions. These captures live in each crate's `test_cases/` directory and are checked into the repo, so deserialization is validated against real-world protocol output.
+3. **CI matrix** tests each feature combination independently, including WASM builds via `wasm32-unknown-unknown`, clippy, rustfmt, and MSRV (1.85).
+
+To run all tests locally:
+
+```bash
+cargo test --workspace
+```
+
+## Workspace Structure
+
+```
+rust-code-agent-sdks/
+  claude-codes/          # Claude Code CLI protocol bindings
+    src/                 # Types, sync/async clients, protocol handling
+    tests/               # Deserialization + integration tests
+    test_cases/          # Real CLI captures and failure cases
+    examples/            # async_client, sync_client, basic_repl
+  codex-codes/           # Codex CLI protocol bindings
+    src/                 # Events, items, options types
+    tests/               # Integration tests
+    test_cases/          # Real CLI captures
+```
+
+See each crate's README for detailed usage:
+- [claude-codes README](./claude-codes/README.md)
+- [codex-codes README](./codex-codes/README.md)
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE).

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -2,11 +2,13 @@
 
 [![Crates.io](https://img.shields.io/crates/v/claude-codes.svg)](https://crates.io/crates/claude-codes)
 [![Documentation](https://docs.rs/claude-codes/badge.svg)](https://docs.rs/claude-codes)
-[![CI](https://github.com/meawoppl/rust-claude-codes/actions/workflows/ci.yml/badge.svg)](https://github.com/meawoppl/rust-claude-codes/actions/workflows/ci.yml)
-[![License](https://img.shields.io/crates/l/claude-codes.svg)](LICENSE)
+[![CI](https://github.com/meawoppl/rust-code-agent-sdks/actions/workflows/ci.yml/badge.svg)](https://github.com/meawoppl/rust-code-agent-sdks/actions/workflows/ci.yml)
+[![License](https://img.shields.io/crates/l/claude-codes.svg)](../LICENSE)
 [![Downloads](https://img.shields.io/crates/d/claude-codes.svg)](https://crates.io/crates/claude-codes)
 
-A typed Rust interface for the Claude Code JSON protocol.
+A typed Rust interface for the [Claude Code](https://docs.anthropic.com/en/docs/claude-code) JSON protocol.
+
+Part of the [rust-code-agent-sdks](https://github.com/meawoppl/rust-code-agent-sdks) workspace.
 
 ## Overview
 
@@ -14,19 +16,9 @@ This library provides type-safe bindings for communicating with the Claude CLI v
 
 **Note:** The Claude CLI protocol is unstable and may change between versions. This crate tracks protocol changes and will warn if you're using an untested CLI version.
 
-## Features
-
-- Type-safe message encoding/decoding
-- JSON Lines protocol support with streaming
-- Async and sync client implementations
-- Image support (JPEG, PNG, GIF, WebP) with base64 encoding
-- Tool use blocks for Claude's tool capabilities
-- OAuth and API key authentication via environment variables
-- UUID-based session management
-
 ## Installation
 
-### Default Installation (All Features)
+### Default (All Features)
 ```bash
 cargo add claude-codes
 ```
@@ -35,16 +27,21 @@ Requires the [Claude CLI](https://docs.anthropic.com/en/docs/claude-code) (`clau
 
 ### Feature Flags
 
-- **`types`** - Core message types only (WASM-compatible, minimal dependencies)
-- **`sync-client`** - Synchronous client with blocking I/O
-- **`async-client`** - Asynchronous client with tokio runtime
-- **Default** - All features enabled
+| Feature | Description | WASM-compatible |
+|---------|-------------|-----------------|
+| `types` | Core message types only (minimal dependencies) | Yes |
+| `sync-client` | Synchronous client with blocking I/O | No |
+| `async-client` | Asynchronous client with tokio runtime | No |
 
-#### Types Only
+All features are enabled by default.
+
+#### Types Only (WASM-compatible)
 ```toml
 [dependencies]
 claude-codes = { version = "2", default-features = false, features = ["types"] }
 ```
+
+This gives you access to all typed message structures (`ClaudeInput`, `ClaudeOutput`, `ContentBlock`, etc.) without pulling in tokio or other native-only dependencies. Useful for frontend apps, shared type definitions, or any WASM context needing Claude protocol types.
 
 #### Sync Client Only
 ```toml
@@ -57,21 +54,6 @@ claude-codes = { version = "2", default-features = false, features = ["sync-clie
 [dependencies]
 claude-codes = { version = "2", default-features = false, features = ["async-client"] }
 ```
-
-### WASM Support
-
-The `types` feature is fully compatible with `wasm32-unknown-unknown`, making it suitable for sharing Claude message types between native and browser/WASM code:
-
-```toml
-[dependencies]
-claude-codes = { version = "2", default-features = false, features = ["types"] }
-```
-
-This gives you access to all the typed message structures (`ClaudeInput`, `ClaudeOutput`, `ContentBlock`, etc.) without pulling in tokio or other native-only dependencies. Useful for:
-
-- Frontend applications that communicate with a Claude proxy
-- Shared type definitions across native backend and WASM frontend
-- Any WASM context needing Claude protocol types
 
 ## Usage
 
@@ -156,20 +138,11 @@ let serialized = Protocol::serialize(&output)?;
 
 ## Compatibility
 
-**Tested version:** Claude CLI 2.1.3
+**Tested against:** Claude CLI 2.1.47
 
-If you're using a different CLI version, please report whether it works at:
-https://github.com/meawoppl/rust-claude-codes/issues
-
-Include:
-- Your Claude CLI version (`claude --version`)
-- Whether messages serialized/deserialized correctly
-- Any errors encountered
+The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
+https://github.com/meawoppl/rust-code-agent-sdks/issues
 
 ## License
 
-Apache-2.0. See [LICENSE](LICENSE).
-
-## Contributing
-
-Contributions welcome. Any contribution submitted for inclusion will be licensed under Apache-2.0.
+Apache-2.0. See [LICENSE](../LICENSE).

--- a/codex-codes/README.md
+++ b/codex-codes/README.md
@@ -1,8 +1,26 @@
 # codex-codes
 
-A tightly typed Rust interface for the [OpenAI Codex CLI](https://github.com/openai/codex) JSON protocol.
+[![Crates.io](https://img.shields.io/crates/v/codex-codes.svg)](https://crates.io/crates/codex-codes)
+[![Documentation](https://docs.rs/codex-codes/badge.svg)](https://docs.rs/codex-codes)
+[![CI](https://github.com/meawoppl/rust-code-agent-sdks/actions/workflows/ci.yml/badge.svg)](https://github.com/meawoppl/rust-code-agent-sdks/actions/workflows/ci.yml)
+[![License](https://img.shields.io/crates/l/codex-codes.svg)](../LICENSE)
+[![Downloads](https://img.shields.io/crates/d/codex-codes.svg)](https://crates.io/crates/codex-codes)
 
-This crate provides type-safe Rust representations of the Codex CLI's JSONL output format, mirroring the structure of the official [TypeScript SDK](https://github.com/openai/codex/tree/main/sdk/typescript).
+A typed Rust interface for the [OpenAI Codex CLI](https://github.com/openai/codex) JSONL protocol.
+
+Part of the [rust-code-agent-sdks](https://github.com/meawoppl/rust-code-agent-sdks) workspace.
+
+## Overview
+
+This crate provides type-safe Rust representations of the Codex CLI's JSONL output format, mirroring the structure of the official [TypeScript SDK](https://github.com/openai/codex/tree/main/sdk/typescript). It is a pure types crate with no feature flags and is WASM-compatible out of the box.
+
+**Tested against:** Codex CLI 0.104.0
+
+## Installation
+
+```bash
+cargo add codex-codes
+```
 
 ## Types
 
@@ -36,7 +54,7 @@ Discriminated union of all agent action items:
 - `ModelReasoningEffort` — Reasoning effort level
 - `WebSearchMode` — Web search behavior
 
-## Example
+## Usage
 
 ```rust
 use codex_codes::{ThreadEvent, ThreadItem};
@@ -48,6 +66,20 @@ let item_json = r#"{"type":"agent_message","id":"msg_1","text":"Hello!"}"#;
 let item: ThreadItem = serde_json::from_str(item_json).unwrap();
 ```
 
+### Parsing a JSONL stream
+
+```rust
+use codex_codes::ThreadEvent;
+
+fn parse_stream(jsonl: &str) -> Vec<ThreadEvent> {
+    jsonl
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+```
+
 ## License
 
-Apache-2.0
+Apache-2.0. See [LICENSE](../LICENSE).


### PR DESCRIPTION
## Summary
- Add root `README.md` with badge matrix, versioning policy, feature flag docs, testing approach, and workspace structure
- Update `claude-codes/README.md` with corrected badge URLs (post-rename), feature flag table, and workspace context
- Update `codex-codes/README.md` with badges, tested version, and workspace context

## Test plan
- [ ] CI passes
- [ ] Badge URLs resolve correctly on GitHub
- [ ] Crate sub-READMEs link back to root and vice versa