### PR TITLE
codex-codes: typed Notification/ServerRequest dispatch; fix wire/struct mismatches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.101.1"
+version = "0.102.0"
 dependencies = [
  "env_logger",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.102.0"
+version = "0.130.0"
 dependencies = [
  "env_logger",
  "log",

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.102.0] - 2026-05-14
+
+### Added
+
+- **Typed message dispatch** — New module [`crate::messages`] introduces closed enums [`Notification`] and [`ServerRequest`] that wrap the per-method param structs. The clients now return the typed [`ServerMessage`] from `next_message()`/`events()` instead of the loose `{ method, params }` shape. Mirrors the [`ContentBlock`]-style dispatch in the sibling `claude-codes` crate: hand-written `Serialize`/`Deserialize` impls inspect the `method` discriminant, route known cases through their typed struct, and route unknown methods to an `Unknown { method, params }` fallback for forward compatibility. Known methods whose payload doesn't fit error loudly — the typing contract is enforced.
+- **New typed notifications** — `AccountRateLimitsUpdatedNotification` (`account/rateLimits/updated`), `McpServerStartupStatusUpdatedNotification` (`mcpServer/startupStatus/updated`), `RemoteControlStatusChangedNotification` (`remoteControl/status/changed`). The app-server emits all three during normal operation; previously they fell through to the raw fallback.
+- **`RateLimits` / `RateLimitWindow` / `TokenCounts`** — Supporting structs for the above and for the new nested `TokenUsage` shape.
+- **`UserMessageItem` / `UserMessageContent`** — Added `ThreadItem::UserMessage` variant for the user-prompt item the app-server emits at the start of each turn (the exec JSONL protocol doesn't typically emit this).
+- **Strict typed-message audit test** — `tests/live_client_tests.rs::test_typed_message_audit_strict` runs a real turn and asserts that every notification and server request resolves to a typed variant (no `Unknown`).
+
+### Fixed
+
+- **`ThreadStartedNotification`** — Was `{ thread_id: String }`; the wire actually sends `{ thread: ThreadInfo }` with the full info object.
+- **`TurnStartedNotification` / `TurnCompletedNotification`** — Had a top-level `turn_id` field that doesn't exist on the wire (the id lives inside `turn.id`). Both now carry `{ thread_id, turn: Turn }`.
+- **`ThreadStatusChangedNotification` / `ThreadStatus`** — Status was modeled as a bare string enum; the wire actually sends an internally-tagged enum (`{"type":"idle"}`, `{"type":"active","activeFlags":[]}`). `ThreadStatus` is now `#[serde(tag = "type")]` with the `Active` variant carrying `active_flags`.
+- **`ThreadTokenUsageUpdatedNotification`** — Field was named `usage` but the wire sends `tokenUsage`. The notification also carries `turn_id` which wasn't modeled. Plus the inner `TokenUsage` is actually a wrapper of `{last, total, modelContextWindow}` over a `TokenCounts` struct with `inputTokens`, `outputTokens`, `cachedInputTokens`, `reasoningOutputTokens`, `totalTokens` — restructured accordingly.
+- **`ItemStartedNotification` / `ItemCompletedNotification`** — Now include `started_at_ms` / `completed_at_ms` from the wire.
+- **`CommandExecutionItem`** — Was snake_case-only (`aggregated_output`, `exit_code`); the app-server protocol uses camelCase. Now carries `#[serde(rename_all = "camelCase")]` with snake_case aliases so both protocols deserialize cleanly. `aggregated_output` is now `Option<String>` since the app-server sends `null` while a command is still in progress.
+
+### Changed (breaking)
+
+- **`ServerMessage` shape** — `ServerMessage::Notification { method, params }` is now `ServerMessage::Notification(Notification)`; `ServerMessage::Request { id, method, params }` is now `ServerMessage::Request { id, request: ServerRequest }`. Update call sites to match on the typed enum variants instead of method-string comparisons.
+- **`CommandExecutionItem.aggregated_output`** — Type changed from `String` to `Option<String>` (see above).
+- **`TokenUsage`** — Restructured from a flat counts struct to `{last, total, modelContextWindow}` over `TokenCounts`. Old direct field access (`usage.input_tokens`) becomes `usage.last.input_tokens` or `usage.total.input_tokens`.
+- **`ThreadStatus`** — Now a `#[serde(tag = "type")]` enum; the `Active` variant has an `active_flags: Vec<Value>` field. Pattern matches need updating.
+
 ## [0.101.2] - 2026-05-14
 
 ### Fixed

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.102.0] - 2026-05-14
+## [0.130.0] - 2026-05-14
+
+Version jumps from 0.101.x to 0.130.0 to align the crate version with the
+Codex CLI version it targets (same convention as the sibling `claude-codes`
+crate, which tracks the Claude Code CLI version).
+
 
 ### Added
 

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.101.2"
+version = "0.102.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.102.0"
+version = "0.130.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/examples/async_client.rs
+++ b/codex-codes/examples/async_client.rs
@@ -4,7 +4,7 @@
 //! until the turn completes.
 
 use codex_codes::{
-    protocol::methods, AsyncClient, ServerMessage, ThreadStartParams, TurnStartParams, UserInput,
+    AsyncClient, Notification, ServerMessage, ThreadStartParams, TurnStartParams, UserInput,
 };
 use std::error::Error;
 
@@ -57,43 +57,30 @@ async fn main() -> Result<(), Box<dyn Error>> {
 /// Handle a server message. Returns true if the turn is complete.
 fn handle_message(msg: &ServerMessage) -> bool {
     match msg {
-        ServerMessage::Notification { method, params } => {
-            match method.as_str() {
-                methods::AGENT_MESSAGE_DELTA => {
-                    if let Some(params) = params {
-                        if let Some(delta) = params.get("delta").and_then(|d| d.as_str()) {
-                            print!("{}", delta);
-                        }
-                    }
-                }
-                methods::TURN_STARTED => {
-                    println!("[turn started]");
-                }
-                methods::TURN_COMPLETED => {
-                    println!("\n[turn completed]");
-                    return true;
-                }
-                methods::ITEM_STARTED => {
-                    // Items starting — could inspect the item type
-                }
-                methods::ITEM_COMPLETED => {
-                    // Items completing
-                }
-                methods::ERROR => {
-                    if let Some(params) = params {
-                        if let Some(error) = params.get("error").and_then(|e| e.as_str()) {
-                            eprintln!("[error] {}", error);
-                        }
-                    }
-                }
-                _ => {
-                    log::debug!("Notification: {}", method);
-                }
+        ServerMessage::Notification(n) => match n {
+            Notification::AgentMessageDelta(d) => {
+                print!("{}", d.delta);
+                false
             }
-            false
-        }
-        ServerMessage::Request { method, .. } => {
-            eprintln!("[server request: {}] (unhandled)", method);
+            Notification::TurnStarted(_) => {
+                println!("[turn started]");
+                false
+            }
+            Notification::TurnCompleted(_) => {
+                println!("\n[turn completed]");
+                true
+            }
+            Notification::Error(e) => {
+                eprintln!("[error] {}", e.error);
+                false
+            }
+            other => {
+                log::debug!("Notification: {}", other.method());
+                false
+            }
+        },
+        ServerMessage::Request { request, .. } => {
+            eprintln!("[server request: {}] (unhandled)", request.method());
             false
         }
     }

--- a/codex-codes/examples/basic_repl.rs
+++ b/codex-codes/examples/basic_repl.rs
@@ -4,9 +4,9 @@
 //! Type your prompt and press Enter. Type "exit" to quit.
 
 use codex_codes::{
-    protocol::methods, AsyncClient, CommandApprovalDecision, CommandExecutionApprovalResponse,
-    FileChangeApprovalDecision, FileChangeApprovalResponse, ServerMessage, ThreadStartParams,
-    TurnStartParams, UserInput,
+    AsyncClient, CommandApprovalDecision, CommandExecutionApprovalResponse,
+    FileChangeApprovalDecision, FileChangeApprovalResponse, Notification, ServerMessage,
+    ServerRequest, ThreadItem, ThreadStartParams, TurnStartParams, UserInput,
 };
 use std::io::{self, Write};
 
@@ -65,73 +65,41 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             };
 
             match msg {
-                ServerMessage::Notification { method, params } => match method.as_str() {
-                    methods::AGENT_MESSAGE_DELTA => {
-                        if let Some(ref p) = params {
-                            if let Some(delta) = p.get("delta").and_then(|d| d.as_str()) {
-                                print!("{}", delta);
-                                io::stdout().flush()?;
-                            }
-                        }
+                ServerMessage::Notification(n) => match n {
+                    Notification::AgentMessageDelta(d) => {
+                        print!("{}", d.delta);
+                        io::stdout().flush()?;
                     }
-                    methods::CMD_OUTPUT_DELTA => {
-                        if let Some(ref p) = params {
-                            if let Some(delta) = p.get("delta").and_then(|d| d.as_str()) {
-                                print!("{}", delta);
-                                io::stdout().flush()?;
-                            }
-                        }
+                    Notification::CmdOutputDelta(d) => {
+                        print!("{}", d.delta);
+                        io::stdout().flush()?;
                     }
-                    methods::REASONING_DELTA => {
-                        if let Some(ref p) = params {
-                            if let Some(delta) = p.get("delta").and_then(|d| d.as_str()) {
-                                print!("[thinking] {}", delta);
-                            }
-                        }
+                    Notification::ReasoningDelta(d) => {
+                        print!("[thinking] {}", d.delta);
                     }
-                    methods::ITEM_STARTED => {
-                        if let Some(ref p) = params {
-                            if let Some(item) = p.get("item") {
-                                if let Some(ty) = item.get("type").and_then(|t| t.as_str()) {
-                                    match ty {
-                                        "commandExecution" | "command_execution" => {
-                                            if let Some(cmd) =
-                                                item.get("command").and_then(|c| c.as_str())
-                                            {
-                                                println!("\n[Command: {}]", cmd);
-                                            }
-                                        }
-                                        "fileChange" | "file_change" => {
-                                            println!("\n[File change]");
-                                        }
-                                        _ => {}
-                                    }
-                                }
-                            }
+                    Notification::ItemStarted(item_event) => match item_event.item {
+                        ThreadItem::CommandExecution(c) => {
+                            println!("\n[Command: {}]", c.command);
                         }
-                    }
-                    methods::TURN_COMPLETED => {
+                        ThreadItem::FileChange(_) => {
+                            println!("\n[File change]");
+                        }
+                        _ => {}
+                    },
+                    Notification::TurnCompleted(_) => {
                         println!();
                         break;
                     }
-                    methods::ERROR => {
-                        if let Some(ref p) = params {
-                            if let Some(error) = p.get("error").and_then(|e| e.as_str()) {
-                                eprintln!("\n[Error: {}]", error);
-                            }
-                        }
+                    Notification::Error(e) => {
+                        eprintln!("\n[Error: {}]", e.error);
                     }
-                    _ => {
-                        log::debug!("Notification: {}", method);
+                    other => {
+                        log::debug!("Notification: {}", other.method());
                     }
                 },
-                ServerMessage::Request { id, method, params } => match method.as_str() {
-                    methods::CMD_EXEC_APPROVAL => {
-                        if let Some(ref p) = params {
-                            if let Some(cmd) = p.get("command").and_then(|c| c.as_str()) {
-                                println!("\n[Approving command: {}]", cmd);
-                            }
-                        }
+                ServerMessage::Request { id, request } => match request {
+                    ServerRequest::CmdExecApproval(p) => {
+                        println!("\n[Approving command: {}]", p.command);
                         client
                             .respond(
                                 id,
@@ -141,7 +109,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             )
                             .await?;
                     }
-                    methods::FILE_CHANGE_APPROVAL => {
+                    ServerRequest::FileChangeApproval(_) => {
                         println!("\n[Approving file change]");
                         client
                             .respond(
@@ -152,7 +120,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             )
                             .await?;
                     }
-                    _ => {
+                    ServerRequest::Unknown { method, .. } => {
                         eprintln!("[unhandled server request: {}]", method);
                     }
                 },

--- a/codex-codes/examples/sync_client.rs
+++ b/codex-codes/examples/sync_client.rs
@@ -4,7 +4,7 @@
 //! until the turn completes.
 
 use codex_codes::{
-    protocol::methods, ServerMessage, SyncClient, ThreadStartParams, TurnStartParams, UserInput,
+    Notification, ServerMessage, SyncClient, ThreadStartParams, TurnStartParams, UserInput,
 };
 use std::error::Error;
 
@@ -33,30 +33,20 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Iterate notifications until the turn completes
     for result in client.events() {
         match result {
-            Ok(msg) => match &msg {
-                ServerMessage::Notification { method, params } => match method.as_str() {
-                    methods::AGENT_MESSAGE_DELTA => {
-                        if let Some(params) = params {
-                            if let Some(delta) = params.get("delta").and_then(|d| d.as_str()) {
-                                print!("{}", delta);
-                            }
-                        }
-                    }
-                    methods::TURN_COMPLETED => {
-                        println!("\n[turn completed]");
-                        break;
-                    }
-                    methods::ERROR => {
-                        if let Some(params) = params {
-                            if let Some(error) = params.get("error").and_then(|e| e.as_str()) {
-                                eprintln!("[error] {}", error);
-                            }
-                        }
-                    }
-                    _ => {}
-                },
-                ServerMessage::Request { method, .. } => {
-                    eprintln!("[server request: {}] (unhandled)", method);
+            Ok(msg) => match msg {
+                ServerMessage::Notification(Notification::AgentMessageDelta(d)) => {
+                    print!("{}", d.delta);
+                }
+                ServerMessage::Notification(Notification::TurnCompleted(_)) => {
+                    println!("\n[turn completed]");
+                    break;
+                }
+                ServerMessage::Notification(Notification::Error(e)) => {
+                    eprintln!("[error] {}", e.error);
+                }
+                ServerMessage::Notification(_) => {}
+                ServerMessage::Request { request, .. } => {
+                    eprintln!("[server request: {}] (unhandled)", request.method());
                 }
             },
             Err(e) => {

--- a/codex-codes/src/client_async.rs
+++ b/codex-codes/src/client_async.rs
@@ -32,10 +32,10 @@
 //!
 //! while let Some(msg) = client.next_message().await? {
 //!     match msg {
-//!         ServerMessage::Notification { method, params } => {
-//!             if method == "turn/completed" { break; }
+//!         ServerMessage::Notification(n) => {
+//!             if let codex_codes::Notification::TurnCompleted(_) = n { break; }
 //!         }
-//!         ServerMessage::Request { id, method, .. } => {
+//!         ServerMessage::Request { id, .. } => {
 //!             client.respond(id, &serde_json::json!({"decision": "accept"})).await?;
 //!         }
 //!     }
@@ -47,10 +47,11 @@ use crate::error::{Error, Result};
 use crate::jsonrpc::{
     JsonRpcError, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, RequestId,
 };
+use crate::messages::{Notification, ServerMessage, ServerRequest};
 use crate::protocol::{
-    ClientInfo, InitializeParams, InitializeResponse, ServerMessage, ThreadArchiveParams,
-    ThreadArchiveResponse, ThreadStartParams, ThreadStartResponse, TurnInterruptParams,
-    TurnInterruptResponse, TurnStartParams, TurnStartResponse,
+    ClientInfo, InitializeParams, InitializeResponse, ThreadArchiveParams, ThreadArchiveResponse,
+    ThreadStartParams, ThreadStartResponse, TurnInterruptParams, TurnInterruptResponse,
+    TurnStartParams, TurnStartResponse,
 };
 use log::{debug, error, warn};
 use serde::de::DeserializeOwned;
@@ -205,16 +206,17 @@ impl AsyncClient {
                 }
                 // Buffer notifications and server requests
                 JsonRpcMessage::Notification(notif) => {
-                    self.buffered.push_back(ServerMessage::Notification {
-                        method: notif.method,
-                        params: notif.params,
-                    });
+                    let typed = Notification::from_envelope(&notif.method, notif.params)
+                        .map_err(Error::Json)?;
+                    self.buffered
+                        .push_back(ServerMessage::Notification(typed));
                 }
                 JsonRpcMessage::Request(req) => {
+                    let typed = ServerRequest::from_envelope(&req.method, req.params)
+                        .map_err(Error::Json)?;
                     self.buffered.push_back(ServerMessage::Request {
                         id: req.id,
-                        method: req.method,
-                        params: req.params,
+                        request: typed,
                     });
                 }
                 // Response/error for a different id — unexpected
@@ -346,16 +348,16 @@ impl AsyncClient {
 
             match msg {
                 JsonRpcMessage::Notification(notif) => {
-                    return Ok(Some(ServerMessage::Notification {
-                        method: notif.method,
-                        params: notif.params,
-                    }));
+                    let typed = Notification::from_envelope(&notif.method, notif.params)
+                        .map_err(Error::Json)?;
+                    return Ok(Some(ServerMessage::Notification(typed)));
                 }
                 JsonRpcMessage::Request(req) => {
+                    let typed = ServerRequest::from_envelope(&req.method, req.params)
+                        .map_err(Error::Json)?;
                     return Ok(Some(ServerMessage::Request {
                         id: req.id,
-                        method: req.method,
-                        params: req.params,
+                        request: typed,
                     }));
                 }
                 // Unexpected responses without a pending request

--- a/codex-codes/src/client_sync.rs
+++ b/codex-codes/src/client_sync.rs
@@ -34,8 +34,8 @@
 //!
 //! for result in client.events() {
 //!     match result? {
-//!         ServerMessage::Notification { method, .. } => {
-//!             if method == "turn/completed" { break; }
+//!         ServerMessage::Notification(n) => {
+//!             if let codex_codes::Notification::TurnCompleted(_) = n { break; }
 //!         }
 //!         _ => {}
 //!     }
@@ -47,10 +47,11 @@ use crate::error::{Error, Result};
 use crate::jsonrpc::{
     JsonRpcError, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, RequestId,
 };
+use crate::messages::{Notification, ServerMessage, ServerRequest};
 use crate::protocol::{
-    ClientInfo, InitializeParams, InitializeResponse, ServerMessage, ThreadArchiveParams,
-    ThreadArchiveResponse, ThreadStartParams, ThreadStartResponse, TurnInterruptParams,
-    TurnInterruptResponse, TurnStartParams, TurnStartResponse,
+    ClientInfo, InitializeParams, InitializeResponse, ThreadArchiveParams, ThreadArchiveResponse,
+    ThreadStartParams, ThreadStartResponse, TurnInterruptParams, TurnInterruptResponse,
+    TurnStartParams, TurnStartResponse,
 };
 use log::{debug, warn};
 use serde::de::DeserializeOwned;
@@ -199,16 +200,17 @@ impl SyncClient {
                     });
                 }
                 JsonRpcMessage::Notification(notif) => {
-                    self.buffered.push_back(ServerMessage::Notification {
-                        method: notif.method,
-                        params: notif.params,
-                    });
+                    let typed = Notification::from_envelope(&notif.method, notif.params)
+                        .map_err(Error::Json)?;
+                    self.buffered
+                        .push_back(ServerMessage::Notification(typed));
                 }
                 JsonRpcMessage::Request(req) => {
+                    let typed = ServerRequest::from_envelope(&req.method, req.params)
+                        .map_err(Error::Json)?;
                     self.buffered.push_back(ServerMessage::Request {
                         id: req.id,
-                        method: req.method,
-                        params: req.params,
+                        request: typed,
                     });
                 }
                 JsonRpcMessage::Response(resp) => {
@@ -317,16 +319,16 @@ impl SyncClient {
 
             match msg {
                 JsonRpcMessage::Notification(notif) => {
-                    return Ok(Some(ServerMessage::Notification {
-                        method: notif.method,
-                        params: notif.params,
-                    }));
+                    let typed = Notification::from_envelope(&notif.method, notif.params)
+                        .map_err(Error::Json)?;
+                    return Ok(Some(ServerMessage::Notification(typed)));
                 }
                 JsonRpcMessage::Request(req) => {
+                    let typed = ServerRequest::from_envelope(&req.method, req.params)
+                        .map_err(Error::Json)?;
                     return Ok(Some(ServerMessage::Request {
                         id: req.id,
-                        method: req.method,
-                        params: req.params,
+                        request: typed,
                     }));
                 }
                 JsonRpcMessage::Response(resp) => {

--- a/codex-codes/src/io/items.rs
+++ b/codex-codes/src/io/items.rs
@@ -30,15 +30,28 @@ pub enum CommandExecutionStatus {
 }
 
 /// A command execution item — a shell command the agent ran.
+///
+/// The exec JSONL protocol uses snake_case (`aggregated_output`, `exit_code`)
+/// while the app-server protocol uses camelCase (`aggregatedOutput`, `exitCode`)
+/// and may emit `null` for missing output. Fields below carry serde aliases so
+/// both formats deserialize cleanly.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CommandExecutionItem {
     pub id: String,
     /// The shell command that was executed.
     pub command: String,
-    /// Combined stdout/stderr output from the command.
-    pub aggregated_output: String,
+    /// Combined stdout/stderr output from the command. `None` while still in
+    /// progress on the app-server protocol; the exec protocol uses an empty
+    /// string for the same state.
+    #[serde(alias = "aggregated_output", default)]
+    pub aggregated_output: Option<String>,
     /// Exit code, if the command has finished.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        alias = "exit_code",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub exit_code: Option<i32>,
     pub status: CommandExecutionStatus,
 }
@@ -120,16 +133,50 @@ pub struct McpToolCallItem {
 }
 
 /// An agent message item containing text output.
+///
+/// `text` may be empty (or absent on the wire) for `item/started` events on
+/// the app-server protocol — codex emits the message envelope before any
+/// tokens have been generated.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentMessageItem {
     pub id: String,
+    #[serde(default)]
     pub text: String,
 }
 
+/// A single content block within a [`UserMessageItem`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserMessageContent {
+    /// Block kind tag (e.g. `"text"`).
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// The text content.
+    #[serde(default)]
+    pub text: String,
+    /// Tokenized/structured representation of the text. Shape varies by
+    /// codex version, so it's preserved as raw JSON.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub text_elements: Vec<Value>,
+}
+
+/// A user message item — the prompt the user sent for the current turn.
+///
+/// Emitted by the app-server as the first item in a turn. The exec JSONL
+/// protocol does not typically emit this item kind.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserMessageItem {
+    pub id: String,
+    pub content: Vec<UserMessageContent>,
+}
+
 /// A reasoning item containing the model's chain-of-thought.
+///
+/// `text` may be empty on `item/started` events; populated by the time
+/// `item/completed` arrives.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReasoningItem {
     pub id: String,
+    #[serde(default)]
     pub text: String,
 }
 
@@ -173,6 +220,9 @@ pub struct TodoListItem {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ThreadItem {
+    /// The user's prompt for the turn (app-server protocol only).
+    #[serde(alias = "userMessage")]
+    UserMessage(UserMessageItem),
     /// Text output from the agent.
     #[serde(alias = "agentMessage")]
     AgentMessage(AgentMessageItem),

--- a/codex-codes/src/lib.rs
+++ b/codex-codes/src/lib.rs
@@ -157,6 +157,7 @@ mod io;
 
 pub mod error;
 pub mod jsonrpc;
+pub mod messages;
 pub mod protocol;
 
 #[cfg(any(feature = "sync-client", feature = "async-client"))]
@@ -204,17 +205,26 @@ pub use jsonrpc::{
 
 // App-server protocol types (always available)
 pub use protocol::{
-    AgentMessageDeltaNotification, ClientInfo, CmdOutputDeltaNotification, CommandApprovalDecision,
-    CommandExecutionApprovalParams, CommandExecutionApprovalResponse, ErrorNotification,
-    FileChangeApprovalDecision, FileChangeApprovalParams, FileChangeApprovalResponse,
-    FileChangeOutputDeltaNotification, InitializeCapabilities, InitializeParams,
-    InitializeResponse, ItemCompletedNotification, ItemStartedNotification,
-    ReasoningDeltaNotification, ServerMessage, ThreadArchiveParams, ThreadArchiveResponse,
-    ThreadInfo, ThreadStartParams, ThreadStartResponse, ThreadStartedNotification, ThreadStatus,
-    ThreadStatusChangedNotification, ThreadTokenUsageUpdatedNotification, TokenUsage, Turn,
-    TurnCompletedNotification, TurnError, TurnInterruptParams, TurnInterruptResponse,
-    TurnStartParams, TurnStartResponse, TurnStartedNotification, TurnStatus, UserInput,
+    AccountRateLimitsUpdatedNotification, AgentMessageDeltaNotification, ClientInfo,
+    CmdOutputDeltaNotification, CommandApprovalDecision, CommandExecutionApprovalParams,
+    CommandExecutionApprovalResponse, ErrorNotification, FileChangeApprovalDecision,
+    FileChangeApprovalParams, FileChangeApprovalResponse, FileChangeOutputDeltaNotification,
+    InitializeCapabilities, InitializeParams, InitializeResponse, ItemCompletedNotification,
+    ItemStartedNotification, McpServerStartupStatusUpdatedNotification, RateLimitWindow,
+    RateLimits, ReasoningDeltaNotification, RemoteControlStatusChangedNotification,
+    ThreadArchiveParams, ThreadArchiveResponse, ThreadInfo, ThreadStartParams, ThreadStartResponse,
+    ThreadStartedNotification, ThreadStatus, ThreadStatusChangedNotification,
+    ThreadTokenUsageUpdatedNotification, TokenCounts, TokenUsage, Turn, TurnCompletedNotification,
+    TurnError, TurnInterruptParams, TurnInterruptResponse, TurnStartParams, TurnStartResponse,
+    TurnStartedNotification, TurnStatus, UserInput,
 };
+
+// Also re-export the `UserMessageItem` and its content block so callers can
+// pattern-match on the new ThreadItem variant added in 0.102.
+pub use io::items::{UserMessageContent, UserMessageItem};
+
+// Typed message dispatch (notifications + server-to-client requests)
+pub use messages::{Notification, ServerMessage, ServerRequest};
 
 // CLI builder (feature-gated)
 #[cfg(any(feature = "sync-client", feature = "async-client"))]

--- a/codex-codes/src/messages.rs
+++ b/codex-codes/src/messages.rs
@@ -1,0 +1,346 @@
+//! Typed dispatch for app-server notifications and server-to-client requests.
+//!
+//! The Codex app-server speaks JSON-RPC where every message carries a
+//! `method` discriminant alongside a free-form `params` blob. This module
+//! lifts that loose envelope into closed enums — [`Notification`] for
+//! server-initiated notifications and [`ServerRequest`] for server-initiated
+//! requests (the approval flow). Each variant wraps a typed param struct
+//! from [`crate::protocol`].
+//!
+//! The pattern mirrors the [`ContentBlock`] dispatch in the sibling
+//! `claude-codes` crate: hand-written [`Serialize`]/[`Deserialize`] impls
+//! inspect the discriminant, route known cases through `serde_json::from_value`
+//! into the typed struct, and route unknown methods into an `Unknown`
+//! variant — preserving the raw payload for forward compatibility with
+//! future codex versions.
+//!
+//! ## Typing contract
+//!
+//! - Unknown methods route to [`Notification::Unknown`] / [`ServerRequest::Unknown`]
+//!   without error. Encountering one in production typically means the
+//!   installed Codex CLI is newer than the bindings.
+//! - Known methods whose payload fails to deserialize **do** cause an error.
+//!   If you see one, the typed binding in [`crate::protocol`] is out of
+//!   sync with the wire format and needs to be updated.
+
+use crate::jsonrpc::RequestId;
+use crate::protocol::{
+    methods, AccountRateLimitsUpdatedNotification, AgentMessageDeltaNotification,
+    CmdOutputDeltaNotification, CommandExecutionApprovalParams, ErrorNotification,
+    FileChangeApprovalParams, FileChangeOutputDeltaNotification, ItemCompletedNotification,
+    ItemStartedNotification, McpServerStartupStatusUpdatedNotification, ReasoningDeltaNotification,
+    RemoteControlStatusChangedNotification, ThreadStartedNotification,
+    ThreadStatusChangedNotification, ThreadTokenUsageUpdatedNotification, TurnCompletedNotification,
+    TurnStartedNotification,
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
+
+/// A server-to-client notification.
+///
+/// Each variant maps to a single `method` string on the wire. The `Unknown`
+/// variant captures methods this crate version doesn't model yet, preserving
+/// the raw payload for inspection.
+#[derive(Debug, Clone)]
+pub enum Notification {
+    /// `thread/started`
+    ThreadStarted(ThreadStartedNotification),
+    /// `thread/status/changed`
+    ThreadStatusChanged(ThreadStatusChangedNotification),
+    /// `thread/tokenUsage/updated`
+    ThreadTokenUsageUpdated(ThreadTokenUsageUpdatedNotification),
+    /// `turn/started`
+    TurnStarted(TurnStartedNotification),
+    /// `turn/completed`
+    TurnCompleted(TurnCompletedNotification),
+    /// `item/started`
+    ItemStarted(ItemStartedNotification),
+    /// `item/completed`
+    ItemCompleted(ItemCompletedNotification),
+    /// `item/agentMessage/delta`
+    AgentMessageDelta(AgentMessageDeltaNotification),
+    /// `item/commandExecution/outputDelta`
+    CmdOutputDelta(CmdOutputDeltaNotification),
+    /// `item/fileChange/outputDelta`
+    FileChangeOutputDelta(FileChangeOutputDeltaNotification),
+    /// `item/reasoning/summaryTextDelta`
+    ReasoningDelta(ReasoningDeltaNotification),
+    /// `error`
+    Error(ErrorNotification),
+    /// `account/rateLimits/updated`
+    AccountRateLimitsUpdated(AccountRateLimitsUpdatedNotification),
+    /// `mcpServer/startupStatus/updated`
+    McpServerStartupStatusUpdated(McpServerStartupStatusUpdatedNotification),
+    /// `remoteControl/status/changed`
+    RemoteControlStatusChanged(RemoteControlStatusChangedNotification),
+    /// A method this crate version does not yet model. The raw params are
+    /// preserved for caller inspection. Encountering this typically means
+    /// the installed codex CLI is newer than the bindings.
+    Unknown {
+        method: String,
+        params: Option<Value>,
+    },
+}
+
+impl Notification {
+    /// Return the wire `method` string for this notification.
+    pub fn method(&self) -> &str {
+        match self {
+            Self::ThreadStarted(_) => methods::THREAD_STARTED,
+            Self::ThreadStatusChanged(_) => methods::THREAD_STATUS_CHANGED,
+            Self::ThreadTokenUsageUpdated(_) => methods::THREAD_TOKEN_USAGE_UPDATED,
+            Self::TurnStarted(_) => methods::TURN_STARTED,
+            Self::TurnCompleted(_) => methods::TURN_COMPLETED,
+            Self::ItemStarted(_) => methods::ITEM_STARTED,
+            Self::ItemCompleted(_) => methods::ITEM_COMPLETED,
+            Self::AgentMessageDelta(_) => methods::AGENT_MESSAGE_DELTA,
+            Self::CmdOutputDelta(_) => methods::CMD_OUTPUT_DELTA,
+            Self::FileChangeOutputDelta(_) => methods::FILE_CHANGE_OUTPUT_DELTA,
+            Self::ReasoningDelta(_) => methods::REASONING_DELTA,
+            Self::Error(_) => methods::ERROR,
+            Self::AccountRateLimitsUpdated(_) => methods::ACCOUNT_RATE_LIMITS_UPDATED,
+            Self::McpServerStartupStatusUpdated(_) => methods::MCP_SERVER_STARTUP_STATUS_UPDATED,
+            Self::RemoteControlStatusChanged(_) => methods::REMOTE_CONTROL_STATUS_CHANGED,
+            Self::Unknown { method, .. } => method,
+        }
+    }
+
+    /// `true` if this notification's method isn't modeled by the crate.
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, Self::Unknown { .. })
+    }
+
+    /// Construct a [`Notification`] from a `method` + `params` envelope.
+    ///
+    /// Returns an error if `method` is recognized but `params` doesn't
+    /// deserialize into the typed struct. Unknown methods route to
+    /// [`Notification::Unknown`] without error.
+    pub fn from_envelope(
+        method: &str,
+        params: Option<Value>,
+    ) -> Result<Self, serde_json::Error> {
+        let params_value = params.clone().unwrap_or(Value::Null);
+        match method {
+            methods::THREAD_STARTED => serde_json::from_value(params_value).map(Self::ThreadStarted),
+            methods::THREAD_STATUS_CHANGED => {
+                serde_json::from_value(params_value).map(Self::ThreadStatusChanged)
+            }
+            methods::THREAD_TOKEN_USAGE_UPDATED => {
+                serde_json::from_value(params_value).map(Self::ThreadTokenUsageUpdated)
+            }
+            methods::TURN_STARTED => serde_json::from_value(params_value).map(Self::TurnStarted),
+            methods::TURN_COMPLETED => {
+                serde_json::from_value(params_value).map(Self::TurnCompleted)
+            }
+            methods::ITEM_STARTED => serde_json::from_value(params_value).map(Self::ItemStarted),
+            methods::ITEM_COMPLETED => {
+                serde_json::from_value(params_value).map(Self::ItemCompleted)
+            }
+            methods::AGENT_MESSAGE_DELTA => {
+                serde_json::from_value(params_value).map(Self::AgentMessageDelta)
+            }
+            methods::CMD_OUTPUT_DELTA => {
+                serde_json::from_value(params_value).map(Self::CmdOutputDelta)
+            }
+            methods::FILE_CHANGE_OUTPUT_DELTA => {
+                serde_json::from_value(params_value).map(Self::FileChangeOutputDelta)
+            }
+            methods::REASONING_DELTA => {
+                serde_json::from_value(params_value).map(Self::ReasoningDelta)
+            }
+            methods::ERROR => serde_json::from_value(params_value).map(Self::Error),
+            methods::ACCOUNT_RATE_LIMITS_UPDATED => {
+                serde_json::from_value(params_value).map(Self::AccountRateLimitsUpdated)
+            }
+            methods::MCP_SERVER_STARTUP_STATUS_UPDATED => {
+                serde_json::from_value(params_value).map(Self::McpServerStartupStatusUpdated)
+            }
+            methods::REMOTE_CONTROL_STATUS_CHANGED => {
+                serde_json::from_value(params_value).map(Self::RemoteControlStatusChanged)
+            }
+            _ => Ok(Self::Unknown {
+                method: method.to_string(),
+                params,
+            }),
+        }
+    }
+
+    /// Decompose this notification back into a `(method, params)` pair.
+    pub fn into_envelope(self) -> Result<(String, Option<Value>), serde_json::Error> {
+        fn pack<T: Serialize>(
+            method: &str,
+            v: &T,
+        ) -> Result<(String, Option<Value>), serde_json::Error> {
+            Ok((method.to_string(), Some(serde_json::to_value(v)?)))
+        }
+        match &self {
+            Self::ThreadStarted(v) => pack(methods::THREAD_STARTED, v),
+            Self::ThreadStatusChanged(v) => pack(methods::THREAD_STATUS_CHANGED, v),
+            Self::ThreadTokenUsageUpdated(v) => pack(methods::THREAD_TOKEN_USAGE_UPDATED, v),
+            Self::TurnStarted(v) => pack(methods::TURN_STARTED, v),
+            Self::TurnCompleted(v) => pack(methods::TURN_COMPLETED, v),
+            Self::ItemStarted(v) => pack(methods::ITEM_STARTED, v),
+            Self::ItemCompleted(v) => pack(methods::ITEM_COMPLETED, v),
+            Self::AgentMessageDelta(v) => pack(methods::AGENT_MESSAGE_DELTA, v),
+            Self::CmdOutputDelta(v) => pack(methods::CMD_OUTPUT_DELTA, v),
+            Self::FileChangeOutputDelta(v) => pack(methods::FILE_CHANGE_OUTPUT_DELTA, v),
+            Self::ReasoningDelta(v) => pack(methods::REASONING_DELTA, v),
+            Self::Error(v) => pack(methods::ERROR, v),
+            Self::AccountRateLimitsUpdated(v) => pack(methods::ACCOUNT_RATE_LIMITS_UPDATED, v),
+            Self::McpServerStartupStatusUpdated(v) => {
+                pack(methods::MCP_SERVER_STARTUP_STATUS_UPDATED, v)
+            }
+            Self::RemoteControlStatusChanged(v) => {
+                pack(methods::REMOTE_CONTROL_STATUS_CHANGED, v)
+            }
+            Self::Unknown { method, params } => Ok((method.clone(), params.clone())),
+        }
+    }
+}
+
+impl Serialize for Notification {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let (method, params) = self
+            .clone()
+            .into_envelope()
+            .map_err(serde::ser::Error::custom)?;
+        let mut env = serde_json::Map::new();
+        env.insert("method".to_string(), Value::String(method));
+        if let Some(p) = params {
+            env.insert("params".to_string(), p);
+        }
+        Value::Object(env).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Notification {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = Value::deserialize(deserializer)?;
+        let method = value
+            .get("method")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| serde::de::Error::missing_field("method"))?
+            .to_string();
+        let params = value.get("params").cloned();
+        Self::from_envelope(&method, params).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A server-to-client request that requires a response (approval flow).
+///
+/// The wire envelope carries an `id` for response correlation; that `id` is
+/// held alongside this enum in [`ServerMessage::Request`] rather than embedded
+/// inside the variant, since responding doesn't depend on which approval-type
+/// was requested.
+#[derive(Debug, Clone)]
+pub enum ServerRequest {
+    /// `item/commandExecution/requestApproval`
+    CmdExecApproval(CommandExecutionApprovalParams),
+    /// `item/fileChange/requestApproval`
+    FileChangeApproval(FileChangeApprovalParams),
+    /// A request method this crate version does not yet model.
+    Unknown {
+        method: String,
+        params: Option<Value>,
+    },
+}
+
+impl ServerRequest {
+    /// Return the wire `method` string for this request.
+    pub fn method(&self) -> &str {
+        match self {
+            Self::CmdExecApproval(_) => methods::CMD_EXEC_APPROVAL,
+            Self::FileChangeApproval(_) => methods::FILE_CHANGE_APPROVAL,
+            Self::Unknown { method, .. } => method,
+        }
+    }
+
+    /// `true` if this request's method isn't modeled by the crate.
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, Self::Unknown { .. })
+    }
+
+    /// Construct a [`ServerRequest`] from a `method` + `params` envelope.
+    pub fn from_envelope(
+        method: &str,
+        params: Option<Value>,
+    ) -> Result<Self, serde_json::Error> {
+        let params_value = params.clone().unwrap_or(Value::Null);
+        match method {
+            methods::CMD_EXEC_APPROVAL => {
+                serde_json::from_value(params_value).map(Self::CmdExecApproval)
+            }
+            methods::FILE_CHANGE_APPROVAL => {
+                serde_json::from_value(params_value).map(Self::FileChangeApproval)
+            }
+            _ => Ok(Self::Unknown {
+                method: method.to_string(),
+                params,
+            }),
+        }
+    }
+}
+
+/// A message coming from the app-server.
+///
+/// Replaces the previous loose `{ method, params }` shape with typed enums.
+/// Match on the outer variant first to distinguish notifications (no response)
+/// from requests (need [`crate::AsyncClient::respond`] /
+/// [`crate::SyncClient::respond`]).
+#[derive(Debug, Clone)]
+pub enum ServerMessage {
+    /// A notification — no response required.
+    Notification(Notification),
+    /// A request — call `respond(id, ...)` on the client with the matching id.
+    Request {
+        id: RequestId,
+        request: ServerRequest,
+    },
+}
+
+impl ServerMessage {
+    /// `true` if this message is an unmodeled method (notification or request).
+    pub fn is_unknown(&self) -> bool {
+        match self {
+            Self::Notification(n) => n.is_unknown(),
+            Self::Request { request, .. } => request.is_unknown(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_notification_unknown_method_routes_to_unknown_variant() {
+        let n = Notification::from_envelope("foo/bar", Some(serde_json::json!({"x": 1})))
+            .expect("unknown methods do not error");
+        match n {
+            Notification::Unknown { method, params } => {
+                assert_eq!(method, "foo/bar");
+                assert_eq!(params, Some(serde_json::json!({"x": 1})));
+            }
+            other => panic!("expected Unknown, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_notification_known_method_with_bad_params_errors() {
+        // thread/started expects a `thread` field — wrong shape should error.
+        let err = Notification::from_envelope("thread/started", Some(serde_json::json!({})));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn test_notification_round_trip_envelope() {
+        let wire = serde_json::json!({
+            "method": "item/agentMessage/delta",
+            "params": {"threadId": "t1", "itemId": "i1", "delta": "hi"},
+        });
+        let n: Notification = serde_json::from_value(wire.clone()).unwrap();
+        assert!(matches!(n, Notification::AgentMessageDelta(_)));
+        let back = serde_json::to_value(&n).unwrap();
+        assert_eq!(back, wire);
+    }
+}

--- a/codex-codes/src/protocol.rs
+++ b/codex-codes/src/protocol.rs
@@ -18,22 +18,19 @@
 //!
 //! # Parsing notifications
 //!
-//! ```
-//! use codex_codes::protocol::{methods, TurnCompletedNotification};
-//! use serde_json::Value;
+//! Prefer the typed dispatch in [`crate::messages`] over manual `method` checks:
 //!
-//! fn handle_notification(method: &str, params: Option<Value>) {
-//!     if method == methods::TURN_COMPLETED {
-//!         if let Some(p) = params {
-//!             let notif: TurnCompletedNotification = serde_json::from_value(p).unwrap();
-//!             println!("Turn {} completed", notif.turn_id);
-//!         }
+//! ```
+//! use codex_codes::{Notification, ServerMessage};
+//!
+//! fn handle(msg: ServerMessage) {
+//!     if let ServerMessage::Notification(Notification::TurnCompleted(c)) = msg {
+//!         println!("Turn {} on thread {} completed", c.turn.id, c.thread_id);
 //!     }
 //! }
 //! ```
 
 use crate::io::items::ThreadItem;
-use crate::jsonrpc::RequestId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -267,19 +264,42 @@ pub struct Turn {
 // Token usage
 // ---------------------------------------------------------------------------
 
-/// Cumulative token usage for a thread.
-///
-/// Sent via [`ThreadTokenUsageUpdatedNotification`] after each turn.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// A snapshot of token counts within a single turn or aggregated across a
+/// thread. Sub-field of [`TokenUsage`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct TokenUsage {
-    /// Total input tokens consumed.
+pub struct TokenCounts {
+    /// Input tokens consumed.
+    #[serde(default)]
     pub input_tokens: u64,
-    /// Total output tokens generated.
+    /// Output tokens generated.
+    #[serde(default)]
     pub output_tokens: u64,
     /// Input tokens served from cache.
     #[serde(default)]
     pub cached_input_tokens: u64,
+    /// Output tokens spent on chain-of-thought reasoning (model-dependent).
+    #[serde(default)]
+    pub reasoning_output_tokens: u64,
+    /// Sum total — may be redundant with the other counts.
+    #[serde(default)]
+    pub total_tokens: u64,
+}
+
+/// Cumulative token usage for a thread.
+///
+/// Sent via [`ThreadTokenUsageUpdatedNotification`] after each turn. Carries
+/// per-turn (`last`) and lifetime (`total`) counts plus the model's context
+/// window for client-side budget tracking.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenUsage {
+    /// Counts for the most recently completed turn.
+    pub last: TokenCounts,
+    /// Cumulative counts for the entire thread.
+    pub total: TokenCounts,
+    /// The model's maximum context window in tokens.
+    pub model_context_window: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -287,15 +307,23 @@ pub struct TokenUsage {
 // ---------------------------------------------------------------------------
 
 /// Status of a thread, sent via [`ThreadStatusChangedNotification`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+///
+/// Wire format is internally tagged on `"type"`, with the `Active` variant
+/// carrying an `activeFlags` array of in-progress markers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
 pub enum ThreadStatus {
     /// Thread is not yet loaded.
     NotLoaded,
     /// Thread is idle (no active turn).
     Idle,
     /// Thread has an active turn being processed.
-    Active,
+    Active {
+        /// Tags identifying what is in flight (e.g. running tools).
+        /// Shape is codex-version-dependent; preserved as raw JSON.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        active_flags: Vec<Value>,
+    },
     /// Thread encountered an unrecoverable error.
     SystemError,
 }
@@ -305,10 +333,13 @@ pub enum ThreadStatus {
 // ---------------------------------------------------------------------------
 
 /// `thread/started` notification.
+///
+/// Sent once when a thread is created. Carries the full [`ThreadInfo`] for
+/// the new thread.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ThreadStartedNotification {
-    pub thread_id: String,
+    pub thread: ThreadInfo,
 }
 
 /// `thread/status/changed` notification.
@@ -320,19 +351,22 @@ pub struct ThreadStatusChangedNotification {
 }
 
 /// `turn/started` notification.
+///
+/// Carries the freshly-created [`Turn`] (with `status: in_progress`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TurnStartedNotification {
     pub thread_id: String,
-    pub turn_id: String,
+    pub turn: Turn,
 }
 
 /// `turn/completed` notification.
+///
+/// Carries the final [`Turn`] state with its full item list.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TurnCompletedNotification {
     pub thread_id: String,
-    pub turn_id: String,
     pub turn: Turn,
 }
 
@@ -342,6 +376,10 @@ pub struct TurnCompletedNotification {
 pub struct ItemStartedNotification {
     pub thread_id: String,
     pub turn_id: String,
+    /// Server-side timestamp (milliseconds since Unix epoch) when the item
+    /// began. Optional — older codex builds omit it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at_ms: Option<i64>,
     pub item: ThreadItem,
 }
 
@@ -351,6 +389,10 @@ pub struct ItemStartedNotification {
 pub struct ItemCompletedNotification {
     pub thread_id: String,
     pub turn_id: String,
+    /// Server-side timestamp (milliseconds since Unix epoch) when the item
+    /// finished. Optional — older codex builds omit it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at_ms: Option<i64>,
     pub item: ThreadItem,
 }
 
@@ -404,11 +446,90 @@ pub struct ErrorNotification {
 }
 
 /// `thread/tokenUsage/updated` notification.
+///
+/// Emitted after each turn with cumulative and per-turn token counts.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ThreadTokenUsageUpdatedNotification {
     pub thread_id: String,
-    pub usage: TokenUsage,
+    /// The turn that triggered this usage update. May be absent for
+    /// thread-level updates that aren't tied to a specific turn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    pub token_usage: TokenUsage,
+}
+
+/// A rate-limit window descriptor used inside [`RateLimits`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RateLimitWindow {
+    /// Unix timestamp (seconds) at which this rate-limit window resets.
+    pub resets_at: i64,
+    /// Percentage of the window already consumed (0-100).
+    pub used_percent: i32,
+    /// Length of the rate-limit window, in minutes.
+    pub window_duration_mins: i64,
+}
+
+/// Rate-limit envelope sent in [`AccountRateLimitsUpdatedNotification`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RateLimits {
+    /// Credit balance, if applicable for this plan. Shape is plan-dependent
+    /// so the payload is preserved as raw JSON.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credits: Option<Value>,
+    /// Stable machine identifier for the limit (e.g. `"codex"`).
+    pub limit_id: String,
+    /// Human-readable label, if the server provides one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit_name: Option<String>,
+    /// Plan tier (e.g. `"free"`, `"plus"`, `"team"`).
+    pub plan_type: String,
+    /// Primary (short-term) rate-limit window, if active.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary: Option<RateLimitWindow>,
+    /// Secondary (longer-term) rate-limit window, if active.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secondary: Option<RateLimitWindow>,
+    /// Which window (if any) the account has already hit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rate_limit_reached_type: Option<String>,
+}
+
+/// `account/rateLimits/updated` notification.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountRateLimitsUpdatedNotification {
+    pub rate_limits: RateLimits,
+}
+
+/// `mcpServer/startupStatus/updated` notification.
+///
+/// Emitted by the app-server as each managed MCP server transitions through
+/// its startup lifecycle (e.g. `starting` → `ready` or `starting` → `failed`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpServerStartupStatusUpdatedNotification {
+    /// MCP server identifier.
+    pub name: String,
+    /// Current lifecycle status string (e.g. `"starting"`, `"ready"`,
+    /// `"failed"`). Kept as `String` so new status values don't break parsing.
+    pub status: String,
+    /// Error message if startup failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// `remoteControl/status/changed` notification.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteControlStatusChangedNotification {
+    /// Status string (e.g. `"disabled"`, `"enabled"`).
+    pub status: String,
+    /// Connected environment id, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment_id: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -503,37 +624,9 @@ pub struct FileChangeApprovalResponse {
     pub decision: FileChangeApprovalDecision,
 }
 
-// ---------------------------------------------------------------------------
-// Server message (what the client receives)
-// ---------------------------------------------------------------------------
-
-/// An incoming message from the app-server that the client should handle.
-///
-/// This is what [`AsyncClient::next_message`](crate::AsyncClient::next_message) and
-/// [`SyncClient::next_message`](crate::SyncClient::next_message) return.
-///
-/// # Handling
-///
-/// - **Notifications** are informational — no response is needed. Match on the `method`
-///   field and deserialize `params` into the appropriate notification type.
-/// - **Requests** require a response via `client.respond(id, &result)`. Currently
-///   used for approval flows (`item/commandExecution/requestApproval` and
-///   `item/fileChange/requestApproval`).
-#[derive(Debug, Clone)]
-pub enum ServerMessage {
-    /// A notification (no response needed). Deserialize `params` based on `method`.
-    Notification {
-        method: String,
-        params: Option<Value>,
-    },
-    /// A request from the server that needs a response (e.g., approval flow).
-    /// Use the client's `respond()` method with the `id`.
-    Request {
-        id: RequestId,
-        method: String,
-        params: Option<Value>,
-    },
-}
+// The [`ServerMessage`] enum that clients return now lives in
+// [`crate::messages`] alongside the typed [`crate::Notification`] and
+// [`crate::ServerRequest`] dispatch enums.
 
 // ---------------------------------------------------------------------------
 // Method name constants
@@ -566,6 +659,9 @@ pub mod methods {
     pub const FILE_CHANGE_OUTPUT_DELTA: &str = "item/fileChange/outputDelta";
     pub const REASONING_DELTA: &str = "item/reasoning/summaryTextDelta";
     pub const ERROR: &str = "error";
+    pub const ACCOUNT_RATE_LIMITS_UPDATED: &str = "account/rateLimits/updated";
+    pub const MCP_SERVER_STARTUP_STATUS_UPDATED: &str = "mcpServer/startupStatus/updated";
+    pub const REMOTE_CONTROL_STATUS_CHANGED: &str = "remoteControl/status/changed";
 
     // Server → client requests (approval)
     pub const CMD_EXEC_APPROVAL: &str = "item/commandExecution/requestApproval";
@@ -726,18 +822,34 @@ mod tests {
     }
 
     #[test]
-    fn test_thread_status() {
-        let json = r#""idle""#;
+    fn test_thread_status_idle() {
+        let json = r#"{"type":"idle"}"#;
         let status: ThreadStatus = serde_json::from_str(json).unwrap();
-        assert_eq!(status, ThreadStatus::Idle);
+        assert!(matches!(status, ThreadStatus::Idle));
+    }
+
+    #[test]
+    fn test_thread_status_active_with_flags() {
+        let json = r#"{"type":"active","activeFlags":[]}"#;
+        let status: ThreadStatus = serde_json::from_str(json).unwrap();
+        match status {
+            ThreadStatus::Active { active_flags } => assert!(active_flags.is_empty()),
+            other => panic!("expected Active, got {:?}", other),
+        }
     }
 
     #[test]
     fn test_token_usage() {
-        let json = r#"{"inputTokens":100,"outputTokens":200,"cachedInputTokens":50}"#;
+        let json = r#"{
+            "last":{"inputTokens":100,"outputTokens":200,"cachedInputTokens":50,"reasoningOutputTokens":0,"totalTokens":300},
+            "total":{"inputTokens":1000,"outputTokens":2000,"cachedInputTokens":500,"reasoningOutputTokens":10,"totalTokens":3000},
+            "modelContextWindow":200000
+        }"#;
         let usage: TokenUsage = serde_json::from_str(json).unwrap();
-        assert_eq!(usage.input_tokens, 100);
-        assert_eq!(usage.output_tokens, 200);
-        assert_eq!(usage.cached_input_tokens, 50);
+        assert_eq!(usage.last.input_tokens, 100);
+        assert_eq!(usage.last.output_tokens, 200);
+        assert_eq!(usage.last.cached_input_tokens, 50);
+        assert_eq!(usage.total.input_tokens, 1000);
+        assert_eq!(usage.model_context_window, 200000);
     }
 }

--- a/codex-codes/tests/integration_tests.rs
+++ b/codex-codes/tests/integration_tests.rs
@@ -128,12 +128,16 @@ fn test_list_files_command_lifecycle() {
     // Started has in_progress status, no exit code, empty output
     assert_eq!(started.status, CommandExecutionStatus::InProgress);
     assert_eq!(started.exit_code, None);
-    assert!(started.aggregated_output.is_empty());
+    assert!(started.aggregated_output.as_deref().unwrap_or("").is_empty());
 
     // Completed has exit code 0, non-empty output
     assert_eq!(completed.status, CommandExecutionStatus::Completed);
     assert_eq!(completed.exit_code, Some(0));
-    assert!(!completed.aggregated_output.is_empty());
+    assert!(!completed
+        .aggregated_output
+        .as_deref()
+        .unwrap_or("")
+        .is_empty());
     assert!(completed.command.contains("ls"));
 }
 
@@ -158,7 +162,7 @@ fn test_file_create_command_output() {
         .expect("Should have a completed command");
 
     assert_eq!(cmd.exit_code, Some(0));
-    assert_eq!(cmd.aggregated_output, "hello from codex");
+    assert_eq!(cmd.aggregated_output.as_deref(), Some("hello from codex"));
 }
 
 // ── failed_command: non-zero exit code ──────────────────────────────
@@ -194,7 +198,11 @@ fn test_failed_command_status_and_exit_code() {
 
     assert_eq!(completed.status, CommandExecutionStatus::Failed);
     assert_eq!(completed.exit_code, Some(42));
-    assert!(completed.aggregated_output.is_empty());
+    assert!(completed
+        .aggregated_output
+        .as_deref()
+        .unwrap_or("")
+        .is_empty());
 }
 
 // ── file_change: patch-based file modification ──────────────────────
@@ -237,9 +245,11 @@ fn test_file_change_also_has_command_verification() {
 
     assert!(!cmds.is_empty());
     assert!(cmds.iter().any(|c| c.command.contains("cat")));
-    assert!(cmds
-        .iter()
-        .any(|c| c.aggregated_output.contains("new content")));
+    assert!(cmds.iter().any(|c| c
+        .aggregated_output
+        .as_deref()
+        .unwrap_or("")
+        .contains("new content")));
 }
 
 // ── multi_command: multiple sequential commands ─────────────────────
@@ -276,7 +286,10 @@ fn test_multi_command_three_commands_executed() {
         assert_eq!(cmd.exit_code, Some(0));
         assert_eq!(cmd.status, CommandExecutionStatus::Completed);
         assert!(
-            cmd.aggregated_output.contains(&step),
+            cmd.aggregated_output
+                .as_deref()
+                .unwrap_or("")
+                .contains(&step),
             "Output of command {} should contain '{}'",
             i,
             step
@@ -388,6 +401,7 @@ fn test_all_item_ids_are_sequential_within_capture() {
         let ids: Vec<String> = completed_items(&events)
             .into_iter()
             .map(|item| match item {
+                ThreadItem::UserMessage(u) => u.id.clone(),
                 ThreadItem::AgentMessage(m) => m.id.clone(),
                 ThreadItem::Reasoning(r) => r.id.clone(),
                 ThreadItem::CommandExecution(c) => c.id.clone(),

--- a/codex-codes/tests/live_client_tests.rs
+++ b/codex-codes/tests/live_client_tests.rs
@@ -7,10 +7,9 @@
 
 #![cfg(feature = "integration-tests")]
 
-use codex_codes::protocol::methods;
 use codex_codes::{
-    AsyncClient, ClientInfo, InitializeCapabilities, InitializeParams, ServerMessage, SyncClient,
-    ThreadStartParams, TurnStartParams, UserInput,
+    AsyncClient, ClientInfo, InitializeCapabilities, InitializeParams, Notification, ServerMessage,
+    SyncClient, ThreadStartParams, TurnStartParams, UserInput,
 };
 
 // ── Version check ───────────────────────────────────────────────────
@@ -76,26 +75,21 @@ async fn test_async_client_basic_turn() {
     while let Some(msg) = client.next_message().await.expect("Failed to read message") {
         message_count += 1;
 
-        match &msg {
-            ServerMessage::Notification { method, params } => {
-                if method == methods::AGENT_MESSAGE_DELTA {
-                    if let Some(params) = params {
-                        if let Some(delta) = params.get("delta").and_then(|d| d.as_str()) {
-                            if delta.contains('4') {
-                                found_answer = true;
-                            }
-                        }
-                    }
-                }
-                if method == methods::TURN_COMPLETED {
-                    turn_completed = true;
-                    break;
+        match msg {
+            ServerMessage::Notification(Notification::AgentMessageDelta(d)) => {
+                if d.delta.contains('4') {
+                    found_answer = true;
                 }
             }
+            ServerMessage::Notification(Notification::TurnCompleted(_)) => {
+                turn_completed = true;
+                break;
+            }
+            ServerMessage::Notification(_) => {}
             ServerMessage::Request { id, .. } => {
                 // Auto-accept any approval requests
                 client
-                    .respond(id.clone(), &serde_json::json!({"decision": "accept"}))
+                    .respond(id, &serde_json::json!({"decision": "accept"}))
                     .await
                     .expect("Failed to respond");
             }
@@ -199,23 +193,17 @@ fn test_sync_client_basic_turn() {
         let msg = result.expect("Failed to read message");
         message_count += 1;
 
-        match &msg {
-            ServerMessage::Notification { method, params } => {
-                if method == methods::AGENT_MESSAGE_DELTA {
-                    if let Some(params) = params {
-                        if let Some(delta) = params.get("delta").and_then(|d| d.as_str()) {
-                            if delta.contains('4') {
-                                found_answer = true;
-                            }
-                        }
-                    }
-                }
-                if method == methods::TURN_COMPLETED {
-                    turn_completed = true;
-                    break;
+        match msg {
+            ServerMessage::Notification(Notification::AgentMessageDelta(d)) => {
+                if d.delta.contains('4') {
+                    found_answer = true;
                 }
             }
-            ServerMessage::Request { .. } => {}
+            ServerMessage::Notification(Notification::TurnCompleted(_)) => {
+                turn_completed = true;
+                break;
+            }
+            ServerMessage::Notification(_) | ServerMessage::Request { .. } => {}
         }
 
         if message_count > 100 {
@@ -258,16 +246,15 @@ async fn test_async_client_multi_turn() {
     let mut message_count = 0;
     while let Some(msg) = client.next_message().await.expect("read") {
         message_count += 1;
-        if let ServerMessage::Notification { method, .. } = &msg {
-            if method == methods::TURN_COMPLETED {
-                break;
+        match msg {
+            ServerMessage::Notification(Notification::TurnCompleted(_)) => break,
+            ServerMessage::Notification(_) => {}
+            ServerMessage::Request { id, .. } => {
+                client
+                    .respond(id, &serde_json::json!({"decision": "accept"}))
+                    .await
+                    .ok();
             }
-        }
-        if let ServerMessage::Request { id, .. } = msg {
-            client
-                .respond(id, &serde_json::json!({"decision": "accept"}))
-                .await
-                .ok();
         }
         if message_count > 100 {
             break;
@@ -293,24 +280,17 @@ async fn test_async_client_multi_turn() {
     let mut message_count = 0;
     while let Some(msg) = client.next_message().await.expect("read") {
         message_count += 1;
-        match &msg {
-            ServerMessage::Notification { method, params } => {
-                if method == methods::AGENT_MESSAGE_DELTA {
-                    if let Some(params) = params {
-                        if let Some(delta) = params.get("delta").and_then(|d| d.as_str()) {
-                            if delta.contains("42") {
-                                found_42 = true;
-                            }
-                        }
-                    }
-                }
-                if method == methods::TURN_COMPLETED {
-                    break;
+        match msg {
+            ServerMessage::Notification(Notification::AgentMessageDelta(d)) => {
+                if d.delta.contains("42") {
+                    found_42 = true;
                 }
             }
+            ServerMessage::Notification(Notification::TurnCompleted(_)) => break,
+            ServerMessage::Notification(_) => {}
             ServerMessage::Request { id, .. } => {
                 client
-                    .respond(id.clone(), &serde_json::json!({"decision": "accept"}))
+                    .respond(id, &serde_json::json!({"decision": "accept"}))
                     .await
                     .ok();
             }
@@ -360,13 +340,14 @@ async fn test_async_client_event_stream() {
         let msg = result.expect("Failed to read event");
         message_count += 1;
 
-        if let ServerMessage::Notification { method, .. } = &msg {
-            if method == methods::TURN_STARTED {
-                got_turn_started = true;
-            }
-            if method == methods::TURN_COMPLETED {
-                got_turn_completed = true;
-                break;
+        if let ServerMessage::Notification(n) = &msg {
+            match n {
+                Notification::TurnStarted(_) => got_turn_started = true,
+                Notification::TurnCompleted(_) => {
+                    got_turn_completed = true;
+                    break;
+                }
+                _ => {}
             }
         }
 
@@ -377,4 +358,113 @@ async fn test_async_client_event_stream() {
 
     assert!(got_turn_started, "Should have received turn/started");
     assert!(got_turn_completed, "Should have received turn/completed");
+}
+
+// ── Strict typed-message audit ──────────────────────────────────────
+//
+// Runs a turn that exercises a command-execution item plus the usual thread
+// and turn lifecycle, then asserts that **every** notification and server
+// request received deserializes into its typed variant — i.e. `Unknown` must
+// not appear. The dispatch in [`codex_codes::messages`] is strict on known
+// methods (deserialization failure surfaces as a client error) and tolerant
+// on unknown methods (routes to `Unknown` without error); this test catches
+// both regressions: a known method whose payload no longer fits the typed
+// struct fails the client call before we get here, and a brand-new method
+// that we haven't modeled fails the assertion below.
+#[tokio::test]
+async fn test_typed_message_audit_strict() {
+    use std::collections::BTreeMap;
+
+    let mut client = AsyncClient::start()
+        .await
+        .expect("Failed to start app-server");
+
+    let thread = client
+        .thread_start(&ThreadStartParams::default())
+        .await
+        .expect("Failed to start thread");
+
+    client
+        .turn_start(&TurnStartParams {
+            thread_id: thread.thread_id().to_string(),
+            input: vec![UserInput::Text {
+                text: "Run `ls` in the current directory, then briefly describe what you saw."
+                    .to_string(),
+            }],
+            model: None,
+            reasoning_effort: None,
+            sandbox_policy: None,
+        })
+        .await
+        .expect("Failed to start turn");
+
+    let mut typed_counts: BTreeMap<&'static str, u32> = BTreeMap::new();
+    let mut unknown_methods: BTreeMap<String, u32> = BTreeMap::new();
+    let mut message_count = 0;
+
+    while let Some(msg) = client.next_message().await.expect("read") {
+        message_count += 1;
+        match msg {
+            ServerMessage::Notification(n) => {
+                let variant = match &n {
+                    Notification::ThreadStarted(_) => "ThreadStarted",
+                    Notification::ThreadStatusChanged(_) => "ThreadStatusChanged",
+                    Notification::ThreadTokenUsageUpdated(_) => "ThreadTokenUsageUpdated",
+                    Notification::TurnStarted(_) => "TurnStarted",
+                    Notification::TurnCompleted(_) => "TurnCompleted",
+                    Notification::ItemStarted(_) => "ItemStarted",
+                    Notification::ItemCompleted(_) => "ItemCompleted",
+                    Notification::AgentMessageDelta(_) => "AgentMessageDelta",
+                    Notification::CmdOutputDelta(_) => "CmdOutputDelta",
+                    Notification::FileChangeOutputDelta(_) => "FileChangeOutputDelta",
+                    Notification::ReasoningDelta(_) => "ReasoningDelta",
+                    Notification::Error(_) => "Error",
+                    Notification::AccountRateLimitsUpdated(_) => "AccountRateLimitsUpdated",
+                    Notification::McpServerStartupStatusUpdated(_) => {
+                        "McpServerStartupStatusUpdated"
+                    }
+                    Notification::RemoteControlStatusChanged(_) => "RemoteControlStatusChanged",
+                    Notification::Unknown { method, .. } => {
+                        *unknown_methods.entry(method.clone()).or_insert(0) += 1;
+                        continue;
+                    }
+                };
+                *typed_counts.entry(variant).or_insert(0) += 1;
+                if matches!(&n, Notification::TurnCompleted(_)) {
+                    break;
+                }
+            }
+            ServerMessage::Request { id, request } => {
+                if request.is_unknown() {
+                    unknown_methods
+                        .entry(request.method().to_string())
+                        .and_modify(|c| *c += 1)
+                        .or_insert(1);
+                }
+                client
+                    .respond(id, &serde_json::json!({"decision": "accept"}))
+                    .await
+                    .expect("respond");
+            }
+        }
+
+        if message_count > 500 {
+            break;
+        }
+    }
+
+    eprintln!("\n── Typed message audit ──────────────────────────────────");
+    eprintln!("Typed variants seen ({} kinds):", typed_counts.len());
+    for (variant, n) in &typed_counts {
+        eprintln!("  {:4}× Notification::{}", n, variant);
+    }
+    eprintln!("─────────────────────────────────────────────────────────\n");
+
+    assert!(
+        unknown_methods.is_empty(),
+        "Wire methods with no typed binding (audit must be empty): {:?}",
+        unknown_methods
+    );
+
+    client.shutdown().await.expect("shutdown");
 }


### PR DESCRIPTION
> Stacked on #126 (stderr drain) — base will retarget to main automatically when #126 merges.

## Summary

- Replaces \`ServerMessage\`'s loose \`{ method, params: Option<Value> }\` shape with closed \`Notification\` and \`ServerRequest\` enums in a new \`messages\` module, mirroring the \`ContentBlock\` dispatch pattern from \`claude-codes\`. Hand-written Serialize/Deserialize routes known methods through typed structs and routes unknown methods to \`Unknown { method, params }\` — known-method deserialization failures are loud (the typing contract), unknown methods are tolerated.
- Adds \`test_typed_message_audit_strict\` that runs a real turn and asserts every observed notification/request resolves to a typed variant (no \`Unknown\`). Catches both directions of drift: a known method whose payload changes (test fails because the client errors out), and a new method on the wire we haven't modeled (test fails the \`Unknown\` assertion).
- The audit run uncovered ~6 real wire/struct mismatches that were silently masked by the raw fallback before. All fixed (see Changed/Fixed below).

## Wire/struct bugs found and fixed

- \`ThreadStartedNotification\`: was \`{ thread_id: String }\`; wire is \`{ thread: ThreadInfo }\`
- \`Turn{Started,Completed}Notification\`: dropped spurious top-level \`turn_id\`; carries \`{ thread_id, turn: Turn }\`
- \`ThreadStatus\`: was bare string enum; wire is internally-tagged (\`{"type":"idle"}\`, \`{"type":"active","activeFlags":[]}\`)
- \`ThreadTokenUsageUpdatedNotification\`: renamed \`usage\` → \`token_usage\`, added \`turn_id\`; \`TokenUsage\` restructured to \`{last, total, modelContextWindow}\` over a new \`TokenCounts\` struct
- \`Item{Started,Completed}Notification\`: added \`{started,completed}_at_ms\`
- \`CommandExecutionItem\`: added \`rename_all = "camelCase"\` with snake_case aliases for exec-format compat; \`aggregated_output\` becomes \`Option<String>\` (wire sends \`null\` while in-progress)
- \`ThreadItem\`: added \`UserMessage\` variant + \`UserMessageItem\` struct (app-server emits this at turn start)
- \`AgentMessage\` / \`Reasoning\` items: \`text\` defaults to \`""\` (item/started arrives before tokens are generated)

## Added typed bindings for three previously-untyped wire methods

- \`account/rateLimits/updated\` → \`AccountRateLimitsUpdatedNotification\` (+ \`RateLimits\`, \`RateLimitWindow\`)
- \`mcpServer/startupStatus/updated\` → \`McpServerStartupStatusUpdatedNotification\`
- \`remoteControl/status/changed\` → \`RemoteControlStatusChangedNotification\`

## Breaking changes

Bumps version to **0.102.0**. See \`CHANGELOG.md\` for the full migration notes. The shape of every \`ServerMessage\` match in caller code needs updating; in-tree examples and tests are all updated as a reference.

## Test plan

- [x] \`cargo test -p codex-codes\` — 17 offline + 3 new \`messages.rs\` unit tests pass.
- [x] \`cargo test -p codex-codes --features integration-tests --test live_client_tests -- --test-threads=2\` — 9/9 live tests pass in ~30s (was 8/9 with the deferred audit test failing in the previous attempt). Audit confirms **11 typed variants observed, 0 \`Unknown\`** on the wire across the test turn.
- [x] 3 consecutive runs of the live suite all pass — no flakes after relaxing \`AgentMessageItem.text\` to default-empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)