### PR TITLE
Preserve tool_use_result on UserMessage, bump 2.1.140

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.53"
+version = "2.1.140"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.117` is tested against Claude CLI `2.1.117`.
+- **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.140` is tested against Claude CLI `2.1.140`.
 - **`codex-codes`** version will track Codex CLI releases as the protocol stabilizes. Currently at `0.101.1`, tested against Codex CLI `0.104.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.140] - 2026-05-13
+
+### Added
+
+- **`UserMessage.tool_use_result`** — `Option<serde_json::Value>` capturing the top-level structured tool result the CLI emits alongside `tool_result` content blocks (e.g. `{ questions, answers }` for `AskUserQuestion`, `{ stdout, stderr, exit_code }` for `Bash`). Previously dropped during deserialization, which broke proxies relaying user messages to viewers that read the field.
+- **`UserMessage.timestamp`** — `Option<String>` capturing the CLI's ISO-8601 timestamp on echoed tool results.
+- **`UserMessage::tool_use_result_as<T>()`** — Typed accessor for parsing `tool_use_result` into a caller-specified type when the tool is known (e.g. `tool_use_result_as::<AskUserQuestionInput>()`).
+- **Integration regression test** — `test_ask_user_question_answered_and_converges` drives the full AskUserQuestion round-trip through the permission control protocol and asserts `tool_use_result` survives end-to-end without information loss.
+
+### Changed
+
+- Updated `TESTED_VERSION` to `2.1.140`
+
 ## [2.1.117] - 2026-04-15
 
 ### Added

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.117"
+version = "2.1.140"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -138,7 +138,7 @@ let serialized = Protocol::serialize(&output)?;
 
 ## Compatibility
 
-**Tested against:** Claude CLI 2.1.117
+**Tested against:** Claude CLI 2.1.140
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/io/claude_input.rs
+++ b/claude-codes/src/io/claude_input.rs
@@ -38,6 +38,8 @@ impl ClaudeInput {
             session_id: Some(session_id),
             parent_tool_use_id: None,
             uuid: None,
+            timestamp: None,
+            tool_use_result: None,
         })
     }
 
@@ -51,6 +53,8 @@ impl ClaudeInput {
             session_id: Some(session_id),
             parent_tool_use_id: None,
             uuid: None,
+            timestamp: None,
+            tool_use_result: None,
         })
     }
 

--- a/claude-codes/src/io/message_types.rs
+++ b/claude-codes/src/io/message_types.rs
@@ -452,6 +452,34 @@ pub struct UserMessage {
     /// Message-level unique identifier
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uuid: Option<String>,
+    /// CLI-emitted ISO-8601 timestamp for the message (present on echoed tool results).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+    /// Structured tool result data echoed by the CLI alongside the `tool_result`
+    /// content block. The shape depends on which tool produced it (e.g. for
+    /// `AskUserQuestion` it is `{ questions, answers }`; for `Bash` it is
+    /// `{ stdout, stderr, exit_code, ... }`). Stored as raw JSON to preserve
+    /// wire fidelity; use [`UserMessage::tool_use_result_as`] to parse into a
+    /// typed shape when you know which tool was invoked.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_use_result: Option<serde_json::Value>,
+}
+
+impl UserMessage {
+    /// Parse the `tool_use_result` field into a caller-specified type.
+    ///
+    /// Returns `None` if `tool_use_result` is absent, otherwise returns the
+    /// deserialization result. The caller must know which tool produced the
+    /// result and supply a matching type — e.g. for `AskUserQuestion` use
+    /// [`AskUserQuestionInput`](crate::AskUserQuestionInput), whose
+    /// `questions` + `answers` fields match the wire result shape.
+    pub fn tool_use_result_as<T: serde::de::DeserializeOwned>(
+        &self,
+    ) -> Option<Result<T, serde_json::Error>> {
+        self.tool_use_result
+            .as_ref()
+            .map(|v| serde_json::from_value(v.clone()))
+    }
 }
 
 /// Message content with role
@@ -1206,5 +1234,82 @@ mod tests {
         } else {
             panic!("Expected User message");
         }
+    }
+
+    /// Real wire payload captured from the CLI after answering an
+    /// AskUserQuestion via the permission control protocol. The top-level
+    /// `tool_use_result` and `timestamp` fields must round-trip without loss —
+    /// proxies using this crate to relay messages to a viewer rely on those
+    /// fields being preserved (the viewer reads `tool_use_result.answers`).
+    #[test]
+    fn test_user_message_preserves_tool_use_result_and_timestamp() {
+        let json = r#"{
+            "type":"user",
+            "message":{"role":"user","content":[{"type":"tool_result","content":"User has answered your questions: . You can now continue with the user's answers in mind.","tool_use_id":"toolu_01331duMqP2PrRaqR2yWa8e4"}]},
+            "parent_tool_use_id":null,
+            "session_id":"622ae0c3-3d50-4fa7-9ee0-69d691238c6d",
+            "uuid":"8ef6e997-a849-4d15-bed3-2837c3d3f4cd",
+            "timestamp":"2026-05-12T23:12:04.121Z",
+            "tool_use_result":{"questions":[{"question":"Which color do you prefer?","header":"Color","options":[{"label":"Red","description":"A warm color"},{"label":"Blue","description":"A cool color"}],"multiSelect":false}],"answers":{"Color":"Blue"}}
+        }"#;
+
+        let output: ClaudeOutput = serde_json::from_str(json).unwrap();
+        let user = match output {
+            ClaudeOutput::User(u) => u,
+            other => panic!("Expected User message, got {:?}", other.message_type()),
+        };
+
+        assert_eq!(user.timestamp.as_deref(), Some("2026-05-12T23:12:04.121Z"));
+        let raw = user
+            .tool_use_result
+            .as_ref()
+            .expect("tool_use_result must be captured");
+        assert_eq!(raw["answers"]["Color"], "Blue");
+        assert_eq!(raw["questions"][0]["header"], "Color");
+
+        // Round-trip: re-serialize and confirm tool_use_result + timestamp
+        // survive — the bug we're guarding against is that the proxy silently
+        // drops these fields when relaying user messages.
+        let reser: serde_json::Value = serde_json::to_value(&user).unwrap();
+        assert_eq!(reser["timestamp"], "2026-05-12T23:12:04.121Z");
+        assert_eq!(reser["tool_use_result"]["answers"]["Color"], "Blue");
+        assert_eq!(
+            reser["tool_use_result"]["questions"][0]["question"],
+            "Which color do you prefer?"
+        );
+
+        // Typed accessor: AskUserQuestionInput has the same shape as the
+        // AskUserQuestion tool_use_result.
+        let typed: crate::AskUserQuestionInput = user
+            .tool_use_result_as::<crate::AskUserQuestionInput>()
+            .expect("tool_use_result present")
+            .expect("AskUserQuestionInput parses");
+        assert_eq!(typed.questions.len(), 1);
+        assert_eq!(typed.questions[0].header, "Color");
+        let answers = typed.answers.expect("answers populated");
+        assert_eq!(answers.get("Color").map(String::as_str), Some("Blue"));
+    }
+
+    /// User messages without `tool_use_result` / `timestamp` must still
+    /// deserialize fine and serialize back without spuriously emitting nulls.
+    #[test]
+    fn test_user_message_without_tool_use_result_omits_field() {
+        let json = r#"{
+            "type":"user",
+            "message":{"role":"user","content":[{"type":"text","text":"hello"}]},
+            "session_id":"622ae0c3-3d50-4fa7-9ee0-69d691238c6d"
+        }"#;
+
+        let output: ClaudeOutput = serde_json::from_str(json).unwrap();
+        let user = match output {
+            ClaudeOutput::User(u) => u,
+            _ => panic!("Expected User message"),
+        };
+        assert!(user.tool_use_result.is_none());
+        assert!(user.timestamp.is_none());
+
+        let reser = serde_json::to_value(&user).unwrap();
+        assert!(reser.get("tool_use_result").is_none());
+        assert!(reser.get("timestamp").is_none());
     }
 }

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.117";
+const TESTED_VERSION: &str = "2.1.140";
 
 /// Ensures version warning is only shown once per session
 static VERSION_CHECK: Once = Once::new();

--- a/claude-codes/tests/integration_tests.rs
+++ b/claude-codes/tests/integration_tests.rs
@@ -294,6 +294,7 @@ async fn test_tool_use_blocks() {
                                 claude_codes::io::ContentBlock::Image(_) => {
                                     // Images might appear in assistant messages for generated images
                                 }
+                                _ => {}
                             }
                         }
                     }
@@ -630,6 +631,7 @@ async fn test_mixed_content_blocks() {
     let blocks = vec![
         ContentBlock::Text(claude_codes::io::TextBlock {
             text: "Here's a question with an image:".to_string(),
+            citations: Vec::new(),
         }),
         ContentBlock::Image(claude_codes::io::ImageBlock {
             source: claude_codes::io::ImageSource {
@@ -640,6 +642,7 @@ async fn test_mixed_content_blocks() {
         }),
         ContentBlock::Text(claude_codes::io::TextBlock {
             text: "What color is this pixel?".to_string(),
+            citations: Vec::new(),
         }),
     ];
 
@@ -1906,4 +1909,478 @@ async fn test_clear_resets_session() {
     }
 
     client.shutdown().await.expect("Failed to shutdown client");
+}
+
+/// Probe the AskUserQuestion round-trip end-to-end.
+///
+/// Prompts Claude to invoke AskUserQuestion, then captures every message that
+/// flows back: the `tool_use` (with its typed input), any `tool_result` echoed
+/// back as a user message, and the assistant text that follows. Logs the raw
+/// shape so we can see whether the answer is "munged" anywhere in the path.
+///
+/// Bounded by a wall-clock timeout because AskUserQuestion in non-interactive
+/// subprocess mode may hang waiting for a UI that doesn't exist.
+#[tokio::test]
+async fn test_ask_user_question_round_trip() {
+    use claude_codes::AskUserQuestionInput;
+    use std::time::Duration;
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let child = ClaudeCliBuilder::new()
+        .model("sonnet")
+        .allow_recursion()
+        .allowed_tools(["AskUserQuestion"])
+        .spawn()
+        .await
+        .expect("Failed to spawn Claude");
+    let mut client = AsyncClient::new(child).expect("Failed to create async client");
+
+    let prompt = "Invoke the AskUserQuestion tool exactly once with the following payload, \
+                  then wait for my answer and write a single sentence telling me which color I picked.\n\
+                  questions: [\n  {\n    question: 'Which color do you prefer?',\n    \
+                  header: 'Color',\n    options: [\n      {label: 'Red', description: 'A warm color'},\n      \
+                  {label: 'Blue', description: 'A cool color'}\n    ],\n    multiSelect: false\n  }\n]";
+
+    let mut stream = client
+        .query_stream(prompt)
+        .await
+        .expect("Failed to send query");
+
+    #[derive(Default, Debug)]
+    struct Trace {
+        message_count: usize,
+        parse_errors: Vec<(String, Option<serde_json::Value>)>,
+        tool_use_id: Option<String>,
+        tool_use_input_raw: Option<serde_json::Value>,
+        tool_use_input_typed: Option<Result<AskUserQuestionInput, String>>,
+        tool_result_for_id: Option<(String, Option<bool>, Option<String>)>,
+        post_tool_assistant_text: String,
+        message_type_log: Vec<String>,
+        saw_result: bool,
+    }
+
+    let mut trace = Trace::default();
+
+    let result = tokio::time::timeout(Duration::from_secs(90), async {
+        while let Some(item) = stream.next().await {
+            trace.message_count += 1;
+            match item {
+                Ok(output) => {
+                    trace
+                        .message_type_log
+                        .push(output.message_type().to_string());
+                    eprintln!("[TRACE #{}] {}", trace.message_count, output.message_type());
+
+                    match output {
+                        ClaudeOutput::Assistant(msg) => {
+                            for block in msg.message.content {
+                                match block {
+                                    ContentBlock::ToolUse(tu) if tu.name == "AskUserQuestion" => {
+                                        eprintln!(
+                                            "[TRACE]   tool_use AskUserQuestion id={} input={}",
+                                            tu.id,
+                                            serde_json::to_string(&tu.input).unwrap_or_default()
+                                        );
+                                        trace.tool_use_id = Some(tu.id.clone());
+                                        trace.tool_use_input_raw = Some(tu.input.clone());
+                                        trace.tool_use_input_typed = Some(
+                                            serde_json::from_value::<AskUserQuestionInput>(
+                                                tu.input.clone(),
+                                            )
+                                            .map_err(|e| e.to_string()),
+                                        );
+                                    }
+                                    ContentBlock::ToolUse(tu) => {
+                                        eprintln!("[TRACE]   tool_use other name={}", tu.name);
+                                    }
+                                    ContentBlock::Text(t) => {
+                                        let snippet = t.text.chars().take(200).collect::<String>();
+                                        eprintln!("[TRACE]   text: {}", snippet);
+                                        if trace.tool_use_id.is_some() {
+                                            trace.post_tool_assistant_text.push_str(&t.text);
+                                            trace.post_tool_assistant_text.push('\n');
+                                        }
+                                    }
+                                    ContentBlock::Thinking(_) => {
+                                        eprintln!("[TRACE]   thinking block");
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                        ClaudeOutput::User(msg) => {
+                            for block in msg.message.content {
+                                if let ContentBlock::ToolResult(tr) = block {
+                                    let preview = match &tr.content {
+                                        Some(claude_codes::ToolResultContent::Text(s)) => {
+                                            let p = s.chars().take(200).collect::<String>();
+                                            Some(p)
+                                        }
+                                        Some(claude_codes::ToolResultContent::Structured(v)) => {
+                                            Some(
+                                                serde_json::to_string(v)
+                                                    .unwrap_or_default()
+                                                    .chars()
+                                                    .take(400)
+                                                    .collect::<String>(),
+                                            )
+                                        }
+                                        None => None,
+                                    };
+                                    eprintln!(
+                                        "[TRACE]   tool_result id={} is_error={:?} preview={:?}",
+                                        tr.tool_use_id, tr.is_error, preview
+                                    );
+                                    if Some(&tr.tool_use_id) == trace.tool_use_id.as_ref() {
+                                        trace.tool_result_for_id =
+                                            Some((tr.tool_use_id.clone(), tr.is_error, preview));
+                                    }
+                                }
+                            }
+                        }
+                        ClaudeOutput::Result(r) => {
+                            eprintln!(
+                                "[TRACE]   result subtype={:?} is_error={}",
+                                r.subtype, r.is_error
+                            );
+                            trace.saw_result = true;
+                            break;
+                        }
+                        ClaudeOutput::ControlRequest(cr) => {
+                            eprintln!("[TRACE]   control_request: {:?}", cr);
+                        }
+                        _ => {}
+                    }
+                }
+                Err(e) => {
+                    let (msg, raw_json) = match &e {
+                        claude_codes::Error::Deserialization(pe) => {
+                            (pe.error_message.clone(), pe.raw_json.clone())
+                        }
+                        other => (other.to_string(), None),
+                    };
+                    eprintln!("[TRACE] parse error: {} raw_json={:?}", msg, raw_json);
+                    trace.parse_errors.push((msg, raw_json));
+                }
+            }
+        }
+    })
+    .await;
+
+    eprintln!("=== AskUserQuestion round-trip trace ===");
+    eprintln!("timed_out: {}", result.is_err());
+    eprintln!("messages: {}", trace.message_count);
+    eprintln!("message_types: {:?}", trace.message_type_log);
+    eprintln!("parse_errors: {}", trace.parse_errors.len());
+    for (i, (msg, raw)) in trace.parse_errors.iter().enumerate() {
+        eprintln!("  [{}] {}", i, msg);
+        if let Some(r) = raw {
+            eprintln!(
+                "      raw: {}",
+                serde_json::to_string(r).unwrap_or_default()
+            );
+        }
+    }
+    eprintln!("tool_use_seen: {}", trace.tool_use_id.is_some());
+    eprintln!(
+        "tool_use_input_typed_ok: {:?}",
+        trace.tool_use_input_typed.as_ref().map(|r| r.is_ok())
+    );
+    if let Some(Err(e)) = &trace.tool_use_input_typed {
+        eprintln!("tool_use_input_typed_err: {}", e);
+    }
+    if let Some(input) = &trace.tool_use_input_raw {
+        eprintln!(
+            "tool_use_input_raw: {}",
+            serde_json::to_string(input).unwrap_or_default()
+        );
+    }
+    eprintln!("tool_result_for_id: {:?}", trace.tool_result_for_id);
+    eprintln!(
+        "post_tool_assistant_text: {:?}",
+        trace.post_tool_assistant_text
+    );
+    eprintln!("saw_result: {}", trace.saw_result);
+
+    // No hard assertions on coherence yet — first run is exploratory so we can
+    // see what the wire actually looks like. We do require that parsing
+    // succeeds for everything we got, since the user's complaint is "things
+    // get munged in processing".
+    assert!(
+        trace.parse_errors.is_empty(),
+        "AskUserQuestion round-trip produced {} parse errors (see stderr trace above)",
+        trace.parse_errors.len()
+    );
+    assert!(
+        trace.tool_use_id.is_some(),
+        "Expected an AskUserQuestion tool_use block; types seen: {:?}",
+        trace.message_type_log
+    );
+    if let Some(Err(e)) = &trace.tool_use_input_typed {
+        panic!(
+            "AskUserQuestion tool_use.input did not deserialize into AskUserQuestionInput: {}",
+            e
+        );
+    }
+}
+
+/// End-to-end probe: sub-Claude asks an AskUserQuestion, we *answer* it via
+/// the permission control protocol, then we check whether the conversation
+/// converges — i.e. sub-Claude's subsequent reply demonstrates it received
+/// and understood our answer.
+///
+/// Wire flow under test:
+/// 1. spawn with `permission_prompt_tool("stdio")` so the CLI asks before invoking tools
+/// 2. send a prompt telling sub-Claude to ask a color question
+/// 3. when the CLI sends `can_use_tool` for AskUserQuestion, parse the input,
+///    inject `answers: {header -> chosen_label}`, and reply `allow_with(updated_input)`
+/// 4. drain remaining messages and look for an assistant text that references
+///    our chosen answer ("Blue")
+#[tokio::test]
+async fn test_ask_user_question_answered_and_converges() {
+    use claude_codes::{AskUserQuestionInput, ControlRequestPayload};
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let child = ClaudeCliBuilder::new()
+        .model("sonnet")
+        .allow_recursion()
+        .permission_prompt_tool("stdio")
+        .spawn()
+        .await
+        .expect("Failed to spawn Claude");
+    let mut client = AsyncClient::new(child).expect("Failed to create async client");
+
+    client
+        .enable_tool_approval()
+        .await
+        .expect("enable_tool_approval");
+
+    const CHOSEN: &str = "Blue";
+
+    let prompt = format!(
+        "Invoke the AskUserQuestion tool exactly once with this exact payload:\n\
+         questions = [{{ question: 'Which color do you prefer?', header: 'Color', \
+         options: [{{label: 'Red', description: 'A warm color'}}, \
+         {{label: '{CHOSEN}', description: 'A cool color'}}], multiSelect: false }}]\n\
+         After you receive my answer, reply with exactly one sentence that names the color I picked."
+    );
+
+    let input = ClaudeInput::user_message(&prompt, Uuid::new_v4());
+    client.send(&input).await.expect("send query");
+
+    let mut trace_lines: Vec<String> = Vec::new();
+    let mut tool_use_id: Option<String> = None;
+    let mut tool_use_input_seen: Option<AskUserQuestionInput> = None;
+    let mut control_req_handled = false;
+    let mut answered_with: Option<HashMap<String, String>> = None;
+    let mut post_answer_assistant_text = String::new();
+    let mut saw_result = false;
+    let mut result_is_error = None;
+    let mut got_post_answer_assistant = false;
+    let mut tool_use_result_field: Option<serde_json::Value> = None;
+    let mut user_msg_timestamp: Option<String> = None;
+    let mut user_msg_roundtrip_diff: Option<String> = None;
+
+    let outcome = tokio::time::timeout(Duration::from_secs(120), async {
+        loop {
+            match client.receive().await {
+                Ok(output) => {
+                    let mt = output.message_type();
+                    trace_lines.push(mt.clone());
+                    eprintln!("[TRACE] {}", mt);
+
+                    match output {
+                        ClaudeOutput::ControlRequest(req) => {
+                            if let ControlRequestPayload::CanUseTool(perm_req) = &req.request {
+                                eprintln!(
+                                    "[TRACE]   can_use_tool: {} input={}",
+                                    perm_req.tool_name,
+                                    serde_json::to_string(&perm_req.input).unwrap_or_default()
+                                );
+                                if perm_req.tool_name == "AskUserQuestion" {
+                                    let parsed: AskUserQuestionInput = serde_json::from_value(
+                                        perm_req.input.clone(),
+                                    )
+                                    .expect("AskUserQuestion input must deserialize");
+                                    let mut answers = HashMap::new();
+                                    for q in &parsed.questions {
+                                        answers.insert(q.header.clone(), CHOSEN.to_string());
+                                    }
+                                    tool_use_input_seen = Some(parsed);
+                                    answered_with = Some(answers.clone());
+
+                                    let mut updated_input = perm_req.input.clone();
+                                    updated_input
+                                        .as_object_mut()
+                                        .expect("input is object")
+                                        .insert(
+                                            "answers".to_string(),
+                                            serde_json::to_value(&answers).unwrap(),
+                                        );
+                                    eprintln!(
+                                        "[TRACE]   replying allow_with: {}",
+                                        serde_json::to_string(&updated_input).unwrap_or_default()
+                                    );
+                                    let response =
+                                        perm_req.allow_with(updated_input, &req.request_id);
+                                    client
+                                        .send_control_response(response)
+                                        .await
+                                        .expect("send_control_response");
+                                    control_req_handled = true;
+                                } else {
+                                    // Allow anything else through unchanged
+                                    let response = perm_req.allow(&req.request_id);
+                                    let _ = client.send_control_response(response).await;
+                                }
+                            }
+                        }
+                        ClaudeOutput::Assistant(msg) => {
+                            for block in msg.message.content {
+                                match block {
+                                    ContentBlock::ToolUse(tu) if tu.name == "AskUserQuestion" => {
+                                        eprintln!(
+                                            "[TRACE]   tool_use AskUserQuestion id={}",
+                                            tu.id
+                                        );
+                                        tool_use_id = Some(tu.id.clone());
+                                    }
+                                    ContentBlock::Text(t) => {
+                                        let snippet =
+                                            t.text.chars().take(300).collect::<String>();
+                                        eprintln!("[TRACE]   text: {}", snippet);
+                                        if control_req_handled {
+                                            got_post_answer_assistant = true;
+                                            post_answer_assistant_text.push_str(&t.text);
+                                            post_answer_assistant_text.push('\n');
+                                        }
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                        ClaudeOutput::User(msg) => {
+                            // Capture the top-level fields before iterating
+                            // (avoids partial-move issues).
+                            if control_req_handled && msg.tool_use_result.is_some() {
+                                tool_use_result_field = msg.tool_use_result.clone();
+                                user_msg_timestamp = msg.timestamp.clone();
+
+                                // Regression check: re-serialize the entire
+                                // parsed UserMessage and verify the
+                                // tool_use_result field round-trips exactly.
+                                if let Ok(reser) = serde_json::to_value(&msg) {
+                                    let original = msg.tool_use_result.as_ref().unwrap();
+                                    let echoed = &reser["tool_use_result"];
+                                    if echoed != original {
+                                        user_msg_roundtrip_diff = Some(format!(
+                                            "tool_use_result round-trip diverged.\noriginal: {}\necho:    {}",
+                                            serde_json::to_string(original).unwrap_or_default(),
+                                            serde_json::to_string(echoed).unwrap_or_default()
+                                        ));
+                                    }
+                                }
+                            }
+                            for block in &msg.message.content {
+                                if let ContentBlock::ToolResult(tr) = block {
+                                    let preview = match &tr.content {
+                                        Some(claude_codes::ToolResultContent::Text(s)) => s.clone(),
+                                        Some(claude_codes::ToolResultContent::Structured(v)) => {
+                                            serde_json::to_string(v).unwrap_or_default()
+                                        }
+                                        None => String::new(),
+                                    };
+                                    eprintln!(
+                                        "[TRACE]   tool_result id={} is_error={:?} preview={}",
+                                        tr.tool_use_id, tr.is_error, preview
+                                    );
+                                }
+                            }
+                        }
+                        ClaudeOutput::Result(r) => {
+                            saw_result = true;
+                            result_is_error = Some(r.is_error);
+                            eprintln!(
+                                "[TRACE]   result subtype={:?} is_error={}",
+                                r.subtype, r.is_error
+                            );
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+                Err(e) => {
+                    eprintln!("[TRACE] error: {}", e);
+                    break;
+                }
+            }
+        }
+    })
+    .await;
+
+    eprintln!("=== Convergence trace ===");
+    eprintln!("timed_out: {}", outcome.is_err());
+    eprintln!("message_types: {:?}", trace_lines);
+    eprintln!("tool_use_id: {:?}", tool_use_id);
+    eprintln!("control_req_handled: {}", control_req_handled);
+    eprintln!("answered_with: {:?}", answered_with);
+    eprintln!(
+        "post_answer_assistant_text: {:?}",
+        post_answer_assistant_text
+    );
+    eprintln!("saw_result: {} is_error: {:?}", saw_result, result_is_error);
+
+    let _ = client.shutdown().await;
+
+    assert!(
+        !outcome.is_err(),
+        "AskUserQuestion convergence test timed out"
+    );
+    assert!(
+        control_req_handled,
+        "Expected to handle a can_use_tool control request for AskUserQuestion"
+    );
+    assert!(saw_result, "Expected a Result message");
+    assert!(
+        got_post_answer_assistant,
+        "Expected at least one assistant text block after answering"
+    );
+
+    // Convergence check: did the sub-Claude reference our chosen answer?
+    let body = post_answer_assistant_text.to_lowercase();
+    let chosen = CHOSEN.to_lowercase();
+    assert!(
+        body.contains(&chosen),
+        "Sub-Claude did not reference the chosen answer {:?} in its follow-up. \
+         Got: {:?}",
+        CHOSEN,
+        post_answer_assistant_text
+    );
+
+    // Regression check: the CLI sends the structured answer in the
+    // top-level `tool_use_result` field on the user message. Proxies
+    // relying on this crate's typed view need that field preserved so
+    // their downstream viewer can render the answer (otherwise the
+    // viewer hits `undefined is not an object (evaluating 'q.map')`).
+    let tur = tool_use_result_field
+        .expect("UserMessage.tool_use_result was not captured by the typed parse");
+    assert_eq!(
+        tur["answers"]["Color"], CHOSEN,
+        "tool_use_result.answers.Color should match the answer we sent via allow_with"
+    );
+    assert_eq!(
+        tur["questions"][0]["header"], "Color",
+        "tool_use_result.questions[0].header should be preserved"
+    );
+    assert!(
+        user_msg_timestamp.is_some(),
+        "UserMessage.timestamp was not captured by the typed parse"
+    );
+    if let Some(diff) = user_msg_roundtrip_diff {
+        panic!("{}", diff);
+    }
 }


### PR DESCRIPTION
## Summary

- `UserMessage` was silently dropping the top-level `tool_use_result` and `timestamp` fields emitted by the CLI alongside `tool_result` content blocks. Proxies round-tripping user messages through this crate lost the structured answer data — a viewer reading `tool_use_result.answers` (or `.questions`) for an `AskUserQuestion` echo would hit `undefined is not an object (evaluating 'q.map')`.
- Adds `tool_use_result: Option<serde_json::Value>` (lossless wire fidelity) and `timestamp: Option<String>`, plus a `UserMessage::tool_use_result_as<T>()` accessor for typed parsing when the caller knows the producing tool (e.g. `AskUserQuestionInput` matches the AskUserQuestion shape).
- Kept `Value` rather than a typed enum because the result shape varies per tool and only AskUserQuestion has a captured fixture; the door is open for a `ToolUseResult` untagged enum once fixtures for the other tools land.
- Bumps version to `2.1.140` and `TESTED_VERSION` to match the installed CLI.

## Test plan

- [x] `cargo test --package claude-codes --lib` — 135 unit tests pass, including two new ones in `message_types.rs`:
  - `test_user_message_preserves_tool_use_result_and_timestamp` — pins the round-trip against a real captured wire payload and exercises `tool_use_result_as::<AskUserQuestionInput>()`.
  - `test_user_message_without_tool_use_result_omits_field` — guards against spurious null emission.
- [x] `cargo test --package claude-codes --tests` — 35 tool_input tests pass.
- [x] `cargo test --package claude-codes --features integration-tests --test integration_tests test_ask_user_question_answered_and_converges -- --nocapture` — drives the full AskUserQuestion permission control protocol against a live CLI, asserts `tool_use_result.answers.Color == "Blue"`, `questions[0].header == "Color"`, `timestamp` is captured, the field re-serializes byte-identically, and sub-Claude's follow-up references the chosen answer.
- [x] `cargo publish --package claude-codes --dry-run --allow-dirty` succeeds.