### PR TITLE
Bump version to 2.1.54, tested against CLI 2.1.117

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.53` is tested against Claude CLI `2.1.47`.
+- **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.54` is tested against Claude CLI `2.1.117`.
 - **`codex-codes`** version will track Codex CLI releases as the protocol stabilizes. Currently at `0.101.1`, tested against Codex CLI `0.104.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.54] - 2026-04-15
+
+### Added
+
+- **`ContentBlock::Unknown(Value)`** — Fallback variant for forward compatibility with new content block types from the CLI. Prevents deserialization failures when encountering unknown block types (#104)
+- **Typed content block variants** — `ServerToolUse`, `WebSearchToolResult`, `CodeExecutionToolResult`, `McpToolUse`, `McpToolResult`, `ContainerUpload` for the new server-side and MCP content blocks emitted by CLI 2.1.117 (#105, #106, #107)
+- **`TextBlock.citations`** — `Vec<Value>` field for web search citations on text blocks (#108)
+- **`ResultMessage` fields** — `api_error_status`, `stop_reason`, `terminal_reason`, `fast_mode_state`, `model_usage` (#109)
+- **`UsageInfo` fields** — `cache_creation`, `inference_geo`, `iterations`, `speed` (#110)
+- **`ServerToolUse.web_fetch_requests`** — Tracks web fetch request count (#110)
+- **`InitMessage` fields** — `uuid`, `memory_paths`, `fast_mode_state` (#111)
+- **`PluginInfo.source`** — Plugin registry source identifier (#111)
+- **`AssistantMessageContent` fields** — `stop_details`, `context_management` (#112)
+- **`AssistantUsage.inference_geo`** — Inference geography field (#112)
+- **`UserMessage` fields** — `parent_tool_use_id`, `uuid` (#113)
+- **New `ToolInput` types** — `MultiEdit`, `LS`, `NotebookRead`, `ScheduleWakeup`, `ToolSearch` with typed structs (#114)
+- **`ClaudeCliBuilder.max_thinking_tokens()`** — Builder method and `CliFlag::MaxThinkingTokens` for extended thinking control (#115)
+- **`ContentBlock.block_type()`** and **`ContentBlock.is_unknown()`** — Helper methods for content block introspection
+
+### Changed
+
+- Updated `TESTED_VERSION` to `2.1.117`
+- `UsageInfo` fields now use `#[serde(default)]` for robustness
+- `ServerToolUse` now derives `Default`
+
 ## [2.1.53] - 2026-03-17
 
 ### Added

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.53"
+version = "2.1.54"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -138,7 +138,7 @@ let serialized = Protocol::serialize(&output)?;
 
 ## Compatibility
 
-**Tested against:** Claude CLI 2.1.47
+**Tested against:** Claude CLI 2.1.117
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.47";
+const TESTED_VERSION: &str = "2.1.117";
 
 /// Ensures version warning is only shown once per session
 static VERSION_CHECK: Once = Once::new();


### PR DESCRIPTION
## Summary
- Bumps crate version from 2.1.53 to 2.1.54
- Updates \`TESTED_VERSION\` from 2.1.47 to 2.1.117
- Updates CHANGELOG with all changes from #104-#115
- Updates README version example

Fixes #116

## Test plan
- [x] All 133 unit tests, 35 integration tests, 34 doc tests pass
- [x] Clippy clean