### PR TITLE
Add sync/async clients to codex-codes

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -45,9 +45,21 @@ jobs:
     - name: Clippy with ${{ matrix.features.name }}
       run: cargo clippy ${{ matrix.features.args }} -- -D warnings
 
-  test-codex-codes:
-    name: "codex-codes: build & test"
+  test-codex-codes-features:
+    name: "codex-codes: ${{ matrix.features.name }}"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+          - name: "types-only"
+            args: "-p codex-codes --no-default-features --features types"
+          - name: "sync-client"
+            args: "-p codex-codes --no-default-features --features sync-client"
+          - name: "async-client"
+            args: "-p codex-codes --no-default-features --features async-client"
+          - name: "all-features"
+            args: "-p codex-codes"
+
     steps:
     - uses: actions/checkout@v4
 
@@ -57,14 +69,14 @@ jobs:
         toolchain: stable
         components: rustfmt, clippy
 
-    - name: Build
-      run: cargo build -p codex-codes
+    - name: Build with ${{ matrix.features.name }}
+      run: cargo build ${{ matrix.features.args }}
 
-    - name: Test
-      run: cargo test -p codex-codes
+    - name: Test with ${{ matrix.features.name }}
+      run: cargo test ${{ matrix.features.args }}
 
-    - name: Clippy
-      run: cargo clippy -p codex-codes -- -D warnings
+    - name: Clippy with ${{ matrix.features.name }}
+      run: cargo clippy ${{ matrix.features.args }} -- -D warnings
 
   wasm-compatibility:
     name: "WASM: ${{ matrix.crate.name }}"
@@ -75,7 +87,7 @@ jobs:
           - name: "claude-codes"
             args: "-p claude-codes --no-default-features --features types"
           - name: "codex-codes"
