### PR TITLE
Supersede answer_questions with index-keyed signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.141"
+version = "2.1.142"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.141` is tested against Claude CLI `2.1.141`.
+- **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.142` is tested against Claude CLI `2.1.142`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.129.3`, tested against Codex CLI `0.130.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.142] - 2026-05-27
+
+### Changed
+
+- **`ToolPermissionRequest::answer_questions`** — Signature changed from `HashMap<String, String>` (keyed by caller-chosen string) to `&HashMap<usize, String>` (keyed by question index). The previous signature let callers — and the rustdoc example — accidentally key answers by `header` instead of the full question text, which makes the CLI render `"Your questions have been answered: ."` with an empty body and leaves Claude unable to see the choice. The new signature looks each index up in the request's `questions` array and uses `q.question` as the wire key, so the wrong-key footgun is impossible.
+- **`answer_questions` now returns `AskUserQuestionResponseError`** instead of a bare `serde_json::Error`, distinguishing `WrongTool` / `ParseInput` / `QuestionIndexOutOfRange { index, total }` failure modes. Also validates that `tool_name == "AskUserQuestion"` before parsing the input.
+
+### Added
+
+- **`AskUserQuestionResponseError`** — Re-exported error type for the helper.
+
+### Migration
+
+If you wired up to the 2.1.141 `answer_questions(HashMap<String, String>)` form, swap to passing a `HashMap<usize, String>` keyed by question index (matches the natural UI shape of "the user picked option X for question 0"). No other callsite changes needed.
+
 ## [2.1.141] - 2026-05-17
 
 ### Added

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.141"
+version = "2.1.142"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -138,7 +138,7 @@ let serialized = Protocol::serialize(&output)?;
 
 ## Compatibility
 
-**Tested against:** Claude CLI 2.1.141
+**Tested against:** Claude CLI 2.1.142
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/io/control.rs
+++ b/claude-codes/src/io/control.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
+use std::collections::HashMap;
 use std::fmt;
+
+use crate::tool_inputs::AskUserQuestionInput;
 
 // ============================================================================
 // Permission Enums
@@ -641,57 +644,113 @@ impl ToolPermissionRequest {
         ControlResponse::from_result(request_id, PermissionResult::deny_and_interrupt(message))
     }
 
-    /// Allow an `AskUserQuestion` permission request by supplying the user's
-    /// answers.
+    /// Build an `allow` response for an `AskUserQuestion` permission request
+    /// by supplying the user's chosen answers.
     ///
-    /// The CLI echoes the `updatedInput` we return back into the
-    /// `tool_use_result` it sends to its frontend; that frontend reads
-    /// `tool_use_result.questions` and calls `questions.map(...)`. If we
-    /// returned only `{answers: …}` (the natural shape if you think of
-    /// the response as "just the new info"), the frontend would crash with
-    /// `undefined is not an object (evaluating 'q.map')`.
+    /// The CLI's `AskUserQuestion` tool has a finicky wire contract that
+    /// is easy to get wrong by hand:
     ///
-    /// This helper parses `self.input` as
-    /// [`AskUserQuestionInput`](crate::AskUserQuestionInput), attaches the
-    /// supplied `answers`, and serializes it back — preserving the
-    /// original `questions` (and any `metadata`) on the wire alongside the
-    /// new answers. Returns an error if `self.input` doesn't parse as an
-    /// `AskUserQuestionInput`; non-`AskUserQuestion` callers should keep
-    /// using [`allow`](Self::allow) / [`allow_with`](Self::allow_with).
+    /// - The response's `input` must preserve the original `questions`
+    ///   array. Stripping it (sending just `{"answers": ...}`) makes the
+    ///   downstream viewer crash with
+    ///   `undefined is not an object (evaluating 'q.map')` (the CLI echoes
+    ///   the `updatedInput` we return into `tool_use_result`, and viewers
+    ///   read `tool_use_result.questions`).
+    /// - The `answers` map must be keyed by the full **question text**
+    ///   (the `question` field). Keying by `header` or by question index
+    ///   makes the CLI's tool render `"Your questions have been answered: ."`
+    ///   with an empty answer body, leaving Claude unable to see which
+    ///   option the user picked.
+    ///
+    /// This helper does both correctly: it parses `self.input` as
+    /// [`AskUserQuestionInput`](crate::AskUserQuestionInput), looks each
+    /// answer up by question index, and inserts the answer keyed by
+    /// `q.question`. The original `questions` (and any `metadata`) pass
+    /// through unchanged.
+    ///
+    /// `answers_by_index` maps 0-based question index into the original
+    /// `questions` array to the user's chosen answer label. For
+    /// multi-select questions, join the selected labels with `", "`.
+    /// Questions not in the map are treated as unanswered.
+    ///
+    /// Non-`AskUserQuestion` callers should keep using
+    /// [`allow`](Self::allow) / [`allow_with`](Self::allow_with).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AskUserQuestionResponseError`] if the request isn't an
+    /// `AskUserQuestion` request, the input doesn't parse, or an answer
+    /// references a question index that doesn't exist.
     ///
     /// # Example
