### PR TITLE
Add missing fields to Result, Usage, Init, Assistant, User

### DIFF
--- a/claude-codes/src/io/claude_input.rs
+++ b/claude-codes/src/io/claude_input.rs
@@ -36,6 +36,8 @@ impl ClaudeInput {
                 })],
             },
             session_id: Some(session_id),
+            parent_tool_use_id: None,
+            uuid: None,
         })
     }
 
@@ -47,6 +49,8 @@ impl ClaudeInput {
                 content: blocks,
             },
             session_id: Some(session_id),
+            parent_tool_use_id: None,
+            uuid: None,
         })
     }
 

--- a/claude-codes/src/io/claude_input.rs
+++ b/claude-codes/src/io/claude_input.rs
@@ -30,7 +30,10 @@ impl ClaudeInput {
         ClaudeInput::User(UserMessage {
             message: MessageContent {
                 role: super::MessageRole::User,
-                content: vec![ContentBlock::Text(TextBlock { text: text.into() })],
+                content: vec![ContentBlock::Text(TextBlock {
+                    text: text.into(),
+                    citations: Vec::new(),
+                })],
             },
             session_id: Some(session_id),
         })
@@ -87,7 +90,10 @@ impl ClaudeInput {
         })];
 
         if let Some(text_content) = text {
-            blocks.push(ContentBlock::Text(TextBlock { text: text_content }));
+            blocks.push(ContentBlock::Text(TextBlock {
+                text: text_content,
+                citations: Vec::new(),
+            }));
         }
 
         Ok(Self::user_message_blocks(blocks, session_id))

