### PR TITLE
Ignore local .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ claude-code-sdk-python/
 # Reference checkouts of other codex / claude SDK consumers, used for
 # studying their serde patterns. Local-only; not part of the workspace build.
 reference/
+
+# Local Claude Code settings and agent worktrees
+.claude/


### PR DESCRIPTION
Adds `.claude/` to `.gitignore` so local Claude Code settings and agent worktrees don't show up in `git status`.