-    /// ```
-    /// # use claude_codes::ToolPermissionRequest;
-    /// # use serde_json::json;
-    /// # use std::collections::HashMap;
-    /// let req = ToolPermissionRequest {
-    ///     tool_name: "AskUserQuestion".to_string(),
-    ///     input: json!({"questions": [
-    ///         {"question": "?", "header": "Q", "options": [], "multiSelect": false}
-    ///     ]}),
-    ///     permission_suggestions: vec![],
-    ///     blocked_path: None,
-    ///     decision_reason: None,
-    ///     tool_use_id: None,
-    /// };
-    /// let mut answers = HashMap::new();
-    /// answers.insert("Q".into(), "yes".into());
-    /// let response = req.answer_questions(answers, "req-123").unwrap();
+    ///
+    /// ```no_run
+    /// use claude_codes::ToolPermissionRequest;
+    /// use std::collections::HashMap;
+    ///
+    /// fn answer(req: &ToolPermissionRequest, request_id: &str) {
+    ///     let mut answers = HashMap::new();
+    ///     answers.insert(0_usize, "Blue".to_string());
+    ///     let response = req
+    ///         .answer_questions(&answers, request_id)
+    ///         .expect("request is AskUserQuestion-shaped");
+    ///     // send `response` back to the CLI
+    /// }
     /// ```
     pub fn answer_questions(
         &self,
-        answers: std::collections::HashMap<String, String>,
+        answers_by_index: &HashMap<usize, String>,
         request_id: &str,
-    ) -> Result<ControlResponse, serde_json::Error> {
-        let mut typed: crate::tool_inputs::AskUserQuestionInput =
-            serde_json::from_value(self.input.clone())?;
-        typed.answers = Some(answers);
-        let updated_input = serde_json::to_value(&typed)?;
+    ) -> Result<ControlResponse, AskUserQuestionResponseError> {
+        if self.tool_name != "AskUserQuestion" {
+            return Err(AskUserQuestionResponseError::WrongTool(
+                self.tool_name.clone(),
+            ));
+        }
+        let parsed: AskUserQuestionInput = serde_json::from_value(self.input.clone())
+            .map_err(AskUserQuestionResponseError::ParseInput)?;
+        let total = parsed.questions.len();
+
+        let mut answers_map = serde_json::Map::new();
+        for (idx, answer) in answers_by_index {
+            let q = parsed.questions.get(*idx).ok_or(
+                AskUserQuestionResponseError::QuestionIndexOutOfRange { index: *idx, total },
+            )?;
+            answers_map.insert(q.question.clone(), Value::String(answer.clone()));
+        }
+
+        let mut updated_input = self.input.clone();
+        // Input is an object — we just deserialized it as `AskUserQuestionInput`.
+        updated_input
+            .as_object_mut()
+            .expect("AskUserQuestion input is a JSON object")
+            .insert("answers".to_string(), Value::Object(answers_map));
+
         Ok(ControlResponse::from_result(
             request_id,
             PermissionResult::allow(updated_input),
         ))
     }
