### PR TITLE
claude-codes: pin tested CLI version to 2.1.150

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.142"
+version = "2.1.150"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.142` is tested against Claude CLI `2.1.142`.
+- **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.150` is tested against Claude CLI `2.1.150`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.129.3`, tested against Codex CLI `0.130.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.150] - 2026-05-29
+
+### Changed
+
+- Pinned the tested Claude CLI version forward to `2.1.150`. The full integration suite passes against the newer CLI with no protocol changes required.
+
 ## [2.1.142] - 2026-05-27
 
 ### Changed

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.142"
+version = "2.1.150"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -138,7 +138,7 @@ let serialized = Protocol::serialize(&output)?;
 
 ## Compatibility
 
-**Tested against:** Claude CLI 2.1.142
+**Tested against:** Claude CLI 2.1.150
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.142";
+const TESTED_VERSION: &str = "2.1.150";
 
 /// Ensures version warning is only shown once per session
 static VERSION_CHECK: Once = Once::new();


### PR DESCRIPTION
Pins the tested Claude CLI version forward from 2.1.142 to 2.1.150.

The full integration suite (`cargo test -p claude-codes --features integration-tests`) passes against the newer CLI — all 26 tests green — with no protocol changes required. Bumps the crate version, `TESTED_VERSION`, README compatibility note, and CHANGELOG.