### PR TITLE
Add typed task system message structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.46` is tested against Claude CLI `2.1.47`.
+- **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.47` is tested against Claude CLI `2.1.47`.
 - **`codex-codes`** version will track Codex CLI releases as the protocol stabilizes. Currently at `0.101.0`, tested against Codex CLI `0.104.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.47] - 2026-02-24
+
+### Added
+
+- **`TaskStartedMessage`** — Typed struct for `task_started` system messages emitted when a background task (agent or bash) begins
+- **`TaskProgressMessage`** — Typed struct for `task_progress` system messages with tool name, description, and cumulative usage stats
+- **`TaskNotificationMessage`** — Typed struct for `task_notification` system messages emitted when a background task completes or fails
+- **`TaskUsage`** — Cumulative usage statistics (`duration_ms`, `tool_uses`, `total_tokens`)
+- **`TaskType`** enum — `LocalAgent` or `LocalBash`
+- **`TaskStatus`** enum — `Completed` or `Failed`
+- **`SystemMessage` helpers** — `is_task_started()`, `is_task_progress()`, `is_task_notification()` and corresponding `as_task_*()` methods
+
 ## [2.1.46] - 2026-02-20
 
 ### Fixed

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.46"
+version = "2.1.47"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -145,6 +145,8 @@ pub use io::{
 // System message subtype types
 pub use io::{
     CompactBoundaryMessage, CompactMetadata, InitMessage, PluginInfo, StatusMessage, SystemMessage,
+    TaskNotificationMessage, TaskProgressMessage, TaskStartedMessage, TaskStatus, TaskType,
+    TaskUsage,
 };
 
 // Rate limit types


### PR DESCRIPTION
## Summary

- Adds typed structs for `task_started`, `task_progress`, and `task_notification` system messages (#89)
- New types: `TaskStartedMessage`, `TaskProgressMessage`, `TaskNotificationMessage`, `TaskUsage`, `TaskType`, `TaskStatus`
- Adds `is_task_started()`, `is_task_progress()`, `is_task_notification()` and `as_task_*()` helpers on `SystemMessage`
- Bumps claude-codes to 2.1.47

## Test plan

- [x] 6 new unit tests using exact JSON from production captures
- [x] All 108 existing tests pass
- [x] Clippy clean, cargo fmt clean

Closes #89