+}
+
+/// Errors that can occur when building an `AskUserQuestion` response via
+/// [`ToolPermissionRequest::answer_questions`].
+#[derive(Debug, thiserror::Error)]
+pub enum AskUserQuestionResponseError {
+    /// The request was for a different tool, not `AskUserQuestion`.
+    #[error("expected tool_name=AskUserQuestion, got `{0}`")]
+    WrongTool(String),
+    /// The `input` field didn't deserialize into `AskUserQuestionInput`.
+    #[error("failed to parse AskUserQuestion input: {0}")]
+    ParseInput(#[source] serde_json::Error),
+    /// An answer entry referenced a question index outside the questions array.
+    #[error("answer references question index {index}, but only {total} question(s) were asked")]
+    QuestionIndexOutOfRange {
+        /// The out-of-range index the caller supplied.
+        index: usize,
+        /// The number of questions actually in the request.
+        total: usize,
+    },
 }
 
 /// Result of a permission decision
@@ -1472,56 +1531,139 @@ mod tests {
         assert!(response.is_none());
     }
 
-    /// Reproducer for the bug where a downstream viewer/frontend rendering
-    /// an `AskUserQuestion` response crashes with
-    /// `undefined is not an object (evaluating 'q.map')`. The frontend reads
-    /// `tool_use_result.questions` (which the CLI populates by echoing the
-    /// `updatedInput` we returned in the `Allow` response) and calls
-    /// `questions.map(...)`. When `updatedInput` omits the `questions`
-    /// array — which is the natural shape if a caller just supplies an
-    /// `{answers: …}` payload — the field is missing and `q.map` blows up.
-    ///
-    /// This test asserts that the convenience for answering questions
-    /// preserves the original `questions` list alongside the user's
-    /// answers, so the wire payload has both fields.
-    #[test]
-    fn test_ask_user_question_answer_preserves_questions_in_updated_input() {
-        let req = ToolPermissionRequest {
+    fn ask_user_question_request() -> ToolPermissionRequest {
+        ToolPermissionRequest {
             tool_name: "AskUserQuestion".to_string(),
             input: serde_json::json!({
-                "questions": [{
-                    "question": "Which color do you prefer?",
-                    "header": "Color",
-                    "options": [
-                        {"label": "Red", "description": "A warm color"},
-                        {"label": "Blue", "description": "A cool color"},
-                    ],
-                    "multiSelect": false,
-                }],
+                "questions": [
+                    {
+                        "question": "Which color do you prefer?",
+                        "header": "Color",
+                        "options": [
+                            {"label": "Red", "description": "warm"},
+                            {"label": "Blue", "description": "cool"}
+                        ],
+                        "multiSelect": false
+                    },
+                    {
+                        "question": "Pick a size",
+                        "header": "Size",
+                        "options": [
+                            {"label": "Small"},
+                            {"label": "Large"}
+                        ],
+                        "multiSelect": false
+                    }
+                ]
             }),
+            permission_suggestions: vec![],
+            blocked_path: None,
+            decision_reason: None,
+            tool_use_id: None,
+        }
+    }
+
+    fn extract_updated_input(resp: &ControlResponse) -> Value {
+        let ControlResponsePayload::Success { response, .. } = &resp.response else {
+            panic!("expected Success payload");
+        };
+        let inner = response.as_ref().expect("response body present");
+        inner
+            .get("updatedInput")
+            .cloned()
+            .expect("updatedInput field present")
+    }
+
+    #[test]
+    fn answer_questions_keys_by_question_text_and_preserves_questions() {
+        let req = ask_user_question_request();
+        let mut answers = HashMap::new();
+        answers.insert(0, "Blue".to_string());
+        answers.insert(1, "Large".to_string());
+
+        let resp = req.answer_questions(&answers, "rid-1").unwrap();
+        let updated = extract_updated_input(&resp);
+
+        // questions array is preserved verbatim
+        assert_eq!(
+            updated["questions"], req.input["questions"],
+            "questions array must round-trip unchanged"
+        );
+        // answers keyed by question text (not header, not index)
+        assert_eq!(
+            updated["answers"]["Which color do you prefer?"],
+            Value::String("Blue".into())
+        );
+        assert_eq!(
+            updated["answers"]["Pick a size"],
+            Value::String("Large".into())
+        );
+        // header is NOT used as the key
+        assert!(updated["answers"].get("Color").is_none());
+        assert!(updated["answers"].get("Size").is_none());
+    }
+
+    #[test]
+    fn answer_questions_partial_answers_omits_unanswered() {
+        let req = ask_user_question_request();
+        let mut answers = HashMap::new();
+        answers.insert(1, "Small".to_string());
+
+        let resp = req.answer_questions(&answers, "rid-2").unwrap();
+        let updated = extract_updated_input(&resp);
+
+        assert_eq!(
+            updated["answers"]["Pick a size"],
+            Value::String("Small".into())
+        );
+        assert!(updated["answers"]
+            .get("Which color do you prefer?")
+            .is_none());
+    }
+
+    #[test]
+    fn answer_questions_rejects_wrong_tool() {
+        let mut req = ask_user_question_request();
+        req.tool_name = "Bash".to_string();
+
+        let mut answers = HashMap::new();
+        answers.insert(0, "Blue".to_string());
+        match req.answer_questions(&answers, "rid-3").unwrap_err() {
+            AskUserQuestionResponseError::WrongTool(name) => assert_eq!(name, "Bash"),
+            other => panic!("expected WrongTool, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn answer_questions_rejects_unparseable_input() {
+        let req = ToolPermissionRequest {
+            tool_name: "AskUserQuestion".to_string(),
+            input: serde_json::json!({"not_questions": "garbage"}),
             permission_suggestions: vec![],
             blocked_path: None,
             decision_reason: None,
             tool_use_id: None,
         };
 
-        let mut answers = std::collections::HashMap::new();
-        answers.insert("Color".to_string(), "Blue".to_string());
+        let answers = HashMap::new();
+        match req.answer_questions(&answers, "rid-4").unwrap_err() {
+            AskUserQuestionResponseError::ParseInput(_) => {}
+            other => panic!("expected ParseInput, got {other:?}"),
+        }
+    }
 
-        let response = req
-            .answer_questions(answers, "req-q1")
-            .expect("AskUserQuestion input round-trips through the typed helper");
-        let wire = serde_json::to_value(&response).expect("ControlResponse serializes");
+    #[test]
+    fn answer_questions_rejects_out_of_range_index() {
+        let req = ask_user_question_request();
+        let mut answers = HashMap::new();
+        answers.insert(7, "ghost".to_string());
 
-        // ControlResponse nests the PermissionResult value at
-        // `response.response`; the PermissionResult itself carries
-        // `behavior: "allow"` + `updatedInput`.
-        let updated_input = &wire["response"]["response"]["updatedInput"];
-        assert_eq!(
-            updated_input["questions"][0]["header"], "Color",
-            "questions array must round-trip in updatedInput so the \
-             frontend's `questions.map(...)` doesn't fault on undefined"
-        );
-        assert_eq!(updated_input["answers"]["Color"], "Blue");
+        match req.answer_questions(&answers, "rid-5").unwrap_err() {
+            AskUserQuestionResponseError::QuestionIndexOutOfRange { index, total } => {
+                assert_eq!(index, 7);
+                assert_eq!(total, 2);
+            }
+            other => panic!("expected QuestionIndexOutOfRange, got {other:?}"),
+        }
     }
 }

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -137,11 +137,12 @@ pub use io::{
 
 // Control protocol types for tool permission handling
 pub use io::{
-    ControlRequest, ControlRequestMessage, ControlRequestPayload, ControlResponse,
-    ControlResponseMessage, ControlResponsePayload, HookCallbackRequest, InitializeRequest,
-    McpMessageRequest, Permission, PermissionBehavior, PermissionDenial, PermissionDestination,
-    PermissionModeName, PermissionResult, PermissionRule, PermissionSuggestion, PermissionType,
-    SDKControlInterruptRequest, ToolPermissionRequest, ToolUseBlock,
+    AskUserQuestionResponseError, ControlRequest, ControlRequestMessage, ControlRequestPayload,
+    ControlResponse, ControlResponseMessage, ControlResponsePayload, HookCallbackRequest,
+    InitializeRequest, McpMessageRequest, Permission, PermissionBehavior, PermissionDenial,
+    PermissionDestination, PermissionModeName, PermissionResult, PermissionRule,
+    PermissionSuggestion, PermissionType, SDKControlInterruptRequest, ToolPermissionRequest,
+    ToolUseBlock,
 };
 
 // System message and assistant message types

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.141";
+const TESTED_VERSION: &str = "2.1.142";
 
 /// Ensures version warning is only shown once per session
 static VERSION_CHECK: Once = Once::new();

--- a/claude-codes/tests/integration_tests.rs
+++ b/claude-codes/tests/integration_tests.rs
@@ -2211,15 +2211,17 @@ async fn test_ask_user_question_answered_and_converges() {
                                         perm_req.input.clone(),
                                     )
                                     .expect("AskUserQuestion input must deserialize");
-                                    let mut answers = HashMap::new();
-                                    for q in &parsed.questions {
-                                        answers.insert(q.header.clone(), CHOSEN.to_string());
+                                    let mut answers_by_index = HashMap::new();
+                                    let mut answers_by_text = HashMap::new();
+                                    for (i, q) in parsed.questions.iter().enumerate() {
+                                        answers_by_index.insert(i, CHOSEN.to_string());
+                                        answers_by_text.insert(q.question.clone(), CHOSEN.to_string());
                                     }
                                     tool_use_input_seen = Some(parsed);
-                                    answered_with = Some(answers.clone());
+                                    answered_with = Some(answers_by_text);
 
                                     let response = perm_req
-                                        .answer_questions(answers, &req.request_id)
+                                        .answer_questions(&answers_by_index, &req.request_id)
                                         .expect("answer_questions round-trips");
                                     eprintln!(
                                         "[TRACE]   replying answer_questions: {}",
@@ -2368,8 +2370,8 @@ async fn test_ask_user_question_answered_and_converges() {
     let tur = tool_use_result_field
         .expect("UserMessage.tool_use_result was not captured by the typed parse");
     assert_eq!(
-        tur["answers"]["Color"], CHOSEN,
-        "tool_use_result.answers.Color should match the answer we sent via allow_with"
+        tur["answers"]["Which color do you prefer?"], CHOSEN,
+        "tool_use_result.answers[question_text] should match the answer we sent via allow_with"
     );
     assert_eq!(
         tur["questions"][0]["header"], "Color",


### PR DESCRIPTION
## Summary

Supersedes the `answer_questions(HashMap<String, String>, &str)` helper that landed in 2.1.141 (#139) with a stricter signature `answer_questions(&HashMap<usize, String>, &str)`.

The 2.1.141 version fixed half the AskUserQuestion footgun (the dropped-`questions`-array crash), but the string-keyed form still let callers — and the rustdoc example itself — key answers by `header` instead of question text. That produces the *other* failure mode: the CLI renders `"Your questions have been answered: ."` with an empty body and Claude can't see the answer. Reproduced live against the CLI in our integration test.

The new signature takes a `HashMap<usize, String>` keyed by question index (the natural form for a UI that renders questions in order), looks each index up in the request's `questions` array, and inserts answers keyed by `q.question`. **Both footguns are now impossible to hit.**

Other changes:
- Returns `AskUserQuestionResponseError` (`WrongTool` / `ParseInput` / `QuestionIndexOutOfRange { index, total }`) instead of a bare `serde_json::Error`.
- Validates `tool_name == "AskUserQuestion"` before parsing the input.

This is a breaking change to a 10-day-old API. Migration: pass `HashMap<usize, String>` keyed by question index instead of `HashMap<String, String>` keyed by question text.

Bumps to 2.1.142.

## Test plan

- [x] 5 unit tests cover happy path + every error variant (`io::control::tests::answer_questions_*`)
- [x] Integration test `test_ask_user_question_answered_and_converges` rewritten to call the new signature; CLI receives the answer keyed by question text and sub-Claude responds "You picked Blue."
- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test -p claude-codes` all clean