### PR TITLE
Bump version to 2.1.117 to match CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.54` is tested against Claude CLI `2.1.117`.
+- **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.117` is tested against Claude CLI `2.1.117`.
 - **`codex-codes`** version will track Codex CLI releases as the protocol stabilizes. Currently at `0.101.1`, tested against Codex CLI `0.104.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.54] - 2026-04-15
+## [2.1.117] - 2026-04-15
 
 ### Added
 

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.54"
+version = "2.1.117"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]


### PR DESCRIPTION
## Summary
- Bumps crate version from 2.1.54 to 2.1.117 to align with the installed Claude CLI version

## Test plan
- [x] 133 unit tests pass
- [x] Clippy clean