### PR TITLE
Add cargo audit to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,21 @@ jobs:
             echo "All version strings are consistent."
           fi
 
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
+      - name: Run cargo audit
+        run: cargo audit
+
   msrv:
     name: Minimum Supported Rust Version
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add a `Security Audit` job to CI that runs `cargo audit` on every push/PR to main

## Test plan

- [ ] CI passes including new audit step