### PR TITLE
Add CI version consistency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,86 @@ jobs:
             exit 1
           fi
 
+  check-versions:
+    name: Check Version Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check version strings are in sync
+        run: |
+          set -e
+          FAILED=0
+
+          # Extract sources of truth
+          CLAUDE_VERSION=$(grep '^version' claude-codes/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          CODEX_VERSION=$(grep '^version' codex-codes/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          CLAUDE_TESTED=$(grep 'const TESTED_VERSION' claude-codes/src/version.rs | grep -oP '\d+\.\d+\.\d+')
+          CODEX_TESTED=$(grep 'Tested against.*Codex CLI' codex-codes/README.md | grep -oP '\d+\.\d+\.\d+')
+
+          echo "claude-codes version: $CLAUDE_VERSION"
+          echo "codex-codes version:  $CODEX_VERSION"
+          echo "Claude CLI tested:    $CLAUDE_TESTED"
+          echo "Codex CLI tested:     $CODEX_TESTED"
+          echo ""
+
+          # Check root README contains correct claude-codes version
+          if ! grep -q "claude-codes $CLAUDE_VERSION" README.md; then
+            echo "❌ README.md missing 'claude-codes $CLAUDE_VERSION'"
+            FAILED=1
+          else
+            echo "✅ README.md has claude-codes $CLAUDE_VERSION"
+          fi
+
+          # Check root README contains correct Claude CLI tested version
+          if ! grep -q "Claude CLI.*$CLAUDE_TESTED" README.md; then
+            echo "❌ README.md missing Claude CLI tested version $CLAUDE_TESTED"
+            FAILED=1
+          else
+            echo "✅ README.md has Claude CLI $CLAUDE_TESTED"
+          fi
+
+          # Check claude-codes README contains correct Claude CLI tested version
+          if ! grep -q "$CLAUDE_TESTED" claude-codes/README.md; then
+            echo "❌ claude-codes/README.md missing tested version $CLAUDE_TESTED"
+            FAILED=1
+          else
+            echo "✅ claude-codes/README.md has Claude CLI $CLAUDE_TESTED"
+          fi
+
+          # Check root README contains correct codex-codes version
+          if ! grep -q "$CODEX_VERSION" README.md; then
+            echo "❌ README.md missing codex-codes version $CODEX_VERSION"
+            FAILED=1
+          else
+            echo "✅ README.md has codex-codes $CODEX_VERSION"
+          fi
+
+          # Check root README contains correct Codex CLI tested version
+          if ! grep -q "Codex CLI.*$CODEX_TESTED" README.md; then
+            echo "❌ README.md missing Codex CLI tested version $CODEX_TESTED"
+            FAILED=1
+          else
+            echo "✅ README.md has Codex CLI $CODEX_TESTED"
+          fi
+
+          # Check codex-codes README contains correct Codex CLI tested version
+          if ! grep -q "$CODEX_TESTED" codex-codes/README.md; then
+            echo "❌ codex-codes/README.md missing tested version $CODEX_TESTED"
+            FAILED=1
+          else
+            echo "✅ codex-codes/README.md has Codex CLI $CODEX_TESTED"
+          fi
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo ""
+            echo "Version strings are out of sync. Update the READMEs to match."
+            exit 1
+          else
+            echo ""
+            echo "All version strings are consistent."
+          fi
+
   msrv:
     name: Minimum Supported Rust Version
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.46` is tested against Claude CLI `2.1.47`.
-- **`codex-codes`** version will track Codex CLI releases as the protocol stabilizes. Currently at `0.90.0`, tested against Codex CLI `0.104.0`.
+- **`codex-codes`** version will track Codex CLI releases as the protocol stabilizes. Currently at `0.100.0`, tested against Codex CLI `0.104.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.
 
@@ -45,7 +45,7 @@ claude-codes = { version = "2", default-features = false, features = ["types"] }
 
 ```toml
 [dependencies]
-codex-codes = "0.90"
+codex-codes = "0.100"
 ```
 
 ## Testing Approach


### PR DESCRIPTION
## Summary
- Add `Check Version Consistency` CI job that verifies version strings across all READMEs match the source of truth (Cargo.toml versions and TESTED_VERSION constant)
- Fix existing drift: root README said codex-codes was `0.90.0`, actual is `0.100.0`

## Checks enforced
- `claude-codes/Cargo.toml` version appears in root README
- `TESTED_VERSION` from `version.rs` appears in both root and claude-codes READMEs
- `codex-codes/Cargo.toml` version appears in root README
- Codex CLI tested version from codex-codes README appears in root README

## Test plan
- [ ] CI passes (including the new check itself)
- [ ] Update GitHub ruleset to require `Check Version Consistency`