--- a/claude-codes/src/io/content_blocks.rs
+++ b/claude-codes/src/io/content_blocks.rs
@@ -11,7 +11,10 @@ where
 {
     let value: Value = Value::deserialize(deserializer)?;
     match value {
-        Value::String(s) => Ok(vec![ContentBlock::Text(TextBlock { text: s })]),
+        Value::String(s) => Ok(vec![ContentBlock::Text(TextBlock {
+            text: s,
+            citations: Vec::new(),
+        })]),
         Value::Array(_) => serde_json::from_value(value).map_err(serde::de::Error::custom),
         _ => Err(serde::de::Error::custom(
             "content must be a string or array",
@@ -159,6 +162,10 @@ fn serialize_tagged<S: Serializer, T: Serialize>(
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TextBlock {
     pub text: String,
+    /// Citations associated with this text block, if any.
+    /// Populated when the model references web search results or other sources.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub citations: Vec<Value>,
 }
 
 /// Image content block (follows Anthropic API structure)
@@ -552,7 +559,7 @@ mod tests {
         let block: ContentBlock = serde_json::from_value(text_json).unwrap();
         assert!(!block.is_unknown());
         assert_eq!(block.block_type(), "text");
-        assert!(matches!(block, ContentBlock::Text(TextBlock { text }) if text == "hello"));
+        assert!(matches!(block, ContentBlock::Text(TextBlock { text, .. }) if text == "hello"));
 
         let tool_json =
             json!({"type": "tool_use", "id": "tu_1", "name": "Bash", "input": {"command": "ls"}});
@@ -610,6 +617,43 @@ mod tests {
         );
         // tool_uses() only returns regular tool_use
         assert_eq!(output.tool_uses().count(), 1);
+    }
+
+    #[test]
+    fn test_text_block_with_citations() {
+        let json = json!({
+            "type": "text",
+            "text": "According to the documentation...",
+            "citations": [
+                {"type": "web_search_result_location", "url": "https://example.com", "title": "Example"}
+            ]
+        });
+
+        let block: ContentBlock = serde_json::from_value(json.clone()).unwrap();
+        if let ContentBlock::Text(t) = &block {
+            assert_eq!(t.text, "According to the documentation...");
+            assert_eq!(t.citations.len(), 1);
+            assert_eq!(t.citations[0]["url"], "https://example.com");
+        } else {
+            panic!("Expected Text variant");
+        }
+        // roundtrip preserves citations
+        let reserialized = serde_json::to_value(&block).unwrap();
+        assert_eq!(json, reserialized);
+    }
+
+    #[test]
+    fn test_text_block_without_citations_defaults_empty() {
+        let json = json!({"type": "text", "text": "no citations"});
+        let block: ContentBlock = serde_json::from_value(json).unwrap();
+        if let ContentBlock::Text(t) = &block {
+            assert!(t.citations.is_empty());
+        } else {
+            panic!("Expected Text variant");
+        }
+        // serialization omits empty citations
+        let reserialized = serde_json::to_value(&block).unwrap();
+        assert!(reserialized.get("citations").is_none());
     }
 
     #[test]

--- a/claude-codes/src/io/message_types.rs
+++ b/claude-codes/src/io/message_types.rs
@@ -446,6 +446,12 @@ pub struct UserMessage {
         deserialize_with = "deserialize_optional_uuid"
     )]
     pub session_id: Option<Uuid>,
+    /// Parent tool use ID for nested agent messages
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_tool_use_id: Option<String>,
+    /// Message-level unique identifier
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
 }
 
 /// Message content with role
@@ -551,6 +557,9 @@ pub struct PluginInfo {
     pub name: String,
     /// Path to the plugin on disk
     pub path: String,
+    /// Plugin registry source (e.g., "rust-analyzer-lsp@claude-plugins-official")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }
 
 /// Init system message data - sent at session start
@@ -594,6 +603,18 @@ pub struct InitMessage {
     /// Permission mode
     #[serde(skip_serializing_if = "Option::is_none", rename = "permissionMode")]
     pub permission_mode: Option<InitPermissionMode>,
+
+    /// Message-level unique identifier
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+
+    /// Memory storage paths (e.g., {"auto": "/path/to/memory/"})
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_paths: Option<Value>,
+
+    /// Fast mode toggle state (e.g., "off")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fast_mode_state: Option<String>,
 }
 
 /// Status system message - sent during operations like context compaction
@@ -727,6 +748,12 @@ pub struct AssistantMessageContent {
     pub stop_sequence: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage: Option<AssistantUsage>,
+    /// Details about why generation stopped
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_details: Option<Value>,
+    /// Context management metadata
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_management: Option<Value>,
 }
 
 /// Usage information for assistant messages
@@ -755,6 +782,10 @@ pub struct AssistantUsage {
     /// Detailed cache creation breakdown
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_creation: Option<CacheCreationDetails>,
+
+    /// Inference geography (e.g., "not_available")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inference_geo: Option<String>,
 }
 
 /// Detailed cache creation information
@@ -1080,6 +1111,100 @@ mod tests {
             );
         } else {
             panic!("Expected System message");
+        }
+    }
+
+    #[test]
+    fn test_init_message_with_new_fields() {
+        let json = r#"{
+            "type": "system",
+            "subtype": "init",
+            "session_id": "test-session",
+            "cwd": "/home/user",
+            "model": "claude-opus-4-7",
+            "tools": ["Bash"],
+            "mcp_servers": [],
+            "permissionMode": "default",
+            "apiKeySource": "none",
+            "uuid": "44841a0d-182d-493a-86b5-79800d3d9665",
+            "memory_paths": {"auto": "/home/user/.claude/projects/memory/"},
+            "fast_mode_state": "off",
+            "plugins": [{"name": "lsp", "path": "/plugins/lsp", "source": "lsp@official"}],
+            "claude_code_version": "2.1.117"
+        }"#;
+
+        let output: ClaudeOutput = serde_json::from_str(json).unwrap();
+        if let ClaudeOutput::System(sys) = output {
+            let init = sys.as_init().expect("Should parse as init");
+            assert_eq!(
+                init.uuid.as_deref(),
+                Some("44841a0d-182d-493a-86b5-79800d3d9665")
+            );
+            assert!(init.memory_paths.is_some());
+            assert_eq!(init.fast_mode_state.as_deref(), Some("off"));
+            assert_eq!(init.plugins[0].source.as_deref(), Some("lsp@official"));
+            assert_eq!(init.claude_code_version.as_deref(), Some("2.1.117"));
+        } else {
+            panic!("Expected System message");
+        }
+    }
+
+    #[test]
+    fn test_assistant_message_with_new_fields() {
+        let json = r#"{
+            "type": "assistant",
+            "message": {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-opus-4-7",
+                "content": [{"type": "text", "text": "Hello"}],
+                "stop_reason": "end_turn",
+                "stop_details": null,
+                "context_management": null,
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 10,
+                    "cache_creation_input_tokens": 50,
+                    "cache_read_input_tokens": 0,
+                    "service_tier": "standard",
+                    "inference_geo": "not_available"
+                }
+            },
+            "session_id": "abc",
+            "uuid": "msg-uuid-123"
+        }"#;
+
+        let output: ClaudeOutput = serde_json::from_str(json).unwrap();
+        if let ClaudeOutput::Assistant(asst) = output {
+            assert_eq!(asst.message.stop_details, None);
+            assert_eq!(asst.message.context_management, None);
+            let usage = asst.message.usage.unwrap();
+            assert_eq!(usage.inference_geo.as_deref(), Some("not_available"));
+        } else {
+            panic!("Expected Assistant message");
+        }
+    }
+
+    #[test]
+    fn test_user_message_with_new_fields() {
+        let json = r#"{
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "Hello"}]
+            },
+            "session_id": "9abbc466-dad0-4b8e-b6b0-cad5eb7a16b9",
+            "parent_tool_use_id": "toolu_123",
+            "uuid": "user-msg-456"
+        }"#;
+
+        let output: ClaudeOutput = serde_json::from_str(json).unwrap();
+        if let ClaudeOutput::User(user) = output {
+            assert_eq!(user.parent_tool_use_id.as_deref(), Some("toolu_123"));
+            assert_eq!(user.uuid.as_deref(), Some("user-msg-456"));
+        } else {
+            panic!("Expected User message");
         }
     }
 }