-            args: "-p codex-codes"
+            args: "-p codex-codes --no-default-features --features types"
 
     steps:
     - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,9 +156,12 @@ dependencies = [
 name = "codex-codes"
 version = "0.100.0"
 dependencies = [
+ "env_logger",
+ "log",
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -175,9 +178,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "env_filter"
-version = "0.1.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
 dependencies = [
  "log",
  "regex",
@@ -185,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
 dependencies = [
  "anstream",
  "anstyle",

--- a/README.md
+++ b/README.md
@@ -41,11 +41,19 @@ claude-codes = { version = "2", default-features = false, features = ["types"] }
 
 ### codex-codes
 
-`codex-codes` is a pure types crate with no feature flags. It is WASM-compatible out of the box.
+`codex-codes` mirrors the same feature flag structure:
+
+| Feature | Description | WASM-compatible |
+|---------|-------------|-----------------|
+| `types` | Core message types and protocol structs only | Yes |
+| `sync-client` | Synchronous client with blocking I/O | No |
+| `async-client` | Asynchronous client using tokio | No |
+
+All features are enabled by default. For WASM or type-sharing use cases:
 
 ```toml
 [dependencies]
-codex-codes = "0.100"
+codex-codes = { version = "0.100", default-features = false, features = ["types"] }
 ```
 
 ## Testing Approach
@@ -72,9 +80,10 @@ rust-code-agent-sdks/
     test_cases/          # Real CLI captures and failure cases
     examples/            # async_client, sync_client, basic_repl
   codex-codes/           # Codex CLI protocol bindings
-    src/                 # Events, items, options types
+    src/                 # Types, sync/async clients, CLI builder
     tests/               # Integration tests
     test_cases/          # Real CLI captures
+    examples/            # async_client, sync_client, basic_repl
 ```
 
 See each crate's README for detailed usage:

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -19,9 +19,31 @@ exclude = [
 ]
 
 [dependencies]
+log = { version = "0.4.29", optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"
 thiserror = "2.0.16"
+tokio = { version = "1.49.0", features = ["full"], optional = true }
 
 [dev-dependencies]
+env_logger = "0.11.9"
 serde_json = "1.0.143"
+tokio = { version = "1.49.0", features = ["full"] }
+
+[features]
+default = ["types", "sync-client", "async-client"]
+types = []
+sync-client = ["types", "dep:log"]
+async-client = ["types", "dep:tokio", "dep:log"]
+
+[[example]]
+name = "async_client"
+required-features = ["async-client"]
+
+[[example]]
+name = "basic_repl"
+required-features = ["async-client"]
+
+[[example]]
+name = "sync_client"
+required-features = ["sync-client"]

--- a/codex-codes/examples/async_client.rs
+++ b/codex-codes/examples/async_client.rs
@@ -1,0 +1,70 @@
+//! Example of using the asynchronous Codex client.
+
+use codex_codes::{AsyncClient, ThreadEvent, ThreadItem};
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+
+    println!("Sending query: What is the capital of France?");
+    println!("Waiting for response...\n");
+
+    let mut client = AsyncClient::exec("What is the capital of France?").await?;
+
+    let mut stream = client.events();
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(event) => handle_event(&event),
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                break;
+            }
+        }
+    }
+
+    println!("\nDone.");
+    Ok(())
+}
+
+fn handle_event(event: &ThreadEvent) {
+    match event {
+        ThreadEvent::ThreadStarted(e) => {
+            println!("[thread.started] id={}", e.thread_id);
+        }
+        ThreadEvent::TurnStarted(_) => {
+            println!("[turn.started]");
+        }
+        ThreadEvent::ItemStarted(_) => {}
+        ThreadEvent::ItemUpdated(e) => match &e.item {
+            ThreadItem::AgentMessage(msg) => {
+                println!("  Agent: {}", msg.text);
+            }
+            ThreadItem::CommandExecution(cmd) => {
+                println!("  Command: {}", cmd.command);
+                for line in cmd.aggregated_output.lines().take(5) {
+                    println!("    > {}", line);
+                }
+            }
+            ThreadItem::FileChange(fc) => {
+                for change in &fc.changes {
+                    println!("  File change: {} ({:?})", change.path, change.kind);
+                }
+            }
+            _ => {}
+        },
+        ThreadEvent::ItemCompleted(_) => {}
+        ThreadEvent::TurnCompleted(e) => {
+            println!(
+                "\n[turn.completed] tokens: {} in / {} out",
+                e.usage.input_tokens, e.usage.output_tokens
+            );
+        }
+        ThreadEvent::TurnFailed(e) => {
+            eprintln!("[turn.failed] {}", e.error.message);
+        }
+        ThreadEvent::Error(e) => {
+            eprintln!("[error] {}", e.message);
+        }
+    }
+}

--- a/codex-codes/examples/basic_repl.rs
+++ b/codex-codes/examples/basic_repl.rs
@@ -1,0 +1,170 @@
+//! Interactive REPL for the Codex CLI using the async client.
+//!
+//! Each query spawns a fresh `codex exec --json -` process.
+//! Type your prompt and press Enter. Type "exit" to quit.
+
+use codex_codes::{AsyncClient, CodexCliBuilder, ThreadEvent, ThreadItem};
+use log::{debug, error};
+use std::env;
+use std::io::{self, Write};
+use tokio::io::AsyncBufReadExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let args: Vec<String> = env::args().collect();
+    let model = args.get(1).cloned();
+
+    println!("\nCodex REPL");
+    println!("==========");
+    if let Some(ref m) = model {
+        println!("Using model: {}", m);
+    }
+    println!("Type your queries and press Enter. Type 'exit' to quit.\n");
+
+    loop {
+        print!("> ");
+        io::stdout().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        let input = input.trim();
+
+        if input.eq_ignore_ascii_case("exit") || input.eq_ignore_ascii_case("quit") {
+            break;
+        }
+
+        if input.is_empty() {
+            continue;
+        }
+
+        let mut builder = CodexCliBuilder::new().full_auto(true);
+        if let Some(ref m) = model {
+            builder = builder.model(m.as_str());
+        }
+
+        let mut client = match AsyncClient::from_builder(builder, input).await {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("Failed to start Codex: {}", e);
+                continue;
+            }
+        };
+
+        // Drain stderr in the background
+        if let Some(mut stderr) = client.take_stderr() {
+            tokio::spawn(async move {
+                let mut line = String::new();
+                loop {
+                    line.clear();
+                    match stderr.read_line(&mut line).await {
+                        Ok(0) => break,
+                        Ok(_) => {
+                            if !line.trim().is_empty() {
+                                error!("Codex stderr: {}", line.trim());
+                            }
+                        }
+                        Err(e) => {
+                            error!("Error reading stderr: {}", e);
+                            break;
+                        }
+                    }
+                }
+            });
+        }
+
+        println!("\n--- Response ---");
+
+        let mut stream = client.events();
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(event) => {
+                    debug!("Event: {:?}", std::mem::discriminant(&event));
+                    handle_event(&event);
+                }
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    break;
+                }
+            }
+        }
+
+        println!("--- End ---\n");
+    }
+
+    Ok(())
+}
+
+fn handle_event(event: &ThreadEvent) {
+    match event {
+        ThreadEvent::ThreadStarted(e) => {
+            debug!("[thread.started] id={}", e.thread_id);
+        }
+        ThreadEvent::TurnStarted(_) => {
+            debug!("[turn.started]");
+        }
+        ThreadEvent::ItemStarted(_) => {}
+        ThreadEvent::ItemUpdated(e) => match &e.item {
+            ThreadItem::AgentMessage(msg) => {
+                println!("{}", msg.text);
+            }
+            ThreadItem::CommandExecution(cmd) => {
+                println!("\n[Command: {}]", cmd.command);
+                for line in cmd.aggregated_output.lines() {
+                    println!("  {}", line);
+                }
+                match cmd.status {
+                    codex_codes::CommandExecutionStatus::Completed => {
+                        if let Some(code) = cmd.exit_code {
+                            if code != 0 {
+                                println!("  (exit code: {})", code);
+                            }
+                        }
+                    }
+                    codex_codes::CommandExecutionStatus::Failed => {
+                        println!("  (FAILED, exit code: {:?})", cmd.exit_code);
+                    }
+                    _ => {}
+                }
+            }
+            ThreadItem::FileChange(fc) => {
+                for change in &fc.changes {
+                    println!("\n[File: {} ({:?})]", change.path, change.kind);
+                }
+            }
+            ThreadItem::Reasoning(r) => {
+                println!("\n[Thinking]\n{}", r.text);
+            }
+            ThreadItem::McpToolCall(mcp) => {
+                println!("\n[MCP: {}::{}]", mcp.server, mcp.tool);
+            }
+            ThreadItem::WebSearch(ws) => {
+                println!("\n[Web search: {}]", ws.query);
+            }
+            ThreadItem::TodoList(todo) => {
+                println!("\n[Todo list: {} items]", todo.items.len());
+                for item in &todo.items {
+                    let check = if item.completed { "x" } else { " " };
+                    println!("  [{}] {}", check, item.text);
+                }
+            }
+            ThreadItem::Error(err) => {
+                eprintln!("\n[Error: {}]", err.message);
+            }
+        },
+        ThreadEvent::ItemCompleted(_) => {}
+        ThreadEvent::TurnCompleted(e) => {
+            println!(
+                "\n[Tokens: {} in / {} out]",
+                e.usage.input_tokens, e.usage.output_tokens
+            );
+        }
+        ThreadEvent::TurnFailed(e) => {
+            eprintln!("\n[Turn failed: {}]", e.error.message);
+        }
+        ThreadEvent::Error(e) => {
+            eprintln!("\n[Error: {}]", e.message);
+        }
+    }
+}

--- a/codex-codes/examples/sync_client.rs
+++ b/codex-codes/examples/sync_client.rs
@@ -1,0 +1,68 @@
+//! Example of using the synchronous Codex client.
+
+use codex_codes::{SyncClient, ThreadEvent, ThreadItem};
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    env_logger::init();
+
+    println!("Sending query: What is the capital of France?");
+    println!("Waiting for response...\n");
+
+    let mut client = SyncClient::exec("What is the capital of France?")?;
+
+    for result in client.events() {
+        match result {
+            Ok(event) => handle_event(&event),
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                break;
+            }
+        }
+    }
+
+    println!("\nDone.");
+    Ok(())
+}
+
+fn handle_event(event: &ThreadEvent) {
+    match event {
+        ThreadEvent::ThreadStarted(e) => {
+            println!("[thread.started] id={}", e.thread_id);
+        }
+        ThreadEvent::TurnStarted(_) => {
+            println!("[turn.started]");
+        }
+        ThreadEvent::ItemStarted(_) => {}
+        ThreadEvent::ItemUpdated(e) => match &e.item {
+            ThreadItem::AgentMessage(msg) => {
+                println!("  Agent: {}", msg.text);
+            }
+            ThreadItem::CommandExecution(cmd) => {
+                println!("  Command: {}", cmd.command);
+                for line in cmd.aggregated_output.lines().take(5) {
+                    println!("    > {}", line);
+                }
+            }
+            ThreadItem::FileChange(fc) => {
+                for change in &fc.changes {
+                    println!("  File change: {} ({:?})", change.path, change.kind);
+                }
+            }
+            _ => {}
+        },
+        ThreadEvent::ItemCompleted(_) => {}
+        ThreadEvent::TurnCompleted(e) => {
+            println!(
+                "\n[turn.completed] tokens: {} in / {} out",
+                e.usage.input_tokens, e.usage.output_tokens
+            );
+        }
+        ThreadEvent::TurnFailed(e) => {
+            eprintln!("[turn.failed] {}", e.error.message);
+        }
+        ThreadEvent::Error(e) => {
+            eprintln!("[error] {}", e.message);
+        }
+    }
+}

--- a/codex-codes/src/cli.rs
+++ b/codex-codes/src/cli.rs
@@ -1,0 +1,357 @@
+//! Builder pattern for configuring and launching the Codex CLI process.
+//!
+//! This module provides [`CodexCliBuilder`] for constructing Codex CLI commands
+//! with the correct flags for JSON streaming mode. The builder produces
+//! `codex exec --json [flags...] -` commands that read prompts from stdin.
+
+use crate::io::options::SandboxMode;
+use log::debug;
+use std::path::PathBuf;
+use std::process::Stdio;
+
+/// Builder for creating Codex CLI commands in JSON mode.
+///
+/// Produces commands of the form: `codex exec --json [flags...] -`
+///
+/// The trailing `-` tells Codex to read the prompt from stdin.
+#[derive(Debug, Clone)]
+pub struct CodexCliBuilder {
+    command: PathBuf,
+    model: Option<String>,
+    sandbox: Option<SandboxMode>,
+    working_directory: Option<PathBuf>,
+    full_auto: bool,
+    dangerously_bypass: bool,
+    skip_git_repo_check: bool,
+    ephemeral: bool,
+    images: Vec<PathBuf>,
+    add_dirs: Vec<PathBuf>,
+    config_overrides: Vec<String>,
+    output_schema: Option<String>,
+    profile: Option<String>,
+    enable_features: Vec<String>,
+    disable_features: Vec<String>,
+}
+
+impl Default for CodexCliBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodexCliBuilder {
+    /// Create a new Codex CLI builder with default settings.
+    pub fn new() -> Self {
+        Self {
+            command: PathBuf::from("codex"),
+            model: None,
+            sandbox: None,
+            working_directory: None,
+            full_auto: false,
+            dangerously_bypass: false,
+            skip_git_repo_check: false,
+            ephemeral: false,
+            images: Vec::new(),
+            add_dirs: Vec::new(),
+            config_overrides: Vec::new(),
+            output_schema: None,
+            profile: None,
+            enable_features: Vec::new(),
+            disable_features: Vec::new(),
+        }
+    }
+
+    /// Set custom path to the codex binary.
+    pub fn command<P: Into<PathBuf>>(mut self, path: P) -> Self {
+        self.command = path.into();
+        self
+    }
+
+    /// Set the model to use.
+    pub fn model<S: Into<String>>(mut self, model: S) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Set the sandbox mode.
+    pub fn sandbox(mut self, mode: SandboxMode) -> Self {
+        self.sandbox = Some(mode);
+        self
+    }
+
+    /// Set the working directory.
+    pub fn working_directory<P: Into<PathBuf>>(mut self, dir: P) -> Self {
+        self.working_directory = Some(dir.into());
+        self
+    }
+
+    /// Enable full-auto mode (skip all approvals).
+    pub fn full_auto(mut self, enabled: bool) -> Self {
+        self.full_auto = enabled;
+        self
+    }
+
+    /// Dangerously bypass all safety checks.
+    pub fn dangerously_bypass(mut self, enabled: bool) -> Self {
+        self.dangerously_bypass = enabled;
+        self
+    }
+
+    /// Skip the git repository check.
+    pub fn skip_git_repo_check(mut self, enabled: bool) -> Self {
+        self.skip_git_repo_check = enabled;
+        self
+    }
+
+    /// Run in ephemeral mode (no persistent state).
+    pub fn ephemeral(mut self, enabled: bool) -> Self {
+        self.ephemeral = enabled;
+        self
+    }
+
+    /// Add image files to include with the prompt.
+    pub fn images<I, P>(mut self, paths: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<PathBuf>,
+    {
+        self.images.extend(paths.into_iter().map(|p| p.into()));
+        self
+    }
+
+    /// Add directories the agent can access.
+    pub fn add_dirs<I, P>(mut self, dirs: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<PathBuf>,
+    {
+        self.add_dirs.extend(dirs.into_iter().map(|p| p.into()));
+        self
+    }
+
+    /// Add configuration overrides (key=value pairs).
+    pub fn config_overrides<I, S>(mut self, overrides: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.config_overrides
+            .extend(overrides.into_iter().map(|s| s.into()));
+        self
+    }
+
+    /// Set a JSON schema for structured output.
+    pub fn output_schema<S: Into<String>>(mut self, schema: S) -> Self {
+        self.output_schema = Some(schema.into());
+        self
+    }
+
+    /// Set the configuration profile.
+    pub fn profile<S: Into<String>>(mut self, profile: S) -> Self {
+        self.profile = Some(profile.into());
+        self
+    }
+
+    /// Enable specific features.
+    pub fn enable_features<I, S>(mut self, features: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.enable_features
+            .extend(features.into_iter().map(|s| s.into()));
+        self
+    }
+
+    /// Disable specific features.
+    pub fn disable_features<I, S>(mut self, features: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.disable_features
+            .extend(features.into_iter().map(|s| s.into()));
+        self
+    }
+
+    /// Build the command arguments.
+    ///
+    /// Always produces: `exec --json [flags...] -`
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["exec".to_string(), "--json".to_string()];
+
+        if let Some(ref model) = self.model {
+            args.push("--model".to_string());
+            args.push(model.clone());
+        }
+
+        if let Some(ref sandbox) = self.sandbox {
+            args.push("--sandbox".to_string());
+            args.push(sandbox.as_cli_str().to_string());
+        }
+
+        if self.full_auto {
+            args.push("--full-auto".to_string());
+        }
+
+        if self.dangerously_bypass {
+            args.push("--dangerously-auto-approve".to_string());
+        }
+
+        if self.skip_git_repo_check {
+            args.push("--skip-git-repo-check".to_string());
+        }
+
+        if self.ephemeral {
+            args.push("--ephemeral".to_string());
+        }
+
+        for image in &self.images {
+            args.push("--image".to_string());
+            args.push(image.to_string_lossy().to_string());
+        }
+
+        for dir in &self.add_dirs {
+            args.push("--add-dir".to_string());
+            args.push(dir.to_string_lossy().to_string());
+        }
+
+        for config in &self.config_overrides {
+            args.push("--config".to_string());
+            args.push(config.clone());
+        }
+
+        if let Some(ref schema) = self.output_schema {
+            args.push("--output-schema".to_string());
+            args.push(schema.clone());
+        }
+
+        if let Some(ref profile) = self.profile {
+            args.push("--profile".to_string());
+            args.push(profile.clone());
+        }
+
+        for feature in &self.enable_features {
+            args.push("--enable-feature".to_string());
+            args.push(feature.clone());
+        }
+
+        for feature in &self.disable_features {
+            args.push("--disable-feature".to_string());
+            args.push(feature.clone());
+        }
+
+        // Trailing `-` tells codex to read prompt from stdin
+        args.push("-".to_string());
+
+        args
+    }
+
+    /// Spawn the Codex process asynchronously.
+    #[cfg(feature = "async-client")]
+    pub async fn spawn(self) -> crate::error::Result<tokio::process::Child> {
+        let args = self.build_args();
+
+        debug!(
+            "[CLI] Executing async command: {} {}",
+            self.command.display(),
+            args.join(" ")
+        );
+
+        let mut cmd = tokio::process::Command::new(&self.command);
+        cmd.args(&args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        if let Some(ref dir) = self.working_directory {
+            cmd.current_dir(dir);
+        }
+
+        cmd.spawn().map_err(crate::error::Error::Io)
+    }
+
+    /// Spawn the Codex process synchronously.
+    pub fn spawn_sync(self) -> std::io::Result<std::process::Child> {
+        let args = self.build_args();
+
+        debug!(
+            "[CLI] Executing sync command: {} {}",
+            self.command.display(),
+            args.join(" ")
+        );
+
+        let mut cmd = std::process::Command::new(&self.command);
+        cmd.args(&args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        if let Some(ref dir) = self.working_directory {
+            cmd.current_dir(dir);
+        }
+
+        cmd.spawn()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_args() {
+        let builder = CodexCliBuilder::new();
+        let args = builder.build_args();
+
+        assert_eq!(args[0], "exec");
+        assert_eq!(args[1], "--json");
+        assert_eq!(args.last().unwrap(), "-");
+    }
+
+    #[test]
+    fn test_with_model() {
+        let builder = CodexCliBuilder::new().model("o4-mini");
+        let args = builder.build_args();
+
+        assert!(args.contains(&"--model".to_string()));
+        assert!(args.contains(&"o4-mini".to_string()));
+    }
+
+    #[test]
+    fn test_with_sandbox() {
+        let builder = CodexCliBuilder::new().sandbox(SandboxMode::ReadOnly);
+        let args = builder.build_args();
+
+        assert!(args.contains(&"--sandbox".to_string()));
+        assert!(args.contains(&"read-only".to_string()));
+    }
+
+    #[test]
+    fn test_full_auto() {
+        let builder = CodexCliBuilder::new().full_auto(true);
+        let args = builder.build_args();
+
+        assert!(args.contains(&"--full-auto".to_string()));
+    }
+
+    #[test]
+    fn test_multiple_images() {
+        let builder = CodexCliBuilder::new().images(vec!["a.png", "b.png"]);
+        let args = builder.build_args();
+
+        let image_count = args.iter().filter(|a| *a == "--image").count();
+        assert_eq!(image_count, 2);
+    }
+
+    #[test]
+    fn test_trailing_dash_always_last() {
+        let builder = CodexCliBuilder::new()
+            .model("o4-mini")
+            .full_auto(true)
+            .ephemeral(true);
+        let args = builder.build_args();
+
+        assert_eq!(args.last().unwrap(), "-");
+    }
+}

--- a/codex-codes/src/client_async.rs
+++ b/codex-codes/src/client_async.rs
@@ -1,0 +1,206 @@
+//! Asynchronous client for Codex CLI communication.
+//!
+//! Spawns `codex exec --json -`, writes the prompt to stdin, closes stdin,
+//! then reads JSONL events from stdout until the turn completes.
+
+use crate::cli::CodexCliBuilder;
+use crate::error::{Error, Result};
+use crate::io::events::ThreadEvent;
+use log::{debug, error, warn};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStderr};
+
+/// Buffer size for reading stdout (10MB).
+const STDOUT_BUFFER_SIZE: usize = 10 * 1024 * 1024;
+
+/// Asynchronous client for one-shot Codex queries.
+///
+/// Each query spawns a fresh `codex exec --json -` process, writes the prompt
+/// to stdin, closes stdin, then reads JSONL [`ThreadEvent`]s from stdout.
+pub struct AsyncClient {
+    child: Child,
+    stdout: BufReader<tokio::process::ChildStdout>,
+    stderr: Option<BufReader<ChildStderr>>,
+    finished: bool,
+}
+
+impl AsyncClient {
+    /// Spawn a client from a builder and prompt.
+    pub async fn from_builder(builder: CodexCliBuilder, prompt: &str) -> Result<Self> {
+        crate::version::check_codex_version_async().await?;
+
+        let mut child = builder.spawn().await?;
+
+        // Write prompt to stdin and close it
+        {
+            let mut stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| Error::Protocol("Failed to get stdin".to_string()))?;
+            stdin
+                .write_all(prompt.as_bytes())
+                .await
+                .map_err(Error::Io)?;
+            stdin.flush().await.map_err(Error::Io)?;
+            // stdin is dropped here, closing the pipe
+        }
+
+        let stdout = BufReader::with_capacity(
+            STDOUT_BUFFER_SIZE,
+            child
+                .stdout
+                .take()
+                .ok_or_else(|| Error::Protocol("Failed to get stdout".to_string()))?,
+        );
+
+        let stderr = child.stderr.take().map(BufReader::new);
+
+        Ok(Self {
+            child,
+            stdout,
+            stderr,
+            finished: false,
+        })
+    }
+
+    /// One-shot query with default settings.
+    pub async fn exec(prompt: &str) -> Result<Self> {
+        Self::from_builder(CodexCliBuilder::new().full_auto(true), prompt).await
+    }
+
+    /// One-shot query with a custom builder.
+    pub async fn exec_with(builder: CodexCliBuilder, prompt: &str) -> Result<Self> {
+        Self::from_builder(builder, prompt).await
+    }
+
+    /// Read the next event from the stream.
+    pub async fn next_event(&mut self) -> Result<Option<ThreadEvent>> {
+        if self.finished {
+            return Ok(None);
+        }
+
+        let mut line = String::new();
+
+        loop {
+            line.clear();
+            let bytes_read = self.stdout.read_line(&mut line).await.map_err(Error::Io)?;
+
+            if bytes_read == 0 {
+                debug!("[CLIENT] Stream closed (EOF)");
+                self.finished = true;
+                return Ok(None);
+            }
+
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            debug!("[CLIENT] Received: {}", trimmed);
+
+            match serde_json::from_str::<ThreadEvent>(trimmed) {
+                Ok(event) => {
+                    if matches!(event, ThreadEvent::TurnCompleted(_)) {
+                        self.finished = true;
+                    }
+                    return Ok(Some(event));
+                }
+                Err(e) => {
+                    warn!(
+                        "[CLIENT] Failed to deserialize event. \
+                         Please report this at https://github.com/meawoppl/rust-code-agent-sdks/issues"
+                    );
+                    warn!("[CLIENT] Parse error: {}", e);
+                    warn!("[CLIENT] Raw: {}", trimmed);
+                    return Err(Error::Deserialization(format!("{} (raw: {})", e, trimmed)));
+                }
+            }
+        }
+    }
+
+    /// Collect all remaining events into a vector.
+    pub async fn collect_all(&mut self) -> Result<Vec<ThreadEvent>> {
+        let mut events = Vec::new();
+        while let Some(event) = self.next_event().await? {
+            events.push(event);
+        }
+        Ok(events)
+    }
+
+    /// Return an async event stream.
+    pub fn events(&mut self) -> EventStream<'_> {
+        EventStream { client: self }
+    }
+
+    /// Take the stderr reader (can only be called once).
+    pub fn take_stderr(&mut self) -> Option<BufReader<ChildStderr>> {
+        self.stderr.take()
+    }
+
+    /// Get the process ID.
+    pub fn pid(&self) -> Option<u32> {
+        self.child.id()
+    }
+
+    /// Check if the child process is still running.
+    pub fn is_alive(&mut self) -> bool {
+        self.child.try_wait().ok().flatten().is_none()
+    }
+
+    /// Check if the stream has finished.
+    pub fn is_finished(&self) -> bool {
+        self.finished
+    }
+
+    /// Shut down the child process.
+    pub async fn shutdown(mut self) -> Result<()> {
+        debug!("[CLIENT] Shutting down");
+        self.child.kill().await.map_err(Error::Io)?;
+        Ok(())
+    }
+}
+
+impl Drop for AsyncClient {
+    fn drop(&mut self) {
+        if self.is_alive() {
+            if let Err(e) = self.child.start_kill() {
+                error!("Failed to kill Codex process on drop: {}", e);
+            }
+        }
+    }
+}
+
+/// Async stream of [`ThreadEvent`]s from an [`AsyncClient`].
+pub struct EventStream<'a> {
+    client: &'a mut AsyncClient,
+}
+
+impl EventStream<'_> {
+    /// Get the next event.
+    pub async fn next(&mut self) -> Option<Result<ThreadEvent>> {
+        match self.client.next_event().await {
+            Ok(Some(event)) => Some(Ok(event)),
+            Ok(None) => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+
+    /// Collect all remaining events.
+    pub async fn collect(mut self) -> Result<Vec<ThreadEvent>> {
+        let mut events = Vec::new();
+        while let Some(result) = self.next().await {
+            events.push(result?);
+        }
+        Ok(events)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_buffer_size() {
+        assert_eq!(STDOUT_BUFFER_SIZE, 10 * 1024 * 1024);
+    }
+}

--- a/codex-codes/src/client_sync.rs
+++ b/codex-codes/src/client_sync.rs
@@ -1,0 +1,187 @@
+//! Synchronous client for Codex CLI communication.
+//!
+//! Spawns `codex exec --json -`, writes the prompt to stdin, closes stdin,
+//! then reads JSONL events from stdout until the turn completes.
+
+use crate::cli::CodexCliBuilder;
+use crate::error::{Error, Result};
+use crate::io::events::ThreadEvent;
+use log::{debug, warn};
+use std::io::{BufRead, BufReader, Write};
+use std::process::Child;
+
+/// Buffer size for reading stdout (10MB).
+const STDOUT_BUFFER_SIZE: usize = 10 * 1024 * 1024;
+
+/// Synchronous client for one-shot Codex queries.
+///
+/// Each query spawns a fresh `codex exec --json -` process, writes the prompt
+/// to stdin, closes stdin, then reads JSONL [`ThreadEvent`]s from stdout.
+pub struct SyncClient {
+    child: Child,
+    stdout: BufReader<std::process::ChildStdout>,
+    finished: bool,
+}
+
+impl SyncClient {
+    /// Spawn a client from a builder and prompt.
+    pub fn from_builder(builder: CodexCliBuilder, prompt: &str) -> Result<Self> {
+        crate::version::check_codex_version()?;
+
+        let mut child = builder.spawn_sync().map_err(Error::Io)?;
+
+        // Write prompt to stdin and close it
+        {
+            let stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| Error::Protocol("Failed to get stdin".to_string()))?;
+            let mut writer = std::io::BufWriter::new(stdin);
+            writer.write_all(prompt.as_bytes()).map_err(Error::Io)?;
+            writer.flush().map_err(Error::Io)?;
+            // stdin is dropped here, closing the pipe
+        }
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| Error::Protocol("Failed to get stdout".to_string()))?;
+
+        Ok(Self {
+            child,
+            stdout: BufReader::with_capacity(STDOUT_BUFFER_SIZE, stdout),
+            finished: false,
+        })
+    }
+
+    /// One-shot query with default settings.
+    pub fn exec(prompt: &str) -> Result<Self> {
+        Self::from_builder(CodexCliBuilder::new().full_auto(true), prompt)
+    }
+
+    /// One-shot query with a custom builder.
+    pub fn exec_with(builder: CodexCliBuilder, prompt: &str) -> Result<Self> {
+        Self::from_builder(builder, prompt)
+    }
+
+    /// Read the next event from the stream.
+    pub fn next_event(&mut self) -> Result<Option<ThreadEvent>> {
+        if self.finished {
+            return Ok(None);
+        }
+
+        loop {
+            let mut line = String::new();
+            match self.stdout.read_line(&mut line) {
+                Ok(0) => {
+                    debug!("[CLIENT] Stream closed (EOF)");
+                    self.finished = true;
+                    return Ok(None);
+                }
+                Ok(_) => {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+
+                    debug!("[CLIENT] Received: {}", trimmed);
+
+                    match serde_json::from_str::<ThreadEvent>(trimmed) {
+                        Ok(event) => {
+                            if matches!(event, ThreadEvent::TurnCompleted(_)) {
+                                self.finished = true;
+                            }
+                            return Ok(Some(event));
+                        }
+                        Err(e) => {
+                            warn!(
+                                "[CLIENT] Failed to deserialize event. \
+                                 Please report this at https://github.com/meawoppl/rust-code-agent-sdks/issues"
+                            );
+                            warn!("[CLIENT] Parse error: {}", e);
+                            warn!("[CLIENT] Raw: {}", trimmed);
+                            return Err(Error::Deserialization(format!(
+                                "{} (raw: {})",
+                                e, trimmed
+                            )));
+                        }
+                    }
+                }
+                Err(e) => {
+                    debug!("[CLIENT] Error reading stdout: {}", e);
+                    self.finished = true;
+                    return Err(Error::Io(e));
+                }
+            }
+        }
+    }
+
+    /// Collect all remaining events into a vector.
+    pub fn collect_all(&mut self) -> Result<Vec<ThreadEvent>> {
+        let mut events = Vec::new();
+        while let Some(event) = self.next_event()? {
+            events.push(event);
+        }
+        Ok(events)
+    }
+
+    /// Return an iterator over events.
+    pub fn events(&mut self) -> EventIterator<'_> {
+        EventIterator { client: self }
+    }
+
+    /// Shut down the child process.
+    pub fn shutdown(&mut self) -> Result<()> {
+        debug!("[CLIENT] Shutting down");
+        // The child may have already exited since stdin was closed
+        match self.child.try_wait() {
+            Ok(Some(_)) => Ok(()),
+            Ok(None) => {
+                self.child.kill().map_err(Error::Io)?;
+                self.child.wait().map_err(Error::Io)?;
+                Ok(())
+            }
+            Err(e) => Err(Error::Io(e)),
+        }
+    }
+
+    /// Check if the stream has finished.
+    pub fn is_finished(&self) -> bool {
+        self.finished
+    }
+}
+
+impl Drop for SyncClient {
+    fn drop(&mut self) {
+        if let Err(e) = self.shutdown() {
+            debug!("[CLIENT] Error during shutdown: {}", e);
+        }
+    }
+}
+
+/// Iterator over [`ThreadEvent`]s from a [`SyncClient`].
+pub struct EventIterator<'a> {
+    client: &'a mut SyncClient,
+}
+
+impl Iterator for EventIterator<'_> {
+    type Item = Result<ThreadEvent>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.client.next_event() {
+            Ok(Some(event)) => Some(Ok(event)),
+            Ok(None) => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_buffer_size() {
+        assert_eq!(STDOUT_BUFFER_SIZE, 10 * 1024 * 1024);
+    }
+}

--- a/codex-codes/src/error.rs
+++ b/codex-codes/src/error.rs
@@ -1,0 +1,27 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Protocol error: {0}")]
+    Protocol(String),
+
+    #[error("Connection closed")]
+    ConnectionClosed,
+
+    #[error("Deserialization error: {0}")]
+    Deserialization(String),
+
+    #[error("Process exited with status {0}: {1}")]
+    ProcessFailed(i32, String),
+
+    #[error("Unknown error: {0}")]
+    Unknown(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/codex-codes/src/io/options.rs
+++ b/codex-codes/src/io/options.rs
@@ -19,6 +19,17 @@ pub enum SandboxMode {
     DangerFullAccess,
 }
 
+impl SandboxMode {
+    /// Get the CLI flag value for this sandbox mode.
+    pub fn as_cli_str(&self) -> &'static str {
+        match self {
+            SandboxMode::ReadOnly => "read-only",
+            SandboxMode::WorkspaceWrite => "workspace-write",
+            SandboxMode::DangerFullAccess => "danger-full-access",
+        }
+    }
+}
+
 /// Model reasoning effort level.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/codex-codes/src/lib.rs
+++ b/codex-codes/src/lib.rs
@@ -3,6 +3,16 @@
 //! This crate provides type-safe representations of the Codex CLI's JSONL output,
 //! mirroring the structure of the official TypeScript SDK (`@openai/codex-sdk`).
 //!
+//! # Feature Flags
+//!
+//! | Feature | Description | WASM-compatible |
+//! |---------|-------------|-----------------|
+//! | `types` | Core message types and protocol structs only | Yes |
+//! | `sync-client` | Synchronous client with blocking I/O | No |
+//! | `async-client` | Asynchronous client using tokio | No |
+//!
+//! All features are enabled by default.
+//!
 //! # Message Types
 //!
 //! The protocol uses two primary discriminated unions:
@@ -26,6 +36,20 @@
 
 mod io;
 
+pub mod error;
+
+#[cfg(any(feature = "sync-client", feature = "async-client"))]
+pub mod cli;
+
+#[cfg(any(feature = "sync-client", feature = "async-client"))]
+pub mod version;
+
+#[cfg(feature = "sync-client")]
+pub mod client_sync;
+
+#[cfg(feature = "async-client")]
+pub mod client_async;
+
 // Events
 pub use io::events::{
     ItemCompletedEvent, ItemStartedEvent, ItemUpdatedEvent, ThreadError, ThreadErrorEvent,
@@ -44,3 +68,18 @@ pub use io::items::{
 pub use io::options::{
     ApprovalMode, ModelReasoningEffort, SandboxMode, ThreadOptions, WebSearchMode,
 };
+
+// Error types (always available)
+pub use error::{Error, Result};
+
+// CLI builder (feature-gated)
+#[cfg(any(feature = "sync-client", feature = "async-client"))]
+pub use cli::CodexCliBuilder;
+
+// Sync client
+#[cfg(feature = "sync-client")]
+pub use client_sync::{EventIterator, SyncClient};
+
+// Async client
+#[cfg(feature = "async-client")]
+pub use client_async::{AsyncClient, EventStream};

--- a/codex-codes/src/version.rs
+++ b/codex-codes/src/version.rs
@@ -1,0 +1,158 @@
+//! Version checking utilities for Codex CLI compatibility.
+
+use crate::error::Result;
+use log::{debug, warn};
+use std::process::Command;
+use std::sync::Once;
+
+/// The latest Codex CLI version we've tested against.
+const TESTED_VERSION: &str = "0.104.0";
+
+/// Ensures version warning is only shown once per session.
+static VERSION_CHECK: Once = Once::new();
+
+/// Check the Codex CLI version and warn if newer than tested.
+///
+/// This will only issue a warning once per program execution.
+pub fn check_codex_version() -> Result<()> {
+    VERSION_CHECK.call_once(|| {
+        if let Err(e) = check_version_impl() {
+            debug!("Failed to check Codex CLI version: {}", e);
+        }
+    });
+    Ok(())
+}
+
+fn check_version_impl() -> Result<()> {
+    let output = Command::new("codex")
+        .arg("--version")
+        .output()
+        .map_err(crate::error::Error::Io)?;
+
+    if !output.status.success() {
+        debug!("Failed to check Codex CLI version - command failed");
+        return Ok(());
+    }
+
+    let version_str = String::from_utf8_lossy(&output.stdout);
+    let version_line = version_str.lines().next().unwrap_or("");
+
+    // Format: "codex-cli X.Y.Z"
+    if let Some(version) = version_line.split_whitespace().last() {
+        if is_version_newer(version, TESTED_VERSION) {
+            warn!(
+                "Codex CLI version {} is newer than tested version {}. \
+                 Please report compatibility at: https://github.com/meawoppl/rust-code-agent-sdks/issues",
+                version, TESTED_VERSION
+            );
+        } else {
+            debug!(
+                "Codex CLI version {} is compatible (tested: {})",
+                version, TESTED_VERSION
+            );
+        }
+    } else {
+        warn!(
+            "Could not parse Codex CLI version from output: '{}'. \
+             Please report compatibility at: https://github.com/meawoppl/rust-code-agent-sdks/issues",
+            version_line
+        );
+    }
+
+    Ok(())
+}
+
+/// Compare two version strings (e.g., "0.104.0" vs "0.103.0").
+fn is_version_newer(version: &str, tested: &str) -> bool {
+    let v_parts: Vec<u32> = version.split('.').filter_map(|s| s.parse().ok()).collect();
+    let t_parts: Vec<u32> = tested.split('.').filter_map(|s| s.parse().ok()).collect();
+
+    use std::cmp::Ordering;
+
+    for i in 0..v_parts.len().min(t_parts.len()) {
+        match v_parts[i].cmp(&t_parts[i]) {
+            Ordering::Greater => return true,
+            Ordering::Less => return false,
+            Ordering::Equal => continue,
+        }
+    }
+
+    v_parts.len() > t_parts.len()
+}
+
+/// Async version check for tokio-based clients.
+#[cfg(feature = "async-client")]
+pub async fn check_codex_version_async() -> Result<()> {
+    use tokio::sync::OnceCell;
+
+    static ASYNC_VERSION_CHECK: OnceCell<()> = OnceCell::const_new();
+
+    ASYNC_VERSION_CHECK
+        .get_or_init(|| async {
+            if let Err(e) = check_version_impl_async().await {
+                debug!("Failed to check Codex CLI version: {}", e);
+            }
+        })
+        .await;
+
+    Ok(())
+}
+
+#[cfg(feature = "async-client")]
+async fn check_version_impl_async() -> Result<()> {
+    use tokio::process::Command;
+
+    let output = Command::new("codex")
+        .arg("--version")
+        .output()
+        .await
+        .map_err(crate::error::Error::Io)?;
+
+    if !output.status.success() {
+        debug!("Failed to check Codex CLI version - command failed");
+        return Ok(());
+    }
+
+    let version_str = String::from_utf8_lossy(&output.stdout);
+    let version_line = version_str.lines().next().unwrap_or("");
+
+    // Format: "codex-cli X.Y.Z"
+    if let Some(version) = version_line.split_whitespace().last() {
+        if is_version_newer(version, TESTED_VERSION) {
+            warn!(
+                "Codex CLI version {} is newer than tested version {}. \
+                 Please report compatibility at: https://github.com/meawoppl/rust-code-agent-sdks/issues",
+                version, TESTED_VERSION
+            );
+        } else {
+            debug!(
+                "Codex CLI version {} is compatible (tested: {})",
+                version, TESTED_VERSION
+            );
+        }
+    } else {
+        warn!(
+            "Could not parse Codex CLI version from output: '{}'. \
+             Please report compatibility at: https://github.com/meawoppl/rust-code-agent-sdks/issues",
+            version_line
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version_comparison() {
+        assert!(is_version_newer("0.105.0", "0.104.0"));
+        assert!(!is_version_newer("0.104.0", "0.104.0"));
+        assert!(!is_version_newer("0.103.0", "0.104.0"));
+
+        assert!(is_version_newer("1.0.0", "0.104.0"));
+        assert!(!is_version_newer("0.0.1", "0.104.0"));
+        assert!(is_version_newer("0.104.1", "0.104.0"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `SyncClient` and `AsyncClient` for one-shot Codex CLI queries (`codex exec --json -`)
- Add `CodexCliBuilder` with builder pattern for all Codex CLI flags
- Add version checking (`codex --version` compat warnings)
- Add feature flags mirroring claude-codes: `types`, `sync-client`, `async-client`
- Add 3 examples: `sync_client`, `async_client`, `basic_repl`
- Update CI feature matrix for codex-codes (types-only, sync, async, all)
- Update WASM check to use types-only for codex-codes
- Update READMEs with feature flag docs and client usage examples

## Test plan

- [x] All 46 tests pass (`cargo test -p codex-codes`)
- [x] Clippy clean (`cargo clippy -p codex-codes --all-targets -- -D warnings`)
- [x] All feature combinations build independently
- [x] WASM-compatible with `--no-default-features --features types`
- [x] Full workspace builds and tests pass
- [ ] CI feature matrix passes (new codex-codes jobs)
- [ ] Run examples against installed Codex CLI manually