### PR TITLE
Add nightly Codex schema drift check + auto-open issue

### DIFF
--- a/.github/workflows/codex-schema-drift.yml
+++ b/.github/workflows/codex-schema-drift.yml
@@ -1,0 +1,98 @@
+name: Codex Schema Drift
+
+# Nightly check: do our snapshotted Codex app-server schemas at
+# `codex-codes/tests/schemas/*.json` still match what `openai/codex@main`
+# publishes? If they've drifted, open (or update) an issue so we know to
+# regenerate the snapshot + typed bindings.
+
+on:
+  schedule:
+    # 06:17 UTC — slightly off the hour so we don't pile on GitHub's
+    # scheduled-workflow flush at :00 / :30.
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: diff snapshotted vs upstream
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Run drift check
+        id: check
+        # Tee both to stdout and to a file so we can publish the body into the issue.
+        run: |
+          set +e
+          python3 scripts/check_codex_schema_drift.py | tee /tmp/drift_report.md
+          STATUS=${PIPESTATUS[0]}
+          echo "exit_code=$STATUS" >> "$GITHUB_OUTPUT"
+          case "$STATUS" in
+            0) echo "result=no-drift"        >> "$GITHUB_OUTPUT" ;;
+            1) echo "result=drift"           >> "$GITHUB_OUTPUT" ;;
+            *) echo "result=fetch-failure"   >> "$GITHUB_OUTPUT" ;;
+          esac
+          exit 0  # don't fail the job on drift; we'll open an issue instead
+
+      - name: Open or update drift issue
+        if: steps.check.outputs.result == 'drift'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # We single-thread by label: there's at most one open drift issue at a
+          # time. If one exists, comment on it with today's report; otherwise
+          # create it.
+          LABEL="codex-schema-drift"
+          TITLE="codex-codes: snapshotted Codex schema has drifted from openai/codex@main"
+          BODY_FILE=/tmp/drift_report.md
+          # Make sure the label exists (idempotent).
+          gh label create "$LABEL" \
+            --color "B60205" \
+            --description "Nightly check found drift between our snapshotted Codex schema and upstream" \
+            --force \
+            || true
+          # Look for an open issue with the label.
+          EXISTING=$(gh issue list --state open --label "$LABEL" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing drift issue #$EXISTING"
+            # Add today's run as a fresh comment so history is preserved.
+            {
+              echo "_Nightly drift re-check (run #${{ github.run_number }}, $(date -u +%Y-%m-%dT%H:%MZ)):_"
+              echo
+              cat "$BODY_FILE"
+            } | gh issue comment "$EXISTING" --body-file -
+          else
+            echo "Opening new drift issue"
+            gh issue create \
+              --title "$TITLE" \
+              --label "$LABEL" \
+              --body-file "$BODY_FILE"
+          fi
+
+      - name: Report fetch failure (job summary only — don't open issue)
+        if: steps.check.outputs.result == 'fetch-failure'
+        run: |
+          {
+            echo "## Schema drift check skipped"
+            echo
+            echo "Could not fetch the upstream schema (network blip, rate limit,"
+            echo "or upstream rename). Will retry on the next nightly run."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: All clear (job summary only)
+        if: steps.check.outputs.result == 'no-drift'
+        run: |
+          {
+            echo "## ✅ No schema drift"
+            echo
+            echo "Snapshotted schemas match \`openai/codex@main\` byte-for-byte."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/check_codex_schema_drift.py
+++ b/scripts/check_codex_schema_drift.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+Diff our snapshotted Codex app-server schemas against the upstream copies
+hosted at github.com/openai/codex@main.
+
+Writes a structured Markdown report to stdout and exits:
+  0 — no drift (or schema missing upstream entirely, which we treat as a soft skip)
+  1 — drift detected; report on stdout describes what changed
+  2 — failed to fetch / parse a schema (transient, treated separately by CI so
+      we don't open spurious issues on network blips)
+
+Usage:
+  python3 scripts/check_codex_schema_drift.py [--ref main]
+
+The two schemas it checks live in the openai/codex repo at:
+  codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+  codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+
+Our local snapshot lives at:
+  codex-codes/tests/schemas/{,v2.}schemas.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+LOCAL_DIR = ROOT / "codex-codes" / "tests" / "schemas"
+
+UPSTREAM_BASE = (
+    "https://raw.githubusercontent.com/openai/codex/{ref}"
+    "/codex-rs/app-server-protocol/schema/json"
+)
+
+# (local file name, upstream file name) pairs. Same names today, but kept
+# explicit so a future rename upstream is easy to handle.
+SCHEMAS = [
+    ("codex_app_server_protocol.v2.schemas.json", "codex_app_server_protocol.v2.schemas.json"),
+    ("codex_app_server_protocol.schemas.json", "codex_app_server_protocol.schemas.json"),
+]
+
+
+def fetch(url: str) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": "codex-codes-drift-check"})
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+        return resp.read().decode("utf-8")
+
+
+def envelope_methods(defs: dict, envelope: str) -> list[tuple[str, str]]:
+    """(method, params_def_name) for every variant in `{envelope}.oneOf`."""
+    out = []
+    for variant in defs.get(envelope, {}).get("oneOf", []):
+        props = variant.get("properties", {})
+        method_enum = props.get("method", {}).get("enum") or []
+        params_ref = props.get("params", {}).get("$ref", "")
+        params_def = params_ref.rsplit("/", 1)[-1] if params_ref else "<no params>"
+        if method_enum:
+            out.append((method_enum[0], params_def))
+    return out
+
+
+def summarize_diff(local: dict, upstream: dict) -> dict:
+    """Compute a structured diff: top-level definition adds/removes/changes,
+    plus per-envelope method adds/removes."""
+    local_defs = local.get("definitions", {}) or {}
+    upstream_defs = upstream.get("definitions", {}) or {}
+    local_names = set(local_defs)
+    upstream_names = set(upstream_defs)
+    added = sorted(upstream_names - local_names)
+    removed = sorted(local_names - upstream_names)
+    shared = sorted(local_names & upstream_names)
+    changed = sorted(
+        name
+        for name in shared
+        if local_defs[name] != upstream_defs[name]
+    )
+
+    method_changes: dict[str, dict[str, list[str]]] = {}
+    for envelope in ("ServerNotification", "ClientRequest", "ServerRequest"):
+        local_methods = {m for m, _ in envelope_methods(local_defs, envelope)}
+        upstream_methods = {m for m, _ in envelope_methods(upstream_defs, envelope)}
+        added_m = sorted(upstream_methods - local_methods)
+        removed_m = sorted(local_methods - upstream_methods)
+        if added_m or removed_m:
+            method_changes[envelope] = {"added": added_m, "removed": removed_m}
+
+    return {
+        "definitions_added": added,
+        "definitions_removed": removed,
+        "definitions_changed": changed,
+        "methods_changed_per_envelope": method_changes,
+    }
+
+
+def render_markdown(file_label: str, diff: dict) -> str:
+    lines = [f"### `{file_label}`", ""]
+    sec = [
+        ("Definitions added upstream", diff["definitions_added"]),
+        ("Definitions removed upstream", diff["definitions_removed"]),
+        ("Definitions whose body changed", diff["definitions_changed"]),
+    ]
+    for header, items in sec:
+        if items:
+            lines.append(f"**{header}** ({len(items)}):")
+            lines.append("")
+            for it in items[:80]:
+                lines.append(f"- `{it}`")
+            if len(items) > 80:
+                lines.append(f"- ... and {len(items) - 80} more")
+            lines.append("")
+    for envelope, ch in diff["methods_changed_per_envelope"].items():
+        lines.append(f"**`{envelope}` methods**:")
+        if ch["added"]:
+            lines.append("")
+            lines.append("- added upstream:")
+            for m in ch["added"]:
+                lines.append(f"  - `{m}`")
+        if ch["removed"]:
+            lines.append("")
+            lines.append("- removed upstream:")
+            for m in ch["removed"]:
+                lines.append(f"  - `{m}`")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--ref", default="main", help="Upstream ref to compare against (default: main)")
+    args = ap.parse_args()
+
+    upstream_base = UPSTREAM_BASE.format(ref=args.ref)
+    any_drift = False
+    output_chunks = [
+        f"# Codex app-server schema drift report",
+        "",
+        f"Comparing `codex-codes/tests/schemas/*.json` against `openai/codex@{args.ref}`.",
+        "",
+    ]
+
+    for local_name, upstream_name in SCHEMAS:
+        local_path = LOCAL_DIR / local_name
+        url = f"{upstream_base}/{upstream_name}"
+        try:
+            local_text = local_path.read_text()
+            local = json.loads(local_text)
+        except FileNotFoundError:
+            print(f"error: local schema missing at {local_path}", file=sys.stderr)
+            return 2
+
+        try:
+            upstream_text = fetch(url)
+            upstream = json.loads(upstream_text)
+        except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError) as e:
+            print(f"error: could not fetch/parse upstream {url}: {e}", file=sys.stderr)
+            return 2
+
+        if local_text == upstream_text:
+            output_chunks.append(f"- ✅ `{local_name}` — byte-identical to upstream\n")
+            continue
+        if local == upstream:
+            # Different bytes but identical JSON (formatting / key ordering).
+            output_chunks.append(
+                f"- ✳️ `{local_name}` — different bytes, identical JSON (formatting only)\n"
+            )
+            continue
+
+        any_drift = True
+        diff = summarize_diff(local, upstream)
+        output_chunks.append(f"- ⚠️ `{local_name}` — **drift detected**\n")
+        output_chunks.append(render_markdown(local_name, diff))
+        output_chunks.append(f"\nUpstream source: {url}\n")
+
+    if any_drift:
+        output_chunks.append("")
+        output_chunks.append("---")
+        output_chunks.append("")
+        output_chunks.append(
+            "Regenerate the snapshot with:"
+        )
+        output_chunks.append("")
+        output_chunks.append("```bash")
+        output_chunks.append(
+            "curl -sSfL "
+            f"{upstream_base}/codex_app_server_protocol.v2.schemas.json "
+            "> codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json"
+        )
+        output_chunks.append(
+            "curl -sSfL "
+            f"{upstream_base}/codex_app_server_protocol.schemas.json "
+            "> codex-codes/tests/schemas/codex_app_server_protocol.schemas.json"
+        )
+        output_chunks.append(
+            "python3 scripts/codegen_protocol.py  # regenerate typed structs + samples"
+        )
+        output_chunks.append("cargo run --example schema_coverage  # confirm 100% coverage")
+        output_chunks.append("```")
+
+    print("\n".join(output_chunks))
+    return 1 if any_drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Nightly GitHub Action (06:17 UTC + \`workflow_dispatch\`) that diffs our snapshotted Codex app-server schemas at \`codex-codes/tests/schemas/\` against \`openai/codex@main\` and opens / updates an issue labeled \`codex-schema-drift\` when they diverge.

## What lands

- \`scripts/check_codex_schema_drift.py\` — fetches upstream schemas from \`raw.githubusercontent.com\`, computes a **structured** diff (top-level definitions added / removed / changed, plus per-envelope method add/remove), and prints a Markdown report. Exit \`0\` no drift, \`1\` drift, \`2\` fetch failure (treated separately so transient network blips don't spam issues).
- \`.github/workflows/codex-schema-drift.yml\` — cron \`17 6 * * *\`, runs the script, and on drift opens a fresh issue labeled \`codex-schema-drift\` (or comments on the existing open one with the new report so history is preserved).

## How the issue body looks

For each schema:

\`\`\`
### codex_app_server_protocol.v2.schemas.json

**Definitions added upstream** (3):
- AppListUpdatedNotification
- ...

**Definitions whose body changed** (1):
- TurnPlanStep

**ServerNotification methods**:

- added upstream:
  - thread/realtime/whatever
\`\`\`

Plus a copy-pasteable regenerate-the-snapshot recipe at the bottom.

## Test plan

- [x] \`python3 scripts/check_codex_schema_drift.py\` — exits \`0\` against current main (byte-identical, no drift).
- [x] \`python3 scripts/check_codex_schema_drift.py --ref HEAD~50\` — exits \`1\` with a structured drift summary listing added/removed/changed defs.
- [x] Workflow YAML lints clean.