--- a/claude-codes/src/io/result.rs
+++ b/claude-codes/src/io/result.rs
@@ -32,6 +32,26 @@ pub struct ResultMessage {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uuid: Option<String>,
+
+    /// HTTP status code when the result is an API error (e.g., 429, 500, 529)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_error_status: Option<u16>,
+
+    /// Why generation stopped (e.g., end_turn, max_tokens)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<String>,
+
+    /// Why the session ended (e.g., "completed")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_reason: Option<String>,
+
+    /// Fast mode toggle state (e.g., "off")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fast_mode_state: Option<String>,
+
+    /// Per-model cost breakdown, keyed by model name
+    #[serde(skip_serializing_if = "Option::is_none", rename = "modelUsage")]
+    pub model_usage: Option<Value>,
 }
 
 /// A record of a tool permission that was denied during the session.
@@ -62,18 +82,44 @@ pub enum ResultSubtype {
 /// Usage information for the request
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UsageInfo {
+    #[serde(default)]
     pub input_tokens: u32,
+    #[serde(default)]
     pub cache_creation_input_tokens: u32,
+    #[serde(default)]
     pub cache_read_input_tokens: u32,
+    #[serde(default)]
     pub output_tokens: u32,
+    #[serde(default)]
     pub server_tool_use: ServerToolUse,
+    #[serde(default)]
     pub service_tier: String,
+
+    /// Cache creation breakdown
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_creation: Option<super::message_types::CacheCreationDetails>,
+
+    /// Inference geography (e.g., "not_available")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inference_geo: Option<String>,
+
+    /// Per-turn usage breakdown
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub iterations: Vec<Value>,
+
+    /// Speed tier (e.g., "standard")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speed: Option<String>,
 }
 
 /// Server tool usage information
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ServerToolUse {
+    #[serde(default)]
     pub web_search_requests: u32,
+    /// Number of web fetch requests made
+    #[serde(default)]
+    pub web_fetch_requests: u32,
 }
 
 #[cfg(test)]
@@ -222,5 +268,90 @@ mod tests {
 
         assert!(reserialized.contains("Error 1"));
         assert!(reserialized.contains("Error 2"));
+    }
+
+    #[test]
+    fn test_result_with_new_fields() {
+        let json = r#"{
+            "type": "result",
+            "subtype": "success",
+            "is_error": false,
+            "duration_ms": 5000,
+            "duration_api_ms": 4500,
+            "num_turns": 1,
+            "result": "Done",
+            "session_id": "abc",
+            "total_cost_usd": 0.06,
+            "api_error_status": null,
+            "stop_reason": "end_turn",
+            "terminal_reason": "completed",
+            "fast_mode_state": "off",
+            "modelUsage": {
+                "claude-opus-4-7[1m]": {
+                    "inputTokens": 3817,
+                    "outputTokens": 14,
+                    "costUSD": 0.06
+                }
+            },
+            "usage": {
+                "input_tokens": 3817,
+                "output_tokens": 14,
+                "cache_creation_input_tokens": 3540,
+                "cache_read_input_tokens": 0,
+                "server_tool_use": {
+                    "web_search_requests": 0,
+                    "web_fetch_requests": 2
+                },
+                "service_tier": "standard",
+                "inference_geo": "not_available",
+                "speed": "standard",
+                "iterations": [
+                    {"input_tokens": 3817, "output_tokens": 14, "type": "turn"}
+                ]
+            }
+        }"#;
+
+        let output: ClaudeOutput = serde_json::from_str(json).unwrap();
+        if let ClaudeOutput::Result(res) = output {
+            assert_eq!(res.stop_reason.as_deref(), Some("end_turn"));
+            assert_eq!(res.terminal_reason.as_deref(), Some("completed"));
+            assert_eq!(res.fast_mode_state.as_deref(), Some("off"));
+            assert!(res.model_usage.is_some());
+            assert!(res.api_error_status.is_none());
+
+            let usage = res.usage.unwrap();
+            assert_eq!(usage.server_tool_use.web_fetch_requests, 2);
+            assert_eq!(usage.inference_geo.as_deref(), Some("not_available"));
+            assert_eq!(usage.speed.as_deref(), Some("standard"));
+            assert_eq!(usage.iterations.len(), 1);
+        } else {
+            panic!("Expected Result");
+        }
+    }
+
+    #[test]
+    fn test_result_backwards_compatible_without_new_fields() {
+        // Verify old-format messages still parse fine
+        let json = r#"{
+            "type": "result",
+            "subtype": "success",
+            "is_error": false,
+            "duration_ms": 100,
+            "duration_api_ms": 200,
+            "num_turns": 1,
+            "session_id": "abc",
+            "total_cost_usd": 0.01
+        }"#;
+
+        let output: ClaudeOutput = serde_json::from_str(json).unwrap();
+        if let ClaudeOutput::Result(res) = output {
+            assert!(res.api_error_status.is_none());
+            assert!(res.stop_reason.is_none());
+            assert!(res.terminal_reason.is_none());
+            assert!(res.fast_mode_state.is_none());
+            assert!(res.model_usage.is_none());
+        } else {
+            panic!("Expected Result");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- **ResultMessage**: adds \`api_error_status\`, \`stop_reason\`, \`terminal_reason\`, \`fast_mode_state\`, \`modelUsage\`
- **UsageInfo**: adds \`cache_creation\`, \`inference_geo\`, \`iterations\`, \`speed\`; adds \`#[serde(default)]\` to all existing fields
- **ServerToolUse**: adds \`web_fetch_requests\`, derives \`Default\`
- **InitMessage**: adds \`uuid\`, \`memory_paths\`, \`fast_mode_state\`
- **PluginInfo**: adds \`source\`
- **AssistantMessageContent**: adds \`stop_details\`, \`context_management\`
- **AssistantUsage**: adds \`inference_geo\`
- **UserMessage**: adds \`parent_tool_use_id\`, \`uuid\`

All new fields are \`Option\` or \`#[serde(default)]\` for backwards compatibility.

Fixes #109, #110, #111, #112, #113

## Test plan
- [x] New unit tests: result with all new fields, backwards compat without new fields
- [x] New unit tests: init message with new fields, plugin source
- [x] New unit tests: assistant message with stop_details/context_management/inference_geo
- [x] New unit tests: user message with parent_tool_use_id and uuid
- [x] 128 unit tests, 35 integration tests, 34 doc tests pass
- [x] Clippy clean