### PR TITLE
codex-codes: carry raw frame on parse failures (closes #128)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "env_logger",
  "log",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.140` is tested against Claude CLI `2.1.140`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.128.0`, tested against Codex CLI `0.130.0`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.128.1`, tested against Codex CLI `0.130.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.
 

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.128.1] - 2026-05-15
+
+### Added
+
+- **`ParseError` struct** — Carries `raw_line`, `raw_json`, `error_message`, and an optional `method` for parsing failures, mirroring [`claude_codes::ParseError`](https://docs.rs/claude-codes/latest/claude_codes/struct.ParseError.html). Two constructors:
+  - `ParseError::from_line(line, error)` — for bare-JSON / envelope-shape failures; populates `raw_json` if the line was valid JSON.
+  - `ParseError::from_envelope(method, params, error)` — for typed-decode failures whose envelope parsed but whose `params` did not match; preserves the JSON-RPC `method` and `params`, and reconstructs a wire-equivalent `raw_line` for bug reports.
+- **Regression tests in `tests/integration_tests.rs`** — three new tests that pin the exact code path used by `next_message`, including one reproducing the `missing field "callId"` failure mode from issue #128.
+
+### Changed
+
+- **`Error::Deserialization`** is now `Error::Deserialization(ParseError)` (was `Error::Deserialization(String)`). Code that matched the previous string payload should read `pe.error_message` / `pe.raw_line` / `pe.method` instead. Shipped as a patch — pre-1.0 crate, only this workspace's `cc-proxy` is a known downstream consumer.
+- **`AsyncClient::next_message` / `SyncClient::next_message`** — On typed-decode failures (`Notification::from_envelope` / `ServerRequest::from_envelope`), the error now carries the original `method` and `params` via `Error::Deserialization(ParseError)` instead of dropping them in an opaque `Error::Json(serde_json::Error)`. Consumers can render the offending frame for bug reports without snooping `DEBUG`-level tracing for the raw line (fixes #128).
+
 ## [0.128.0] - 2026-05-14
 
 Version jumps from 0.101.x into the 0.1xx range that tracks the Codex CLI it

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.128.0"
+version = "0.128.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/src/client_async.rs
+++ b/codex-codes/src/client_async.rs
@@ -43,7 +43,7 @@
 //! ```
 
 use crate::cli::AppServerBuilder;
-use crate::error::{Error, Result};
+use crate::error::{Error, ParseError, Result};
 use crate::jsonrpc::{
     JsonRpcError, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, RequestId,
 };
@@ -347,17 +347,20 @@ impl AsyncClient {
 
             match msg {
                 JsonRpcMessage::Notification(notif) => {
-                    let typed = Notification::from_envelope(&notif.method, notif.params)
-                        .map_err(Error::Json)?;
+                    let JsonRpcNotification { method, params } = notif;
+                    let typed =
+                        Notification::from_envelope(&method, params.clone()).map_err(|e| {
+                            Error::Deserialization(ParseError::from_envelope(method, params, e))
+                        })?;
                     return Ok(Some(ServerMessage::Notification(typed)));
                 }
                 JsonRpcMessage::Request(req) => {
-                    let typed = ServerRequest::from_envelope(&req.method, req.params)
-                        .map_err(Error::Json)?;
-                    return Ok(Some(ServerMessage::Request {
-                        id: req.id,
-                        request: typed,
-                    }));
+                    let JsonRpcRequest { id, method, params } = req;
+                    let typed =
+                        ServerRequest::from_envelope(&method, params.clone()).map_err(|e| {
+                            Error::Deserialization(ParseError::from_envelope(method, params, e))
+                        })?;
+                    return Ok(Some(ServerMessage::Request { id, request: typed }));
                 }
                 // Unexpected responses without a pending request
                 JsonRpcMessage::Response(resp) => {
@@ -459,7 +462,7 @@ impl AsyncClient {
                     );
                     warn!("[CLIENT] Parse error: {}", e);
                     warn!("[CLIENT] Raw: {}", trimmed);
-                    return Err(Error::Deserialization(format!("{} (raw: {})", e, trimmed)));
+                    return Err(Error::Deserialization(ParseError::from_line(trimmed, e)));
                 }
             }
         }

--- a/codex-codes/src/client_sync.rs
+++ b/codex-codes/src/client_sync.rs
@@ -43,7 +43,7 @@
 //! ```
 
 use crate::cli::AppServerBuilder;
-use crate::error::{Error, Result};
+use crate::error::{Error, ParseError, Result};
 use crate::jsonrpc::{
     JsonRpcError, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, RequestId,
 };
@@ -318,17 +318,20 @@ impl SyncClient {
 
             match msg {
                 JsonRpcMessage::Notification(notif) => {
-                    let typed = Notification::from_envelope(&notif.method, notif.params)
-                        .map_err(Error::Json)?;
+                    let JsonRpcNotification { method, params } = notif;
+                    let typed =
+                        Notification::from_envelope(&method, params.clone()).map_err(|e| {
+                            Error::Deserialization(ParseError::from_envelope(method, params, e))
+                        })?;
                     return Ok(Some(ServerMessage::Notification(typed)));
                 }
                 JsonRpcMessage::Request(req) => {
-                    let typed = ServerRequest::from_envelope(&req.method, req.params)
-                        .map_err(Error::Json)?;
-                    return Ok(Some(ServerMessage::Request {
-                        id: req.id,
-                        request: typed,
-                    }));
+                    let JsonRpcRequest { id, method, params } = req;
+                    let typed =
+                        ServerRequest::from_envelope(&method, params.clone()).map_err(|e| {
+                            Error::Deserialization(ParseError::from_envelope(method, params, e))
+                        })?;
+                    return Ok(Some(ServerMessage::Request { id, request: typed }));
                 }
                 JsonRpcMessage::Response(resp) => {
                     warn!(
@@ -419,10 +422,7 @@ impl SyncClient {
                             );
                             warn!("[CLIENT] Parse error: {}", e);
                             warn!("[CLIENT] Raw: {}", trimmed);
-                            return Err(Error::Deserialization(format!(
-                                "{} (raw: {})",
-                                e, trimmed
-                            )));
+                            return Err(Error::Deserialization(ParseError::from_line(trimmed, e)));
                         }
                     }
                 }

--- a/codex-codes/src/error.rs
+++ b/codex-codes/src/error.rs
@@ -4,7 +4,106 @@
 //! error type. The variants cover JSON serialization, I/O, protocol-level
 //! issues, and JSON-RPC errors from the app-server.
 
+use serde_json::Value;
 use thiserror::Error;
+
+/// Error type for parsing failures that preserves the raw frame data.
+///
+/// Returned inside [`Error::Deserialization`] when a message from the
+/// app-server fails to deserialize. The structured fields let consumers
+/// render the offending frame in bug reports without grepping logs.
+///
+/// Two failure modes are represented:
+///
+/// 1. **Bare JSON failure** — the line wasn't valid JSON, or the JSON didn't
+///    match the [`JsonRpcMessage`](crate::JsonRpcMessage) envelope. `raw_line`
+///    is the original line from stdout. `raw_json` is populated when the line
+///    parsed as JSON but didn't fit the envelope; `None` when the line wasn't
+///    even JSON. `method` is `None`.
+///
+/// 2. **Typed decode failure** — the envelope parsed fine (so the JSON-RPC
+///    `method` is known), but the typed payload decode
+///    (`Notification::from_envelope` / `ServerRequest::from_envelope`) failed
+///    on the `params`. `method` carries the JSON-RPC method name. `raw_json`
+///    carries the `params` value. `raw_line` is the re-serialized envelope —
+///    wire-equivalent to what came in, suitable for pasting into a bug report.
+#[derive(Debug, Clone)]
+pub struct ParseError {
+    /// Line from stdout (or re-serialized envelope, for typed-decode failures).
+    pub raw_line: String,
+    /// Parsed JSON value when available (the `params` for typed-decode
+    /// failures; the parsed line for envelope-shape failures).
+    pub raw_json: Option<Value>,
+    /// The underlying serde error description.
+    pub error_message: String,
+    /// JSON-RPC `method` name when the failure happened at the typed-decode
+    /// stage. `None` for bare-JSON / envelope-shape failures.
+    pub method: Option<String>,
+}
+
+impl ParseError {
+    /// Build a [`ParseError`] for a bare-JSON or envelope-shape failure.
+    pub fn from_line(line: impl Into<String>, error: serde_json::Error) -> Self {
+        let raw_line = line.into();
+        let raw_json = serde_json::from_str::<Value>(&raw_line).ok();
+        ParseError {
+            raw_line,
+            raw_json,
+            error_message: error.to_string(),
+            method: None,
+        }
+    }
+
+    /// Build a [`ParseError`] for a typed-decode failure on a notification or
+    /// request whose envelope parsed but whose `params` did not match.
+    ///
+    /// `raw_line` is reconstructed by re-serializing the envelope so consumers
+    /// can render the full offending frame even though the original line was
+    /// already consumed by the envelope decode.
+    pub fn from_envelope(
+        method: impl Into<String>,
+        params: Option<Value>,
+        error: serde_json::Error,
+    ) -> Self {
+        let method = method.into();
+        let raw_line = match &params {
+            Some(p) => format!(
+                r#"{{"method":{},"params":{}}}"#,
+                serde_json::to_string(&method).unwrap_or_else(|_| "\"<unserializable>\"".into()),
+                serde_json::to_string(p).unwrap_or_else(|_| "null".into()),
+            ),
+            None => format!(
+                r#"{{"method":{}}}"#,
+                serde_json::to_string(&method).unwrap_or_else(|_| "\"<unserializable>\"".into()),
+            ),
+        };
+        ParseError {
+            raw_line,
+            raw_json: params,
+            error_message: error.to_string(),
+            method: Some(method),
+        }
+    }
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.method {
+            Some(m) => write!(
+                f,
+                "Failed to decode params for method {:?}: {} (raw: {})",
+                m, self.error_message, self.raw_line
+            ),
+            None => write!(
+                f,
+                "Failed to parse JSON-RPC message: {} (raw: {})",
+                self.error_message, self.raw_line
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
 
 /// All possible errors from codex-codes operations.
 #[derive(Error, Debug)]
@@ -32,10 +131,12 @@ pub enum Error {
 
     /// A message from the server could not be deserialized.
     ///
-    /// Includes the raw message text for debugging. If you encounter this,
-    /// please report it — it likely indicates a protocol change.
+    /// Carries a [`ParseError`] with the offending `method` (when known),
+    /// raw frame, and the underlying serde diagnostic. If you encounter this,
+    /// please report it with the `raw_line` — it likely indicates a protocol
+    /// change.
     #[error("Deserialization error: {0}")]
-    Deserialization(String),
+    Deserialization(#[from] ParseError),
 
     /// The app-server process exited with a non-zero status.
     #[error("Process exited with status {0}: {1}")]
@@ -65,3 +166,79 @@ pub enum Error {
 
 /// A `Result` type alias using [`enum@Error`].
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn serde_err(s: &str) -> serde_json::Error {
+        serde_json::from_str::<Value>(s).unwrap_err()
+    }
+
+    #[test]
+    fn parse_error_from_line_valid_json_populates_raw_json() {
+        let line = r#"{"foo":"bar"}"#;
+        // Force a downstream typed-decode failure to produce a serde_json::Error;
+        // we just need *some* error to attach.
+        let err = serde_json::from_str::<i32>(line).unwrap_err();
+
+        let pe = ParseError::from_line(line, err);
+        assert_eq!(pe.raw_line, line);
+        assert_eq!(pe.raw_json, Some(json!({"foo": "bar"})));
+        assert!(pe.method.is_none());
+        assert!(!pe.error_message.is_empty());
+    }
+
+    #[test]
+    fn parse_error_from_line_invalid_json_has_none_raw_json() {
+        let line = "not-json{";
+        let err = serde_err(line);
+
+        let pe = ParseError::from_line(line, err);
+        assert_eq!(pe.raw_line, line);
+        assert!(pe.raw_json.is_none());
+        assert!(pe.method.is_none());
+    }
+
+    #[test]
+    fn parse_error_from_envelope_carries_method_params_and_reconstructs_line() {
+        let params = json!({"callId": null, "kind": "fileChange"});
+        let err = serde_json::from_value::<i32>(params.clone()).unwrap_err();
+
+        let pe =
+            ParseError::from_envelope("item/fileChange/requestApproval", Some(params.clone()), err);
+
+        assert_eq!(
+            pe.method.as_deref(),
+            Some("item/fileChange/requestApproval")
+        );
+        assert_eq!(pe.raw_json, Some(params.clone()));
+
+        // raw_line round-trips to the same shape (re-parse what we built).
+        let v: Value = serde_json::from_str(&pe.raw_line).unwrap();
+        assert_eq!(v["method"], "item/fileChange/requestApproval");
+        assert_eq!(v["params"], params);
+    }
+
+    #[test]
+    fn parse_error_from_envelope_handles_missing_params() {
+        let err = serde_err("not json");
+        let pe = ParseError::from_envelope("turn/completed", None, err);
+        let v: Value = serde_json::from_str(&pe.raw_line).unwrap();
+        assert_eq!(v["method"], "turn/completed");
+        assert!(v.get("params").is_none());
+        assert!(pe.raw_json.is_none());
+    }
+
+    #[test]
+    fn error_deserialization_display_includes_method_and_raw() {
+        let params = json!({"foo": 1});
+        let err = serde_err("not json");
+        let pe = ParseError::from_envelope("item/bogus", Some(params), err);
+        let e: Error = Error::Deserialization(pe);
+        let rendered = format!("{}", e);
+        assert!(rendered.contains("item/bogus"), "got: {}", rendered);
+        assert!(rendered.contains("foo"), "got: {}", rendered);
+    }
+}

--- a/codex-codes/src/lib.rs
+++ b/codex-codes/src/lib.rs
@@ -195,7 +195,7 @@ pub use io::options::{
 };
 
 // Error types (always available)
-pub use error::{Error, Result};
+pub use error::{Error, ParseError, Result};
 
 // JSON-RPC types (always available)
 pub use jsonrpc::{

--- a/codex-codes/tests/integration_tests.rs
+++ b/codex-codes/tests/integration_tests.rs
@@ -1,5 +1,6 @@
 use codex_codes::{
-    CommandExecutionStatus, FileChangeItem, PatchApplyStatus, PatchChangeKind, ThreadEvent,
+    CommandExecutionStatus, FileChangeItem, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest,
+    Notification, ParseError, PatchApplyStatus, PatchChangeKind, ServerRequest, ThreadEvent,
     ThreadItem,
 };
 
@@ -442,4 +443,95 @@ fn test_all_item_ids_are_sequential_within_capture() {
             );
         }
     }
+}
+
+// ── typed-decode failure plumbing (issue #128) ───────────────────────────
+//
+// When a wire frame's envelope parses but the typed-payload decode fails,
+// callers must still be able to recover the original `method` + `params` for
+// bug reports. These tests pin the exact code path used by
+// `AsyncClient::next_message` / `SyncClient::next_message`: deserialize the
+// line as a `JsonRpcMessage`, run `Notification::from_envelope` /
+// `ServerRequest::from_envelope`, wrap the resulting `serde_json::Error` in a
+// `ParseError`, and check that nothing was dropped on the floor.
+
+#[test]
+fn parse_error_carries_method_and_params_for_unmodeled_notification_variant() {
+    // Simulates a notification whose envelope is fine but whose params don't
+    // match any modeled variant — e.g. a future `FileUpdateChange.type` value
+    // the crate version doesn't yet know about.
+    //
+    // The crate uses an `Unknown { method, params }` fallback for unmodeled
+    // *methods*, so to actually trigger a typed-decode failure on a *known*
+    // method we send malformed params for it.
+    let line = r#"{"method":"item/completed","params":{"item":42}}"#;
+    let envelope: JsonRpcMessage = serde_json::from_str(line).expect("envelope parses");
+    let JsonRpcMessage::Notification(JsonRpcNotification { method, params }) = envelope else {
+        panic!("expected Notification, got: {:?}", envelope);
+    };
+
+    let err = Notification::from_envelope(&method, params.clone())
+        .expect_err("malformed params must fail typed decode");
+    let pe = ParseError::from_envelope(method.clone(), params.clone(), err);
+
+    assert_eq!(pe.method.as_deref(), Some("item/completed"));
+    assert_eq!(pe.raw_json, params);
+    assert!(
+        !pe.error_message.is_empty(),
+        "error_message should be populated"
+    );
+    // raw_line is a wire-equivalent reconstruction, parseable back into an envelope.
+    let echoed: JsonRpcMessage = serde_json::from_str(&pe.raw_line)
+        .unwrap_or_else(|e| panic!("raw_line should re-parse as JsonRpcMessage: {}", e));
+    if let JsonRpcMessage::Notification(n) = echoed {
+        assert_eq!(n.method, "item/completed");
+        assert_eq!(n.params.unwrap()["item"], 42);
+    } else {
+        panic!("raw_line should re-parse as a Notification");
+    }
+}
+
+#[test]
+fn parse_error_carries_method_and_params_for_server_request_with_missing_field() {
+    // Reproduces the "missing field `callId`" failure mode from issue #128:
+    // a valid item/commandExecution/requestApproval envelope whose params
+    // are missing the required `callId` field.
+    let line = r#"{"id":1,"method":"item/commandExecution/requestApproval","params":{"threadId":"t1","turnId":"u1","command":"ls -la","cwd":"/tmp"}}"#;
+    let envelope: JsonRpcMessage = serde_json::from_str(line).expect("envelope parses");
+    let JsonRpcMessage::Request(JsonRpcRequest {
+        id: _,
+        method,
+        params,
+    }) = envelope
+    else {
+        panic!("expected Request, got: {:?}", envelope);
+    };
+
+    let err = ServerRequest::from_envelope(&method, params.clone())
+        .expect_err("missing callId must fail typed decode");
+    let pe = ParseError::from_envelope(method, params, err);
+
+    assert_eq!(
+        pe.method.as_deref(),
+        Some("item/commandExecution/requestApproval")
+    );
+    assert!(
+        pe.error_message.contains("callId"),
+        "underlying error should mention callId; got: {}",
+        pe.error_message
+    );
+    assert_eq!(pe.raw_json.as_ref().unwrap()["command"], "ls -la");
+    assert_eq!(pe.raw_json.as_ref().unwrap()["threadId"], "t1");
+}
+
+#[test]
+fn parse_error_from_invalid_envelope_keeps_raw_line_without_method() {
+    // The bare-JSON failure path: line is not a valid JsonRpcMessage.
+    let line = r#"{"completely":"unexpected"}"#;
+    let err = serde_json::from_str::<JsonRpcMessage>(line).expect_err("should not parse");
+    let pe = ParseError::from_line(line, err);
+    assert!(pe.method.is_none());
+    assert_eq!(pe.raw_line, line);
+    // raw_json is populated because the line was valid JSON, just not a JsonRpcMessage.
+    assert_eq!(pe.raw_json.as_ref().unwrap()["completely"], "unexpected");
 }


### PR DESCRIPTION
## Summary

Fixes #128. When `AsyncClient::next_message` / `SyncClient::next_message` read a valid JSON-RPC envelope but `Notification::from_envelope` / `ServerRequest::from_envelope` fails on the params, the underlying \`serde_json::Error\` was wrapped in \`Error::Json\` and the original \`method\` + \`params\` were dropped on the floor. Downstream consumers saw \`missing field 'callId'\` or \`unknown variant 'type'\` with no way to render the offending frame for a bug report.

Mirrors the existing \`claude-codes\` \`ParseError\` pattern:

- New \`ParseError { raw_line, raw_json, error_message, method }\` with \`from_line()\` and \`from_envelope()\` constructors. The latter re-serializes the envelope to populate \`raw_line\` so consumers get a wire-equivalent frame to paste into bug reports.
- \`Error::Deserialization(String)\` → \`Error::Deserialization(ParseError)\`. Breaking, shipped as a patch — pre-1.0 crate, only this workspace's \`cc-proxy\` is a known downstream.
- \`next_message\` (both clients) now wraps typed-decode failures in \`Error::Deserialization(ParseError::from_envelope(method, params, e))\`. The bare-JSON path in \`read_message_opt\` uses \`ParseError::from_line(trimmed, e)\`.
- \`ParseError\` is re-exported from \`lib.rs\`.

Bumps version 0.128.0 → 0.128.1.

## Test plan

- [x] \`cargo test --package codex-codes --lib error::\` — 5 new unit tests for \`ParseError\` constructors and \`Error::Deserialization\` display.
- [x] \`cargo test --package codex-codes --test integration_tests parse_error\` — 3 new integration regression tests:
  - \`parse_error_carries_method_and_params_for_unmodeled_notification_variant\` — bad params on a known method.
  - \`parse_error_carries_method_and_params_for_server_request_with_missing_field\` — reproduces the \`missing field 'callId'\` failure mode from #128 against a real \`item/commandExecution/requestApproval\` envelope.
  - \`parse_error_from_invalid_envelope_keeps_raw_line_without_method\` — bare-JSON failure path.
- [x] Full suite: 68 lib + 20 integration + 5 doc-tests green.
- [x] \`cargo publish --package codex-codes --dry-run --allow-dirty\` succeeds.