### PR TITLE
Bump codex-codes to 0.100.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.90.0"
+version = "0.100.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.90.0"
+version = "0.100.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]


### PR DESCRIPTION
## Summary
- Bump codex-codes version from 0.90.0 to 0.100.0

## Test plan
- [ ] CI passes
- [ ] Publish to crates.io after merge