### PR TITLE
codex-codes: add config_override + extra_args on AppServerBuilder (closes #135)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.129.1"
+version = "0.129.2"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.140` is tested against Claude CLI `2.1.140`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.129.1`, tested against Codex CLI `0.130.0`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.129.2`, tested against Codex CLI `0.130.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.
 

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.129.2] - 2026-05-16
+
+### Added
+
+- **`AppServerBuilder::config_override(key, value)`** — repeatable; appends a `-c key=value` *global* codex flag (placed before `app-server` since `-c` is parsed as a global option, not a subcommand arg). Closes [#135](https://github.com/meawoppl/rust-code-agent-sdks/issues/135). Unblocks consumers like agent-portal that need to pass e.g. `("sandbox_mode", "workspace-write")` or `("approval_policy", "on-request")` at spawn time — previously the only way to do this was to fork the crate or shell out around it.
+- **`AppServerBuilder::extra_args(args)`** — appends raw additional args *after* `--listen stdio://` so they land as `app-server` subcommand args. The seam for any flag the SDK doesn't model yet (`--strict-config`, future `--session-source app-server`, etc.).
+
+Both follow the existing `ClaudeCliBuilder` patterns in the sibling crate: `key: K, value: V` with `K: Into<String>`, `V: Into<String>` for the keyed variant; `<I, S: Into<String>>` for the iterable variant.
+
+Values are passed to codex unparsed — codex tries TOML, falls back to raw string. Caller is responsible for any quoting/escaping (e.g. arrays: `r#"["disk-full-read-access"]"#`).
+
 ## [0.129.1] - 2026-05-15
 
 ### Added

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.129.1"
+version = "0.129.2"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/src/cli.rs
+++ b/codex-codes/src/cli.rs
@@ -9,14 +9,22 @@ use std::process::Stdio;
 
 /// Builder for launching a Codex app-server process.
 ///
-/// Produces commands of the form: `codex app-server --listen stdio://`
+/// Produces commands of the form: `codex [-c k=v]... app-server --listen stdio:// [extra]...`
 ///
-/// All model, sandbox, and approval configuration is done via JSON-RPC
-/// requests after connecting, not via CLI flags.
+/// All model, sandbox, and approval configuration that isn't expressible as a
+/// CLI flag is done via JSON-RPC requests after connecting. For everything
+/// that *is* a CLI flag, see [`config_override`](Self::config_override) and
+/// [`extra_args`](Self::extra_args).
 #[derive(Debug, Clone)]
 pub struct AppServerBuilder {
     command: PathBuf,
     working_directory: Option<PathBuf>,
+    /// `-c key=value` overrides, in insertion order. Emitted *before* the
+    /// `app-server` subcommand because `-c` is a global `codex` flag.
+    config_overrides: Vec<(String, String)>,
+    /// Raw additional args appended *after* the `--listen stdio://` so they
+    /// land as subcommand args to `app-server`.
+    extra_args: Vec<String>,
 }
 
 impl Default for AppServerBuilder {
@@ -31,6 +39,8 @@ impl AppServerBuilder {
         Self {
             command: PathBuf::from("codex"),
             working_directory: None,
+            config_overrides: Vec::new(),
+            extra_args: Vec::new(),
         }
     }
 
@@ -46,6 +56,62 @@ impl AppServerBuilder {
         self
     }
 
+    /// Append a `-c key=value` global config override.
+    ///
+    /// Repeatable. Each call appends one override; order is preserved on the
+    /// command line. The `value` is passed to codex unparsed — codex tries
+    /// TOML, then falls back to the raw string. The caller is responsible for
+    /// any quoting / escaping the value itself needs (e.g. arrays:
+    /// `("sandbox_permissions", r#"["disk-full-read-access"]"#)`).
+    ///
+    /// `-c` flags are placed *before* the `app-server` subcommand because
+    /// they're parsed as global `codex` options, not subcommand args.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use codex_codes::AppServerBuilder;
+    ///
+    /// let builder = AppServerBuilder::new()
+    ///     .config_override("sandbox_mode", "workspace-write")
+    ///     .config_override("approval_policy", "on-request");
+    /// ```
+    pub fn config_override<K, V>(mut self, key: K, value: V) -> Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.config_overrides.push((key.into(), value.into()));
+        self
+    }
+
+    /// Append raw arguments to the `app-server` subcommand invocation.
+    ///
+    /// Inserted *after* the hardcoded `--listen stdio://`, so they land as
+    /// subcommand args. Use this for flags the SDK doesn't model yet — e.g.
+    /// `--strict-config`, or `--session-source app-server` once that becomes
+    /// available on the multitool subcommand.
+    ///
+    /// For `-c key=value` global overrides use [`config_override`](Self::config_override)
+    /// instead; those need to be placed before the subcommand.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use codex_codes::AppServerBuilder;
+    ///
+    /// let builder = AppServerBuilder::new()
+    ///     .extra_args(["--strict-config"]);
+    /// ```
+    pub fn extra_args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.extra_args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
     /// Resolve the command path, using `which` for non-absolute paths.
     fn resolve_command(&self) -> crate::error::Result<PathBuf> {
         if self.command.is_absolute() {
@@ -57,12 +123,20 @@ impl AppServerBuilder {
     }
 
     /// Build the command arguments.
+    ///
+    /// Layout: `[-c k=v]... app-server --listen stdio:// [extra_args]...`
     fn build_args(&self) -> Vec<String> {
-        vec![
-            "app-server".to_string(),
-            "--listen".to_string(),
-            "stdio://".to_string(),
-        ]
+        let mut args =
+            Vec::with_capacity(self.config_overrides.len() * 2 + 3 + self.extra_args.len());
+        for (k, v) in &self.config_overrides {
+            args.push("-c".to_string());
+            args.push(format!("{k}={v}"));
+        }
+        args.push("app-server".to_string());
+        args.push("--listen".to_string());
+        args.push("stdio://".to_string());
+        args.extend(self.extra_args.iter().cloned());
+        args
     }
 
     /// Spawn the app-server process asynchronously.
@@ -137,5 +211,85 @@ mod tests {
     fn test_working_directory() {
         let builder = AppServerBuilder::new().working_directory("/tmp/work");
         assert_eq!(builder.working_directory, Some(PathBuf::from("/tmp/work")));
+    }
+
+    #[test]
+    fn test_config_override_single() {
+        let args = AppServerBuilder::new()
+            .config_override("sandbox_mode", "workspace-write")
+            .build_args();
+        assert_eq!(
+            args,
+            vec![
+                "-c",
+                "sandbox_mode=workspace-write",
+                "app-server",
+                "--listen",
+                "stdio://"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_config_override_multiple_preserves_order() {
+        let args = AppServerBuilder::new()
+            .config_override("sandbox_mode", "workspace-write")
+            .config_override("approval_policy", "on-request")
+            .build_args();
+        // Both `-c` pairs come BEFORE `app-server` since `-c` is a global
+        // codex flag.
+        assert_eq!(
+            args,
+            vec![
+                "-c",
+                "sandbox_mode=workspace-write",
+                "-c",
+                "approval_policy=on-request",
+                "app-server",
+                "--listen",
+                "stdio://"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_extra_args_appended_after_listen() {
+        let args = AppServerBuilder::new()
+            .extra_args(["--strict-config"])
+            .build_args();
+        assert_eq!(
+            args,
+            vec!["app-server", "--listen", "stdio://", "--strict-config"]
+        );
+    }
+
+    #[test]
+    fn test_config_override_and_extra_args_combined() {
+        let args = AppServerBuilder::new()
+            .config_override("sandbox_mode", "workspace-write")
+            .extra_args(["--strict-config", "--something-else"])
+            .build_args();
+        assert_eq!(
+            args,
+            vec![
+                "-c",
+                "sandbox_mode=workspace-write",
+                "app-server",
+                "--listen",
+                "stdio://",
+                "--strict-config",
+                "--something-else",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_config_override_value_with_special_chars_unchanged() {
+        // Caller is responsible for quoting the value half; we pass it
+        // through unchanged so codex's TOML parser sees it verbatim.
+        let args = AppServerBuilder::new()
+            .config_override("sandbox_permissions", r#"["disk-full-read-access"]"#)
+            .build_args();
+        assert_eq!(args[1], r#"sandbox_permissions=["disk-full-read-access"]"#);
     }
 }


### PR DESCRIPTION
## Summary

Closes #135. Two new builder methods on \`AppServerBuilder\`:

\`\`\`rust
let builder = AppServerBuilder::new()
    .config_override(\"sandbox_mode\", \"workspace-write\")
    .config_override(\"approval_policy\", \"on-request\")
    .extra_args([\"--strict-config\"]);
\`\`\`

Layout: \`codex [-c k=v]... app-server --listen stdio:// [extra]...\`. \`-c\` goes BEFORE the subcommand because it's a global codex flag; raw \`extra_args\` go AFTER (subcommand args).

Matches \`ClaudeCliBuilder\`'s patterns from the sibling crate:
- Keyed: \`<K, V: Into<String>>\`
- Iterable: \`<I, S: Into<String>>\`

Values pass through unchanged — codex tries TOML, falls back to raw string; the caller handles any quoting (e.g. arrays: \`r#\"[\\\"disk-full-read-access\\\"]\"#\`).

## Why now

#134 (apply_patch silently aborts in readOnly sandbox) is recoverable today by spawning codex with \`-c sandbox_mode=workspace-write\` — but \`AppServerBuilder\` previously gave no seam to add that arg. agent-portal had to fork or shell-wrap. Now it can just \`.config_override(...)\` and move on.

## Test plan

- [x] 6 new unit tests in \`codex-codes/src/cli.rs\` covering single override, multiple-preserves-order, extra_args, combined, value-with-special-chars passthrough. \`cargo test --package codex-codes --lib cli::\` → 8 pass.
- [x] Full suite: 73 lib + 20 integration + 7 doc tests pass.
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean.
- [x] \`cargo publish --dry-run\` succeeds.

## Version

Patch: \`0.129.1 → 0.129.2\` (purely additive API, no breaking changes).