### PR TITLE
codex-codes: 0.137.0 — re-snapshot schema, model new methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.129.3"
+version = "0.137.0"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.150` is tested against Claude CLI `2.1.150`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.129.3`, tested against Codex CLI `0.130.0`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.137.0`, tested against Codex CLI `0.137.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.
 
@@ -53,7 +53,7 @@ All features are enabled by default. For WASM or type-sharing use cases:
 
 ```toml
 [dependencies]
-codex-codes = { version = "0.128", default-features = false, features = ["types"] }
+codex-codes = { version = "0.137", default-features = false, features = ["types"] }
 ```
 
 ## Testing Approach

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.137.0] - 2026-06-07
+
+### Changed (breaking)
+
+Re-snapshotted the Codex app-server schema from `openai/codex@main` (Codex
+CLI 0.137.0) and regenerated every wire type. The snapshot is now
+byte-identical to upstream. 31 definitions were added, 4 removed
+(`PermissionProfile`, `PermissionProfileFileSystemPermissions`,
+`PermissionProfileNetworkPermissions`, `ProfileV2`), and 40 definition
+bodies changed.
+
+- `TurnStartParams` gains a `client_user_message_id: Option<String>` field;
+  struct-literal construction must supply it.
+
+### Added
+
+Modeled the new protocol methods so schema coverage stays at 100%:
+
+- Client requests: `account/usage/read`, `permissionProfile/list`,
+  `plugin/installed`, `skills/extraRoots/set`, `thread/goal/get`,
+  `thread/goal/set`, `thread/goal/clear`.
+- Notifications: `thread/settings/updated` (`Notification::ThreadSettingsUpdated`)
+  and `turn/moderationMetadata` (`Notification::TurnModerationMetadata`).
+
 ## [0.129.3] - 2026-05-17
 
 ### Changed (breaking)

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.129.3"
+version = "0.137.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/README.md
+++ b/codex-codes/README.md
@@ -14,7 +14,7 @@ Part of the [rust-code-agent-sdks](https://github.com/meawoppl/rust-code-agent-s
 
 This crate provides type-safe Rust representations of the Codex CLI's JSON-RPC protocol, used by `codex app-server`. It includes optional sync and async clients for multi-turn conversations with the Codex agent.
 
-**Tested against:** Codex CLI 0.130.0
+**Tested against:** Codex CLI 0.137.0
 
 ## Installation
 
@@ -193,7 +193,7 @@ Discriminated union of agent action items (shared between exec and app-server):
 
 ## Compatibility
 
-**Tested against:** Codex CLI 0.130.0
+**Tested against:** Codex CLI 0.137.0
 
 The crate version tracks the Codex CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/codex-codes/examples/async_client.rs
+++ b/codex-codes/examples/async_client.rs
@@ -32,6 +32,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }],
             approval_policy: None,
             approvals_reviewer: None,
+            client_user_message_id: None,
             cwd: None,
             effort: None,
             model: None,

--- a/codex-codes/examples/basic_repl.rs
+++ b/codex-codes/examples/basic_repl.rs
@@ -51,6 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }],
                 approval_policy: None,
                 approvals_reviewer: None,
+                client_user_message_id: None,
                 cwd: None,
                 effort: None,
                 model: None,

--- a/codex-codes/examples/schema_coverage.rs
+++ b/codex-codes/examples/schema_coverage.rs
@@ -460,6 +460,8 @@ mod samples {
             methods::THREAD_REALTIME_TRANSCRIPT_DONE,
             methods::WINDOWS_WORLD_WRITABLE_WARNING,
             methods::WINDOWS_SANDBOX_SETUP_COMPLETED,
+            methods::THREAD_SETTINGS_UPDATED,
+            methods::TURN_MODERATION_METADATA,
         ]
         .into_iter()
         .collect()
@@ -546,6 +548,13 @@ mod samples {
             methods::CONFIGREQUIREMENTS_READ,
             methods::ACCOUNT_READ,
             methods::FUZZYFILESEARCH,
+            methods::ACCOUNT_USAGE_READ,
+            methods::PERMISSION_PROFILE_LIST,
+            methods::PLUGIN_INSTALLED,
+            methods::SKILLS_EXTRA_ROOTS_SET,
+            methods::THREAD_GOAL_GET,
+            methods::THREAD_GOAL_SET,
+            methods::THREAD_GOAL_CLEAR,
         ]
         .into_iter()
         .collect()

--- a/codex-codes/examples/sync_client.rs
+++ b/codex-codes/examples/sync_client.rs
@@ -30,6 +30,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }],
         approval_policy: None,
         approvals_reviewer: None,
+        client_user_message_id: None,
         cwd: None,
         effort: None,
         model: None,

--- a/codex-codes/src/lib.rs
+++ b/codex-codes/src/lib.rs
@@ -79,7 +79,7 @@
 //!
 //! The Codex CLI protocol is evolving. This crate automatically checks your
 //! installed CLI version and warns if it's newer than tested. Current tested
-//! version: **0.130.0**
+//! version: **0.137.0**
 //!
 //! Report compatibility issues at: <https://github.com/meawoppl/rust-code-agent-sdks/issues>
 //!

--- a/codex-codes/src/messages.rs
+++ b/codex-codes/src/messages.rs
@@ -47,11 +47,12 @@ use crate::protocol::{
     ThreadRealtimeErrorNotification, ThreadRealtimeItemAddedNotification,
     ThreadRealtimeOutputAudioDeltaNotification, ThreadRealtimeSdpNotification,
     ThreadRealtimeStartedNotification, ThreadRealtimeTranscriptDeltaNotification,
-    ThreadRealtimeTranscriptDoneNotification, ThreadStartedNotification,
-    ThreadStatusChangedNotification, ThreadTokenUsageUpdatedNotification,
-    ThreadUnarchivedNotification, TurnCompletedNotification, TurnDiffUpdatedNotification,
-    TurnPlanUpdatedNotification, TurnStartedNotification, WarningNotification,
-    WindowsSandboxSetupCompletedNotification, WindowsWorldWritableWarningNotification,
+    ThreadRealtimeTranscriptDoneNotification, ThreadSettingsUpdatedNotification,
+    ThreadStartedNotification, ThreadStatusChangedNotification,
+    ThreadTokenUsageUpdatedNotification, ThreadUnarchivedNotification, TurnCompletedNotification,
+    TurnDiffUpdatedNotification, TurnModerationMetadataNotification, TurnPlanUpdatedNotification,
+    TurnStartedNotification, WarningNotification, WindowsSandboxSetupCompletedNotification,
+    WindowsWorldWritableWarningNotification,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
@@ -189,6 +190,10 @@ pub enum Notification {
     WindowsWorldWritableWarning(WindowsWorldWritableWarningNotification),
     /// `windowsSandbox/setupCompleted`
     WindowsSandboxSetupCompleted(WindowsSandboxSetupCompletedNotification),
+    /// `thread/settings/updated`
+    ThreadSettingsUpdated(ThreadSettingsUpdatedNotification),
+    /// `turn/moderationMetadata`
+    TurnModerationMetadata(TurnModerationMetadataNotification),
     /// A method this crate version does not yet model. The raw params are
     /// preserved for caller inspection. Encountering this typically means
     /// the installed codex CLI is newer than the bindings.
@@ -273,6 +278,8 @@ impl Notification {
             Self::ThreadRealtimeTranscriptDone(_) => methods::THREAD_REALTIME_TRANSCRIPT_DONE,
             Self::WindowsWorldWritableWarning(_) => methods::WINDOWS_WORLD_WRITABLE_WARNING,
             Self::WindowsSandboxSetupCompleted(_) => methods::WINDOWS_SANDBOX_SETUP_COMPLETED,
+            Self::ThreadSettingsUpdated(_) => methods::THREAD_SETTINGS_UPDATED,
+            Self::TurnModerationMetadata(_) => methods::TURN_MODERATION_METADATA,
             Self::Unknown { method, .. } => method,
         }
     }
@@ -463,6 +470,12 @@ impl Notification {
             methods::WINDOWS_SANDBOX_SETUP_COMPLETED => {
                 serde_json::from_value(params_value).map(Self::WindowsSandboxSetupCompleted)
             }
+            methods::THREAD_SETTINGS_UPDATED => {
+                serde_json::from_value(params_value).map(Self::ThreadSettingsUpdated)
+            }
+            methods::TURN_MODERATION_METADATA => {
+                serde_json::from_value(params_value).map(Self::TurnModerationMetadata)
+            }
             _ => Ok(Self::Unknown {
                 method: method.to_string(),
                 params,
@@ -568,6 +581,8 @@ impl Notification {
             Self::WindowsSandboxSetupCompleted(v) => {
                 pack(methods::WINDOWS_SANDBOX_SETUP_COMPLETED, v)
             }
+            Self::ThreadSettingsUpdated(v) => pack(methods::THREAD_SETTINGS_UPDATED, v),
+            Self::TurnModerationMetadata(v) => pack(methods::TURN_MODERATION_METADATA, v),
             Self::Unknown { method, params } => Ok((method.clone(), params.clone())),
         }
     }

--- a/codex-codes/src/protocol.rs
+++ b/codex-codes/src/protocol.rs
@@ -104,6 +104,13 @@ pub mod methods {
     pub const CONFIGREQUIREMENTS_READ: &str = "configRequirements/read";
     pub const ACCOUNT_READ: &str = "account/read";
     pub const FUZZYFILESEARCH: &str = "fuzzyFileSearch";
+    pub const ACCOUNT_USAGE_READ: &str = "account/usage/read";
+    pub const PERMISSION_PROFILE_LIST: &str = "permissionProfile/list";
+    pub const PLUGIN_INSTALLED: &str = "plugin/installed";
+    pub const SKILLS_EXTRA_ROOTS_SET: &str = "skills/extraRoots/set";
+    pub const THREAD_GOAL_GET: &str = "thread/goal/get";
+    pub const THREAD_GOAL_SET: &str = "thread/goal/set";
+    pub const THREAD_GOAL_CLEAR: &str = "thread/goal/clear";
 
     // Server → client notifications
     pub const THREAD_STARTED: &str = "thread/started";
@@ -170,6 +177,8 @@ pub mod methods {
     pub const THREAD_REALTIME_TRANSCRIPT_DONE: &str = "thread/realtime/transcript/done";
     pub const WINDOWS_WORLD_WRITABLE_WARNING: &str = "windows/worldWritableWarning";
     pub const WINDOWS_SANDBOX_SETUP_COMPLETED: &str = "windowsSandbox/setupCompleted";
+    pub const THREAD_SETTINGS_UPDATED: &str = "thread/settings/updated";
+    pub const TURN_MODERATION_METADATA: &str = "turn/moderationMetadata";
 
     // Server → client requests (approval flow, v2 envelope)
     pub const CMD_EXEC_APPROVAL: &str = "item/commandExecution/requestApproval";

--- a/codex-codes/src/protocol_generated/samples.rs
+++ b/codex-codes/src/protocol_generated/samples.rs
@@ -120,7 +120,7 @@ pub fn server_notification_samples() -> Vec<(&'static str, Value)> {
         ),
         (
             "remoteControl/status/changed",
-            json!({"installationId": "x", "status": "disabled"}),
+            json!({"installationId": "x", "serverName": "x", "status": "disabled"}),
         ),
         (
             "serverRequest/resolved",
@@ -163,6 +163,10 @@ pub fn server_notification_samples() -> Vec<(&'static str, Value)> {
             json!({"role": "x", "text": "x", "threadId": "x"}),
         ),
         (
+            "thread/settings/updated",
+            json!({"threadId": "x", "threadSettings": {"approvalPolicy": "untrusted", "approvalsReviewer": "user", "collaborationMode": {"mode": "plan", "settings": {"model": "x"}}, "cwd": "x", "model": "x", "modelProvider": "x", "sandboxPolicy": {"type": "dangerFullAccess"}}}),
+        ),
+        (
             "thread/started",
             json!({"thread": {"cliVersion": "x", "createdAt": 0, "cwd": null, "ephemeral": false, "id": "x", "modelProvider": "x", "preview": "x", "sessionId": "x", "source": null, "status": null, "turns": [], "updatedAt": 0}}),
         ),
@@ -182,6 +186,10 @@ pub fn server_notification_samples() -> Vec<(&'static str, Value)> {
         (
             "turn/diff/updated",
             json!({"diff": "x", "threadId": "x", "turnId": "x"}),
+        ),
+        (
+            "turn/moderationMetadata",
+            json!({"metadata": null, "threadId": "x", "turnId": "x"}),
         ),
         (
             "turn/plan/updated",
@@ -218,6 +226,7 @@ pub fn client_request_samples() -> Vec<(&'static str, Value)> {
             "account/sendAddCreditsNudgeEmail",
             json!({"creditType": "credits"}),
         ),
+        ("account/usage/read", json!({})),
         ("app/list", json!({})),
         ("command/exec", json!({"command": []})),
         (
@@ -241,10 +250,7 @@ pub fn client_request_samples() -> Vec<(&'static str, Value)> {
         ("experimentalFeature/list", json!({})),
         ("externalAgentConfig/detect", json!({})),
         ("externalAgentConfig/import", json!({"migrationItems": []})),
-        (
-            "feedback/upload",
-            json!({"classification": "x", "includeLogs": false}),
-        ),
+        ("feedback/upload", json!({"classification": "x"})),
         (
             "fs/copy",
             json!({"destinationPath": null, "sourcePath": null}),
@@ -278,7 +284,9 @@ pub fn client_request_samples() -> Vec<(&'static str, Value)> {
         ("mcpServerStatus/list", json!({})),
         ("model/list", json!({})),
         ("modelProvider/capabilities/read", json!({})),
+        ("permissionProfile/list", json!({})),
         ("plugin/install", json!({"pluginName": "x"})),
+        ("plugin/installed", json!({})),
         ("plugin/list", json!({})),
         ("plugin/read", json!({"pluginName": "x"})),
         ("plugin/share/checkout", json!({"remotePluginId": "x"})),
@@ -299,6 +307,7 @@ pub fn client_request_samples() -> Vec<(&'static str, Value)> {
             json!({"target": {"type": "uncommittedChanges"}, "threadId": "x"}),
         ),
         ("skills/config/write", json!({"enabled": false})),
+        ("skills/extraRoots/set", json!({"extraRoots": []})),
         ("skills/list", json!({})),
         (
             "thread/approveGuardianDeniedAction",
@@ -307,6 +316,9 @@ pub fn client_request_samples() -> Vec<(&'static str, Value)> {
         ("thread/archive", json!({"threadId": "x"})),
         ("thread/compact/start", json!({"threadId": "x"})),
         ("thread/fork", json!({"threadId": "x"})),
+        ("thread/goal/clear", json!({"threadId": "x"})),
+        ("thread/goal/get", json!({"threadId": "x"})),
+        ("thread/goal/set", json!({"threadId": "x"})),
         ("thread/inject_items", json!({"items": [], "threadId": "x"})),
         ("thread/list", json!({})),
         ("thread/loaded/list", json!({})),

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -57,11 +57,64 @@ pub struct AccountRateLimitsUpdatedNotification {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct AccountTokenUsageDailyBucket {
+    #[serde(rename = "startDate", default)]
+    pub start_date: String,
+    #[serde(default)]
+    pub tokens: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountTokenUsageSummary {
+    #[serde(
+        rename = "currentStreakDays",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub current_streak_days: Option<i64>,
+    #[serde(
+        rename = "lifetimeTokens",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub lifetime_tokens: Option<i64>,
+    #[serde(
+        rename = "longestRunningTurnSec",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub longest_running_turn_sec: Option<i64>,
+    #[serde(
+        rename = "longestStreakDays",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub longest_streak_days: Option<i64>,
+    #[serde(
+        rename = "peakDailyTokens",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub peak_daily_tokens: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AccountUpdatedNotification {
     #[serde(rename = "authMode", default, skip_serializing_if = "Option::is_none")]
     pub auth_mode: Option<AuthMode>,
     #[serde(rename = "planType", default, skip_serializing_if = "Option::is_none")]
     pub plan_type: Option<PlanType>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivePermissionProfile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extends: Option<String>,
+    #[serde(default)]
+    pub id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -307,6 +360,43 @@ pub struct AppSummary {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct AppTemplateSummary {
+    #[serde(
+        rename = "canonicalConnectorId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub canonical_connector_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(rename = "logoUrl", default, skip_serializing_if = "Option::is_none")]
+    pub logo_url: Option<String>,
+    #[serde(
+        rename = "logoUrlDark",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub logo_url_dark: Option<String>,
+    #[serde(rename = "materializedAppIds", default)]
+    pub materialized_app_ids: Vec<String>,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<AppTemplateUnavailableReason>,
+    #[serde(rename = "templateId", default)]
+    pub template_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AppTemplateUnavailableReason {
+    #[serde(rename = "NOT_CONFIGURED_FOR_WORKSPACE")]
+    NOT_CONFIGURED_FOR_WORKSPACE,
+    #[serde(rename = "NO_ACTIVE_WORKSPACE")]
+    NO_ACTIVE_WORKSPACE,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApplyPatchApprovalParams {
     #[serde(rename = "callId", default)]
     pub call_id: String,
@@ -413,6 +503,16 @@ pub enum AuthMode {
     ChatgptAuthTokens,
     #[serde(rename = "agentIdentity")]
     AgentIdentity,
+    #[serde(rename = "personalAccessToken")]
+    PersonalAccessToken,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum AutoCompactTokenLimitScope {
+    #[serde(rename = "total")]
+    Total,
+    #[serde(rename = "body_after_prefix")]
+    BodyAfterPrefix,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -611,6 +711,15 @@ pub enum CollabAgentToolCallStatus {
     Completed,
     #[serde(rename = "failed")]
     Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CollaborationMode {
+    #[serde()]
+    pub mode: ModeKind,
+    #[serde()]
+    pub settings: Settings,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -911,6 +1020,17 @@ pub struct CommandMigration {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ComputerUseRequirements {
+    #[serde(
+        rename = "allowLockedComputerUse",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allow_locked_computer_use: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Config {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub analytics: Option<AnalyticsConfig>,
@@ -935,6 +1055,8 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_auto_compact_token_limit: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_auto_compact_token_limit_scope: Option<AutoCompactTokenLimitScope>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_context_window: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_provider: Option<String>,
@@ -944,10 +1066,6 @@ pub struct Config {
     pub model_reasoning_summary: Option<ReasoningSummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_verbosity: Option<Verbosity>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub profile: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub profiles: Option<std::collections::BTreeMap<String, ProfileV2>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub review_model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1030,6 +1148,11 @@ pub enum ConfigLayerSource {
     System {
         file: Value,
     },
+    #[serde(rename = "enterpriseManaged")]
+    EnterpriseManaged {
+        id: String,
+        name: String,
+    },
     User {
         file: Value,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1077,6 +1200,12 @@ pub struct ConfigReadResponse {
 #[serde(rename_all = "camelCase")]
 pub struct ConfigRequirements {
     #[serde(
+        rename = "allowAppshots",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allow_appshots: Option<bool>,
+    #[serde(
         rename = "allowManagedHooksOnly",
         default,
         skip_serializing_if = "Option::is_none"
@@ -1089,6 +1218,12 @@ pub struct ConfigRequirements {
     )]
     pub allowed_approval_policies: Option<Vec<AskForApproval>>,
     #[serde(
+        rename = "allowedPermissionProfiles",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allowed_permission_profiles: Option<std::collections::BTreeMap<String, bool>>,
+    #[serde(
         rename = "allowedSandboxModes",
         default,
         skip_serializing_if = "Option::is_none"
@@ -1100,6 +1235,24 @@ pub struct ConfigRequirements {
         skip_serializing_if = "Option::is_none"
     )]
     pub allowed_web_search_modes: Option<Vec<WebSearchMode>>,
+    #[serde(
+        rename = "allowedWindowsSandboxImplementations",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allowed_windows_sandbox_implementations: Option<Vec<WindowsSandboxSetupMode>>,
+    #[serde(
+        rename = "computerUse",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub computer_use: Option<ComputerUseRequirements>,
+    #[serde(
+        rename = "defaultPermissions",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub default_permissions: Option<String>,
     #[serde(
         rename = "enforceResidency",
         default,
@@ -1334,6 +1487,8 @@ pub struct ExperimentalFeatureListParams {
     pub cursor: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<i64>,
+    #[serde(rename = "threadId", default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1450,8 +1605,12 @@ pub struct FeedbackUploadParams {
         skip_serializing_if = "Option::is_none"
     )]
     pub extra_log_files: Option<Vec<String>>,
-    #[serde(rename = "includeLogs", default)]
-    pub include_logs: bool,
+    #[serde(
+        rename = "includeLogs",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub include_logs: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1551,8 +1710,8 @@ pub enum FileSystemAccessMode {
     Read,
     #[serde(rename = "write")]
     Write,
-    #[serde(rename = "none")]
-    None,
+    #[serde(rename = "deny")]
+    Deny,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1884,6 +2043,19 @@ pub struct GetAccountResponse {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct GetAccountTokenUsageResponse {
+    #[serde(
+        rename = "dailyUsageBuckets",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub daily_usage_buckets: Option<Vec<AccountTokenUsageDailyBucket>>,
+    #[serde()]
+    pub summary: AccountTokenUsageSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GitInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub branch: Option<String>,
@@ -2068,6 +2240,10 @@ pub enum HookEventName {
     SessionStart,
     #[serde(rename = "userPromptSubmit")]
     UserPromptSubmit,
+    #[serde(rename = "subagentStart")]
+    SubagentStart,
+    #[serde(rename = "subagentStop")]
+    SubagentStop,
     #[serde(rename = "stop")]
     Stop,
 }
@@ -2251,6 +2427,8 @@ pub enum HookSource {
     Plugin,
     #[serde(rename = "cloudRequirements")]
     CloudRequirements,
+    #[serde(rename = "cloudManagedConfig")]
+    CloudManagedConfig,
     #[serde(rename = "legacyManagedConfigFile")]
     LegacyManagedConfigFile,
     #[serde(rename = "legacyManagedConfigMdm")]
@@ -2307,6 +2485,18 @@ pub struct HooksListParams {
 pub struct HooksListResponse {
     #[serde(default)]
     pub data: Vec<HooksListEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ImageDetail {
+    #[serde(rename = "auto")]
+    Auto,
+    #[serde(rename = "low")]
+    Low,
+    #[serde(rename = "high")]
+    High,
+    #[serde(rename = "original")]
+    Original,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -2456,6 +2646,8 @@ pub struct ListMcpServerStatusParams {
     pub detail: Option<McpServerStatusDetail>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<i64>,
+    #[serde(rename = "threadId", default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -2952,6 +3144,27 @@ pub struct McpServerElicitationRequestResponse {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct McpServerInfo {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icons: Option<Vec<Value>>,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub version: String,
+    #[serde(
+        rename = "websiteUrl",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub website_url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct McpServerMigration {
     #[serde(default)]
     pub name: String,
@@ -3020,6 +3233,12 @@ pub struct McpServerStatus {
     pub resource_templates: Vec<ResourceTemplate>,
     #[serde(default)]
     pub resources: Vec<Resource>,
+    #[serde(
+        rename = "serverInfo",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub server_info: Option<McpServerInfo>,
     #[serde(default)]
     pub tools: std::collections::BTreeMap<String, Tool>,
 }
@@ -3179,6 +3398,14 @@ pub struct MigrationDetails {
     pub subagents: Option<Vec<SubagentMigration>>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ModeKind {
+    #[serde(rename = "plan")]
+    Plan,
+    #[serde(rename = "default")]
+    Default,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Model {
@@ -3196,6 +3423,12 @@ pub struct Model {
     pub availability_nux: Option<ModelAvailabilityNux>,
     #[serde(rename = "defaultReasoningEffort")]
     pub default_reasoning_effort: ReasoningEffort,
+    #[serde(
+        rename = "defaultServiceTier",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub default_service_tier: Option<String>,
     #[serde(default)]
     pub description: String,
     #[serde(rename = "displayName", default)]
@@ -3484,9 +3717,48 @@ pub enum PermissionGrantScope {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct PermissionProfileListParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionProfileListResponse {
+    #[serde(default)]
+    pub data: Vec<PermissionProfileSummary>,
+    #[serde(
+        rename = "nextCursor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionProfileSummary {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PermissionsRequestApprovalParams {
     #[serde()]
     pub cwd: AbsolutePathBuf,
+    #[serde(
+        rename = "environmentId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub environment_id: Option<String>,
     #[serde(rename = "itemId", default)]
     pub item_id: String,
     #[serde()]
@@ -3585,6 +3857,8 @@ pub enum PluginAvailability {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PluginDetail {
+    #[serde(rename = "appTemplates", default)]
+    pub app_templates: Vec<AppTemplateSummary>,
     #[serde(default)]
     pub apps: Vec<AppSummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3652,6 +3926,32 @@ pub struct PluginInstallResponse {
     pub apps_needing_auth: Vec<AppSummary>,
     #[serde(rename = "authPolicy")]
     pub auth_policy: PluginAuthPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginInstalledParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwds: Option<Vec<AbsolutePathBuf>>,
+    #[serde(
+        rename = "installSuggestionPluginNames",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub install_suggestion_plugin_names: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginInstalledResponse {
+    #[serde(
+        rename = "marketplaceLoadErrors",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub marketplace_load_errors: Option<Vec<MarketplaceLoadErrorInfo>>,
+    #[serde(default)]
+    pub marketplaces: Vec<PluginMarketplaceEntry>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -3741,6 +4041,8 @@ pub struct PluginInterface {
 pub enum PluginListMarketplaceKind {
     #[serde(rename = "local")]
     Local,
+    #[serde(rename = "vertical")]
+    Vertical,
     #[serde(rename = "workspace-directory")]
     Workspace_directory,
     #[serde(rename = "shared-with-me")]
@@ -4184,33 +4486,6 @@ pub enum ProcessOutputStream {
     Stderr,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ProfileV2 {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub approval_policy: Option<AskForApproval>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub approvals_reviewer: Option<ApprovalsReviewer>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub chatgpt_base_url: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model_provider: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model_reasoning_effort: Option<ReasoningEffort>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model_reasoning_summary: Option<ReasoningSummary>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model_verbosity: Option<Verbosity>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub service_tier: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tools: Option<ToolsV2>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub web_search: Option<WebSearchMode>,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum RateLimitReachedType {
     #[serde(rename = "rate_limit_reached")]
@@ -4230,6 +4505,12 @@ pub enum RateLimitReachedType {
 pub struct RateLimitSnapshot {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credits: Option<CreditsSnapshot>,
+    #[serde(
+        rename = "individualLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub individual_limit: Option<SpendControlLimitSnapshot>,
     #[serde(rename = "limitId", default, skip_serializing_if = "Option::is_none")]
     pub limit_id: Option<String>,
     #[serde(rename = "limitName", default, skip_serializing_if = "Option::is_none")]
@@ -4271,21 +4552,10 @@ pub enum RealtimeConversationVersion {
     V2,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum ReasoningEffort {
-    #[serde(rename = "none")]
-    None,
-    #[serde(rename = "minimal")]
-    Minimal,
-    #[serde(rename = "low")]
-    Low,
-    #[serde(rename = "medium")]
-    Medium,
-    #[serde(rename = "high")]
-    High,
-    #[serde(rename = "xhigh")]
-    Xhigh,
-}
+/// A non-empty reasoning effort value advertised by the model.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+pub struct ReasoningEffort(pub String);
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -4374,6 +4644,8 @@ pub struct RemoteControlStatusChangedNotification {
     pub environment_id: Option<String>,
     #[serde(rename = "installationId", default)]
     pub installation_id: String,
+    #[serde(rename = "serverName", default)]
+    pub server_name: String,
     #[serde()]
     pub status: RemoteControlConnectionStatus,
 }
@@ -4649,6 +4921,17 @@ pub enum SessionSource {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct Settings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub developer_instructions: Option<String>,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<ReasoningEffort>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SkillDependencies {
     #[serde(default)]
     pub tools: Vec<SkillToolDependency>,
@@ -4798,6 +5081,20 @@ pub struct SkillsConfigWriteResponse {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct SkillsExtraRootsSetParams {
+    #[serde(rename = "extraRoots", default)]
+    pub extra_roots: Vec<AbsolutePathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillsExtraRootsSetResponse {
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SkillsListEntry {
     #[serde(default)]
     pub cwd: String,
@@ -4833,6 +5130,19 @@ pub enum SortDirection {
     Asc,
     #[serde(rename = "desc")]
     Desc,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpendControlLimitSnapshot {
+    #[serde(default)]
+    pub limit: String,
+    #[serde(rename = "remainingPercent", default)]
+    pub remaining_percent: i64,
+    #[serde(rename = "resetsAt", default)]
+    pub resets_at: i64,
+    #[serde(default)]
+    pub used: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -4940,6 +5250,12 @@ pub struct Thread {
     pub model_provider: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(
+        rename = "parentThreadId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub parent_thread_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
     #[serde(default)]
@@ -5151,9 +5467,61 @@ pub struct ThreadGoal {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ThreadGoalClearParams {
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadGoalClearResponse {
+    #[serde(default)]
+    pub cleared: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ThreadGoalClearedNotification {
     #[serde(rename = "threadId", default)]
     pub thread_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadGoalGetParams {
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadGoalGetResponse {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub goal: Option<ThreadGoal>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadGoalSetParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub objective: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<ThreadGoalStatus>,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+    #[serde(
+        rename = "tokenBudget",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub token_budget: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadGoalSetResponse {
+    #[serde()]
+    pub goal: ThreadGoal,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -5162,6 +5530,10 @@ pub enum ThreadGoalStatus {
     Active,
     #[serde(rename = "paused")]
     Paused,
+    #[serde(rename = "blocked")]
+    Blocked,
+    #[serde(rename = "usageLimited")]
+    UsageLimited,
     #[serde(rename = "budgetLimited")]
     BudgetLimited,
     #[serde(rename = "complete")]
@@ -5204,6 +5576,8 @@ pub struct ThreadInjectItemsResponse {
 pub enum ThreadItem {
     #[serde(rename = "userMessage")]
     UserMessage {
+        #[serde(rename = "clientId", default, skip_serializing_if = "Option::is_none")]
+        client_id: Option<String>,
         content: Vec<UserInput>,
         id: String,
     },
@@ -5287,6 +5661,8 @@ pub enum ThreadItem {
             skip_serializing_if = "Option::is_none"
         )]
         mcp_app_resource_uri: Option<String>,
+        #[serde(rename = "pluginId", default, skip_serializing_if = "Option::is_none")]
+        plugin_id: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         result: Option<McpToolCallResult>,
         server: String,
@@ -5754,6 +6130,52 @@ pub struct ThreadSetNameParams {
 pub struct ThreadSetNameResponse {
     #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
     pub extra: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadSettings {
+    #[serde(
+        rename = "activePermissionProfile",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub active_permission_profile: Option<ActivePermissionProfile>,
+    #[serde(rename = "approvalPolicy")]
+    pub approval_policy: AskForApproval,
+    #[serde(rename = "approvalsReviewer")]
+    pub approvals_reviewer: ApprovalsReviewer,
+    #[serde(rename = "collaborationMode")]
+    pub collaboration_mode: CollaborationMode,
+    #[serde()]
+    pub cwd: AbsolutePathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<ReasoningEffort>,
+    #[serde(default)]
+    pub model: String,
+    #[serde(rename = "modelProvider", default)]
+    pub model_provider: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub personality: Option<Personality>,
+    #[serde(rename = "sandboxPolicy")]
+    pub sandbox_policy: SandboxPolicy,
+    #[serde(
+        rename = "serviceTier",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub service_tier: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<ReasoningSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadSettingsUpdatedNotification {
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+    #[serde(rename = "threadSettings")]
+    pub thread_settings: ThreadSettings,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -6227,6 +6649,17 @@ pub enum TurnItemsView {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct TurnModerationMetadataNotification {
+    #[serde(default)]
+    pub metadata: Value,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+    #[serde(rename = "turnId", default)]
+    pub turn_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TurnPlanStep {
     #[serde()]
     pub status: TurnPlanStepStatus,
@@ -6272,6 +6705,12 @@ pub struct TurnStartParams {
         skip_serializing_if = "Option::is_none"
     )]
     pub approvals_reviewer: Option<ApprovalsReviewer>,
+    #[serde(
+        rename = "clientUserMessageId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub client_user_message_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6337,6 +6776,12 @@ pub enum TurnStatus {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TurnSteerParams {
+    #[serde(
+        rename = "clientUserMessageId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub client_user_message_id: Option<String>,
     #[serde(rename = "expectedTurnId", default)]
     pub expected_turn_id: String,
     #[serde(default)]
@@ -6361,10 +6806,14 @@ pub enum UserInput {
         text_elements: Option<Vec<TextElement>>,
     },
     Image {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<ImageDetail>,
         url: String,
     },
     #[serde(rename = "localImage")]
     LocalImage {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<ImageDetail>,
         path: String,
     },
     Skill {

--- a/codex-codes/src/version.rs
+++ b/codex-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Codex CLI version we've tested against.
-const TESTED_VERSION: &str = "0.130.0";
+const TESTED_VERSION: &str = "0.137.0";
 
 /// Ensures version warning is only shown once per session.
 static VERSION_CHECK: Once = Once::new();

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -379,6 +379,78 @@
             },
             "method": {
               "enum": [
+                "thread/goal/set"
+              ],
+              "title": "Thread/goal/setRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadGoalSetParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/goal/setRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
+                "thread/goal/get"
+              ],
+              "title": "Thread/goal/getRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadGoalGetParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/goal/getRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
+                "thread/goal/clear"
+              ],
+              "title": "Thread/goal/clearRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadGoalClearParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/goal/clearRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
                 "thread/metadata/update"
               ],
               "title": "Thread/metadata/updateRequestMethod",
@@ -644,6 +716,30 @@
             },
             "method": {
               "enum": [
+                "skills/extraRoots/set"
+              ],
+              "title": "Skills/extraRoots/setRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/SkillsExtraRootsSetParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Skills/extraRoots/setRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
                 "hooks/list"
               ],
               "title": "Hooks/listRequestMethod",
@@ -755,6 +851,30 @@
             "params"
           ],
           "title": "Plugin/listRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
+                "plugin/installed"
+              ],
+              "title": "Plugin/installedRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/PluginInstalledParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Plugin/installedRequest",
           "type": "object"
         },
         {
@@ -1412,6 +1532,30 @@
             },
             "method": {
               "enum": [
+                "permissionProfile/list"
+              ],
+              "title": "PermissionProfile/listRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/PermissionProfileListParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "PermissionProfile/listRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
                 "experimentalFeature/enablement/set"
               ],
               "title": "ExperimentalFeature/enablement/setRequestMethod",
@@ -1687,6 +1831,29 @@
             "method"
           ],
           "title": "Account/rateLimits/readRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
+                "account/usage/read"
+              ],
+              "title": "Account/usage/readRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "type": "null"
+            }
+          },
+          "required": [
+            "id",
+            "method"
+          ],
+          "title": "Account/usage/readRequest",
           "type": "object"
         },
         {
@@ -3639,6 +3806,13 @@
         "cwd": {
           "$ref": "#/definitions/v2/AbsolutePathBuf"
         },
+        "environmentId": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "itemId": {
           "type": "string"
         },
@@ -4005,6 +4179,26 @@
             "params"
           ],
           "title": "Thread/goal/clearedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "thread/settings/updated"
+              ],
+              "title": "Thread/settings/updatedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadSettingsUpdatedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/settings/updatedNotification",
           "type": "object"
         },
         {
@@ -4731,6 +4925,26 @@
             "params"
           ],
           "title": "Model/verificationNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "turn/moderationMetadata"
+              ],
+              "title": "Turn/moderationMetadataNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/TurnModerationMetadataNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Turn/moderationMetadataNotification",
           "type": "object"
         },
         {
@@ -5556,6 +5770,7 @@
       },
       "AccountRateLimitsUpdatedNotification": {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "Sparse rolling rate-limit update.\n\nClients should merge available values into the most recent `account/rateLimits/read` response or refetch that snapshot. Nullable account metadata may be unavailable in a rolling update and does not clear a previously observed value.",
         "properties": {
           "rateLimits": {
             "$ref": "#/definitions/v2/RateLimitSnapshot"
@@ -5565,6 +5780,62 @@
           "rateLimits"
         ],
         "title": "AccountRateLimitsUpdatedNotification",
+        "type": "object"
+      },
+      "AccountTokenUsageDailyBucket": {
+        "properties": {
+          "startDate": {
+            "type": "string"
+          },
+          "tokens": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "startDate",
+          "tokens"
+        ],
+        "type": "object"
+      },
+      "AccountTokenUsageSummary": {
+        "properties": {
+          "currentStreakDays": {
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "lifetimeTokens": {
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "longestRunningTurnSec": {
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "longestStreakDays": {
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "peakDailyTokens": {
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
         "type": "object"
       },
       "AccountUpdatedNotification": {
@@ -5598,7 +5869,7 @@
         "properties": {
           "extends": {
             "default": null,
-            "description": "Parent profile identifier once permissions profiles support inheritance. This is currently always `null`.",
+            "description": "Parent profile identifier from the selected permissions profile's `extends` setting, when present.",
             "type": [
               "string",
               "null"
@@ -5625,6 +5896,28 @@
         "enum": [
           "sent",
           "cooldown_active"
+        ],
+        "type": "string"
+      },
+      "AdditionalContextEntry": {
+        "properties": {
+          "kind": {
+            "$ref": "#/definitions/v2/AdditionalContextKind"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "value"
+        ],
+        "type": "object"
+      },
+      "AdditionalContextKind": {
+        "enum": [
+          "untrusted",
+          "application"
         ],
         "type": "string"
       },
@@ -5706,6 +5999,30 @@
         "title": "AgentMessageDeltaNotification",
         "type": "object"
       },
+      "AgentMessageInputContent": {
+        "oneOf": [
+          {
+            "properties": {
+              "encrypted_content": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "encrypted_content"
+                ],
+                "title": "EncryptedContentAgentMessageInputContentType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "encrypted_content",
+              "type"
+            ],
+            "title": "EncryptedContentAgentMessageInputContent",
+            "type": "object"
+          }
+        ]
+      },
       "AgentPath": {
         "type": "string"
       },
@@ -5765,6 +6082,16 @@
       },
       "AppConfig": {
         "properties": {
+          "approvals_reviewer": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ApprovalsReviewer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "default_tools_approval_mode": {
             "anyOf": [
               {
@@ -6074,6 +6401,69 @@
         ],
         "type": "object"
       },
+      "AppTemplateSummary": {
+        "properties": {
+          "canonicalConnectorId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "logoUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "logoUrlDark": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "materializedAppIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/AppTemplateUnavailableReason"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "templateId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "materializedAppIds",
+          "name",
+          "templateId"
+        ],
+        "type": "object"
+      },
+      "AppTemplateUnavailableReason": {
+        "enum": [
+          "NOT_CONFIGURED_FOR_WORKSPACE",
+          "NO_ACTIVE_WORKSPACE"
+        ],
+        "type": "string"
+      },
       "AppToolApproval": {
         "enum": [
           "auto",
@@ -6285,6 +6675,32 @@
             "description": "Programmatic Codex auth backed by a registered Agent Identity.",
             "enum": [
               "agentIdentity"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Programmatic Codex auth backed by a personal access token.",
+            "enum": [
+              "personalAccessToken"
+            ],
+            "type": "string"
+          }
+        ]
+      },
+      "AutoCompactTokenLimitScope": {
+        "description": "Selects which part of the active context is charged against `model_auto_compact_token_limit`.",
+        "oneOf": [
+          {
+            "description": "Count the full active context against the limit.",
+            "enum": [
+              "total"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Count sampled output and later growth after the carried window prefix.",
+            "enum": [
+              "body_after_prefix"
             ],
             "type": "string"
           }
@@ -7046,6 +7462,17 @@
         ],
         "type": "object"
       },
+      "ComputerUseRequirements": {
+        "properties": {
+          "allowLockedComputerUse": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
       "Config": {
         "additionalProperties": true,
         "properties": {
@@ -7138,6 +7565,16 @@
               "null"
             ]
           },
+          "model_auto_compact_token_limit_scope": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/AutoCompactTokenLimitScope"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "model_context_window": {
             "format": "int64",
             "type": [
@@ -7180,19 +7617,6 @@
                 "type": "null"
               }
             ]
-          },
-          "profile": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "profiles": {
-            "additionalProperties": {
-              "$ref": "#/definitions/v2/ProfileV2"
-            },
-            "default": {},
-            "type": "object"
           },
           "review_model": {
             "type": [
@@ -7391,6 +7815,33 @@
             "type": "object"
           },
           {
+            "description": "Enterprise-managed config layer delivered by the cloud config bundle.",
+            "properties": {
+              "id": {
+                "description": "Stable identifier for the delivered layer.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Admin-facing name for the delivered layer. This is surfaced in diagnostics so users know which cloud layer needs administrator attention.",
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "enterpriseManaged"
+                ],
+                "title": "EnterpriseManagedConfigLayerSourceType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "type"
+            ],
+            "title": "EnterpriseManagedConfigLayerSource",
+            "type": "object"
+          },
+          {
             "description": "User config layer from $CODEX_HOME/config.toml. This layer is special in that it is expected to be: - writable by the user - generally outside the workspace directory",
             "properties": {
               "file": {
@@ -7511,7 +7962,6 @@
             ]
           },
           "includeLayers": {
-            "default": false,
             "type": "boolean"
           }
         },
@@ -7549,6 +7999,12 @@
       },
       "ConfigRequirements": {
         "properties": {
+          "allowAppshots": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "allowManagedHooksOnly": {
             "type": [
               "boolean",
@@ -7561,6 +8017,15 @@
             },
             "type": [
               "array",
+              "null"
+            ]
+          },
+          "allowedPermissionProfiles": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "type": [
+              "object",
               "null"
             ]
           },
@@ -7579,6 +8044,31 @@
             },
             "type": [
               "array",
+              "null"
+            ]
+          },
+          "allowedWindowsSandboxImplementations": {
+            "items": {
+              "$ref": "#/definitions/v2/WindowsSandboxSetupMode"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "computerUse": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ComputerUseRequirements"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "defaultPermissions": {
+            "type": [
+              "string",
               "null"
             ]
           },
@@ -8170,6 +8660,13 @@
               "integer",
               "null"
             ]
+          },
+          "threadId": {
+            "description": "Optional loaded thread id. Pass this when showing feature state for an existing thread so enablement is computed from that thread's refreshed config, including project-local config for the thread's cwd.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "title": "ExperimentalFeatureListParams",
@@ -8387,8 +8884,7 @@
           }
         },
         "required": [
-          "classification",
-          "includeLogs"
+          "classification"
         ],
         "title": "FeedbackUploadParams",
         "type": "object"
@@ -8464,7 +8960,7 @@
         "enum": [
           "read",
           "write",
-          "none"
+          "deny"
         ],
         "type": "string"
       },
@@ -9137,6 +9633,26 @@
             ],
             "title": "InputImageFunctionCallOutputContentItem",
             "type": "object"
+          },
+          {
+            "properties": {
+              "encrypted_content": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "encrypted_content"
+                ],
+                "title": "EncryptedContentFunctionCallOutputContentItemType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "encrypted_content",
+              "type"
+            ],
+            "title": "EncryptedContentFunctionCallOutputContentItem",
+            "type": "object"
           }
         ]
       },
@@ -9144,7 +9660,6 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
           "refreshToken": {
-            "default": false,
             "description": "When `true`, requests a proactive token refresh before returning.\n\nIn managed auth mode this triggers the normal refresh-token flow. In external auth mode this flag is ignored. Clients should refresh tokens themselves and call `account/login/start` with `chatgptAuthTokens`.",
             "type": "boolean"
           }
@@ -9201,6 +9716,28 @@
           "requiresOpenaiAuth"
         ],
         "title": "GetAccountResponse",
+        "type": "object"
+      },
+      "GetAccountTokenUsageResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "dailyUsageBuckets": {
+            "items": {
+              "$ref": "#/definitions/v2/AccountTokenUsageDailyBucket"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "summary": {
+            "$ref": "#/definitions/v2/AccountTokenUsageSummary"
+          }
+        },
+        "required": [
+          "summary"
+        ],
+        "title": "GetAccountTokenUsageResponse",
         "type": "object"
       },
       "GitInfo": {
@@ -9564,6 +10101,8 @@
           "postCompact",
           "sessionStart",
           "userPromptSubmit",
+          "subagentStart",
+          "subagentStop",
           "stop"
         ],
         "type": "string"
@@ -9818,6 +10357,7 @@
           "sessionFlags",
           "plugin",
           "cloudRequirements",
+          "cloudManagedConfig",
           "legacyManagedConfigFile",
           "legacyManagedConfigMdm",
           "unknown"
@@ -10125,6 +10665,12 @@
             "minimum": 0.0,
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "threadId": {
+            "type": [
+              "string",
               "null"
             ]
           }
@@ -10456,6 +11002,18 @@
             },
             "type": "array"
           },
+          "SubagentStart": {
+            "items": {
+              "$ref": "#/definitions/v2/ConfiguredHookMatcherGroup"
+            },
+            "type": "array"
+          },
+          "SubagentStop": {
+            "items": {
+              "$ref": "#/definitions/v2/ConfiguredHookMatcherGroup"
+            },
+            "type": "array"
+          },
           "UserPromptSubmit": {
             "items": {
               "$ref": "#/definitions/v2/ConfiguredHookMatcherGroup"
@@ -10483,6 +11041,8 @@
           "PreToolUse",
           "SessionStart",
           "Stop",
+          "SubagentStart",
+          "SubagentStop",
           "UserPromptSubmit"
         ],
         "type": "object"
@@ -10704,6 +11264,47 @@
         "title": "McpResourceReadResponse",
         "type": "object"
       },
+      "McpServerInfo": {
+        "description": "Presentation metadata advertised by an initialized MCP server.",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "icons": {
+            "items": true,
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "version": {
+            "type": "string"
+          },
+          "websiteUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "version"
+        ],
+        "type": "object"
+      },
       "McpServerMigration": {
         "properties": {
           "name": {
@@ -10813,6 +11414,16 @@
               "$ref": "#/definitions/v2/Resource"
             },
             "type": "array"
+          },
+          "serverInfo": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/McpServerInfo"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "tools": {
             "additionalProperties": {
@@ -11114,6 +11725,14 @@
           },
           "defaultReasoningEffort": {
             "$ref": "#/definitions/v2/ReasoningEffort"
+          },
+          "defaultServiceTier": {
+            "default": null,
+            "description": "Catalog default service tier id for this model, when one is configured.",
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "description": {
             "type": "string"
@@ -11526,7 +12145,7 @@
       "NetworkUnixSocketPermission": {
         "enum": [
           "allow",
-          "none"
+          "deny"
         ],
         "type": "string"
       },
@@ -11621,132 +12240,75 @@
           }
         ]
       },
-      "PermissionProfile": {
-        "oneOf": [
-          {
-            "description": "Codex owns sandbox construction for this profile.",
-            "properties": {
-              "fileSystem": {
-                "$ref": "#/definitions/v2/PermissionProfileFileSystemPermissions"
-              },
-              "network": {
-                "$ref": "#/definitions/v2/PermissionProfileNetworkPermissions"
-              },
-              "type": {
-                "enum": [
-                  "managed"
-                ],
-                "title": "ManagedPermissionProfileType",
-                "type": "string"
-              }
-            },
-            "required": [
-              "fileSystem",
-              "network",
-              "type"
-            ],
-            "title": "ManagedPermissionProfile",
-            "type": "object"
-          },
-          {
-            "description": "Do not apply an outer sandbox.",
-            "properties": {
-              "type": {
-                "enum": [
-                  "disabled"
-                ],
-                "title": "DisabledPermissionProfileType",
-                "type": "string"
-              }
-            },
-            "required": [
-              "type"
-            ],
-            "title": "DisabledPermissionProfile",
-            "type": "object"
-          },
-          {
-            "description": "Filesystem isolation is enforced by an external caller.",
-            "properties": {
-              "network": {
-                "$ref": "#/definitions/v2/PermissionProfileNetworkPermissions"
-              },
-              "type": {
-                "enum": [
-                  "external"
-                ],
-                "title": "ExternalPermissionProfileType",
-                "type": "string"
-              }
-            },
-            "required": [
-              "network",
-              "type"
-            ],
-            "title": "ExternalPermissionProfile",
-            "type": "object"
-          }
-        ]
-      },
-      "PermissionProfileFileSystemPermissions": {
-        "oneOf": [
-          {
-            "properties": {
-              "entries": {
-                "items": {
-                  "$ref": "#/definitions/v2/FileSystemSandboxEntry"
-                },
-                "type": "array"
-              },
-              "globScanMaxDepth": {
-                "format": "uint",
-                "minimum": 1.0,
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              },
-              "type": {
-                "enum": [
-                  "restricted"
-                ],
-                "title": "RestrictedPermissionProfileFileSystemPermissionsType",
-                "type": "string"
-              }
-            },
-            "required": [
-              "entries",
-              "type"
-            ],
-            "title": "RestrictedPermissionProfileFileSystemPermissions",
-            "type": "object"
-          },
-          {
-            "properties": {
-              "type": {
-                "enum": [
-                  "unrestricted"
-                ],
-                "title": "UnrestrictedPermissionProfileFileSystemPermissionsType",
-                "type": "string"
-              }
-            },
-            "required": [
-              "type"
-            ],
-            "title": "UnrestrictedPermissionProfileFileSystemPermissions",
-            "type": "object"
-          }
-        ]
-      },
-      "PermissionProfileNetworkPermissions": {
+      "PermissionProfileListParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
-          "enabled": {
-            "type": "boolean"
+          "cursor": {
+            "description": "Opaque pagination cursor returned by a previous call.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "cwd": {
+            "description": "Optional working directory to resolve project config layers.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "limit": {
+            "description": "Optional page size; defaults to the full result set.",
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "title": "PermissionProfileListParams",
+        "type": "object"
+      },
+      "PermissionProfileListResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/definitions/v2/PermissionProfileSummary"
+            },
+            "type": "array"
+          },
+          "nextCursor": {
+            "description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
-          "enabled"
+          "data"
+        ],
+        "title": "PermissionProfileListResponse",
+        "type": "object"
+      },
+      "PermissionProfileSummary": {
+        "properties": {
+          "description": {
+            "description": "Optional user-facing description for display in clients.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "description": "Available permission profile identifier.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
         ],
         "type": "object"
       },
@@ -11827,6 +12389,12 @@
       },
       "PluginDetail": {
         "properties": {
+          "appTemplates": {
+            "items": {
+              "$ref": "#/definitions/v2/AppTemplateSummary"
+            },
+            "type": "array"
+          },
           "apps": {
             "items": {
               "$ref": "#/definitions/v2/AppSummary"
@@ -11875,6 +12443,7 @@
           }
         },
         "required": [
+          "appTemplates",
           "apps",
           "hooks",
           "marketplaceName",
@@ -11954,6 +12523,56 @@
           "authPolicy"
         ],
         "title": "PluginInstallResponse",
+        "type": "object"
+      },
+      "PluginInstalledParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "cwds": {
+            "description": "Optional working directories used to discover repo marketplaces.",
+            "items": {
+              "$ref": "#/definitions/v2/AbsolutePathBuf"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "installSuggestionPluginNames": {
+            "description": "Additional uninstalled plugin names that should be returned when present locally. This is used by mention surfaces that intentionally expose install entrypoints.",
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "title": "PluginInstalledParams",
+        "type": "object"
+      },
+      "PluginInstalledResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "marketplaceLoadErrors": {
+            "default": [],
+            "items": {
+              "$ref": "#/definitions/v2/MarketplaceLoadErrorInfo"
+            },
+            "type": "array"
+          },
+          "marketplaces": {
+            "items": {
+              "$ref": "#/definitions/v2/PluginMarketplaceEntry"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "marketplaces"
+        ],
+        "title": "PluginInstalledResponse",
         "type": "object"
       },
       "PluginInterface": {
@@ -12089,6 +12708,7 @@
       "PluginListMarketplaceKind": {
         "enum": [
           "local",
+          "vertical",
           "workspace-directory",
           "shared-with-me"
         ],
@@ -12931,107 +13551,6 @@
         ],
         "type": "object"
       },
-      "ProfileV2": {
-        "additionalProperties": true,
-        "properties": {
-          "approval_policy": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/v2/AskForApproval"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "approvals_reviewer": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/v2/ApprovalsReviewer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "[UNSTABLE] Optional profile-level override for where approval requests are routed for review. If omitted, the enclosing config default is used."
-          },
-          "chatgpt_base_url": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "model": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "model_provider": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "model_reasoning_effort": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/v2/ReasoningEffort"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "model_reasoning_summary": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/v2/ReasoningSummary"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "model_verbosity": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/v2/Verbosity"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "service_tier": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "tools": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/v2/ToolsV2"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "web_search": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/v2/WebSearchMode"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "type": "object"
-      },
       "RateLimitReachedType": {
         "enum": [
           "rate_limit_reached",
@@ -13048,6 +13567,16 @@
             "anyOf": [
               {
                 "$ref": "#/definitions/v2/CreditsSnapshot"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "individualLimit": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/SpendControlLimitSnapshot"
               },
               {
                 "type": "null"
@@ -13224,15 +13753,8 @@
         "type": "object"
       },
       "ReasoningEffort": {
-        "description": "See https://platform.openai.com/docs/guides/reasoning?api-mode=responses#get-started-with-reasoning",
-        "enum": [
-          "none",
-          "minimal",
-          "low",
-          "medium",
-          "high",
-          "xhigh"
-        ],
+        "description": "A non-empty reasoning effort value advertised by the model.",
+        "minLength": 1,
         "type": "string"
       },
       "ReasoningEffortOption": {
@@ -13446,12 +13968,16 @@
           "installationId": {
             "type": "string"
           },
+          "serverName": {
+            "type": "string"
+          },
           "status": {
             "$ref": "#/definitions/v2/RemoteControlConnectionStatus"
           }
         },
         "required": [
           "installationId",
+          "serverName",
           "status"
         ],
         "title": "RemoteControlStatusChangedNotification",
@@ -13680,6 +14206,37 @@
               "type"
             ],
             "title": "MessageResponseItem",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "author": {
+                "type": "string"
+              },
+              "content": {
+                "items": {
+                  "$ref": "#/definitions/v2/AgentMessageInputContent"
+                },
+                "type": "array"
+              },
+              "recipient": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "agent_message"
+                ],
+                "title": "AgentMessageResponseItemType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "author",
+              "content",
+              "recipient",
+              "type"
+            ],
+            "title": "AgentMessageResponseItem",
             "type": "object"
           },
           {
@@ -14905,6 +15462,27 @@
         "title": "SkillsConfigWriteResponse",
         "type": "object"
       },
+      "SkillsExtraRootsSetParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "extraRoots": {
+            "items": {
+              "$ref": "#/definitions/v2/AbsolutePathBuf"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "extraRoots"
+        ],
+        "title": "SkillsExtraRootsSetParams",
+        "type": "object"
+      },
+      "SkillsExtraRootsSetResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "SkillsExtraRootsSetResponse",
+        "type": "object"
+      },
       "SkillsListEntry": {
         "properties": {
           "cwd": {
@@ -14970,6 +15548,31 @@
           "desc"
         ],
         "type": "string"
+      },
+      "SpendControlLimitSnapshot": {
+        "properties": {
+          "limit": {
+            "type": "string"
+          },
+          "remainingPercent": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "resetsAt": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "used": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "limit",
+          "remainingPercent",
+          "resetsAt",
+          "used"
+        ],
+        "type": "object"
       },
       "SubAgentSource": {
         "oneOf": [
@@ -15215,6 +15818,13 @@
               "null"
             ]
           },
+          "parentThreadId": {
+            "description": "The ID of the parent thread. This will only be set if this thread is a subagent.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "path": {
             "description": "[UNSTABLE] Path to the thread on disk.",
             "type": [
@@ -15379,7 +15989,7 @@
       },
       "ThreadForkParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "description": "There are two ways to fork a thread: 1. By thread_id: load the thread from disk by thread_id and fork it into a new thread. 2. By path: load the thread from disk by path and fork it into a new thread.\n\nIf using path, the thread_id param will be ignored.\n\nPrefer using thread_id whenever possible.",
+        "description": "There are two ways to fork a thread: 1. By thread_id: load the thread from disk by thread_id and fork it into a new thread. 2. By path: load the thread from disk by path and fork it into a new thread.\n\nIf using a non-empty path, the thread_id param will be ignored. Empty string path values are treated as absent.\n\nPrefer using thread_id whenever possible.",
         "properties": {
           "approvalPolicy": {
             "anyOf": [
@@ -15527,7 +16137,7 @@
                 "$ref": "#/definitions/v2/SandboxPolicy"
               }
             ],
-            "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `permissionProfile` when they need exact runtime permissions."
+            "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `activePermissionProfile` for profile provenance."
           },
           "serviceTier": {
             "type": [
@@ -15597,6 +16207,32 @@
         ],
         "type": "object"
       },
+      "ThreadGoalClearParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "threadId"
+        ],
+        "title": "ThreadGoalClearParams",
+        "type": "object"
+      },
+      "ThreadGoalClearResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "cleared": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "cleared"
+        ],
+        "title": "ThreadGoalClearResponse",
+        "type": "object"
+      },
       "ThreadGoalClearedNotification": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
@@ -15610,10 +16246,91 @@
         "title": "ThreadGoalClearedNotification",
         "type": "object"
       },
+      "ThreadGoalGetParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "threadId"
+        ],
+        "title": "ThreadGoalGetParams",
+        "type": "object"
+      },
+      "ThreadGoalGetResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "goal": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ThreadGoal"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "title": "ThreadGoalGetResponse",
+        "type": "object"
+      },
+      "ThreadGoalSetParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "objective": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ThreadGoalStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "tokenBudget": {
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "threadId"
+        ],
+        "title": "ThreadGoalSetParams",
+        "type": "object"
+      },
+      "ThreadGoalSetResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "goal": {
+            "$ref": "#/definitions/v2/ThreadGoal"
+          }
+        },
+        "required": [
+          "goal"
+        ],
+        "title": "ThreadGoalSetResponse",
+        "type": "object"
+      },
       "ThreadGoalStatus": {
         "enum": [
           "active",
           "paused",
+          "blocked",
+          "usageLimited",
           "budgetLimited",
           "complete"
         ],
@@ -15673,6 +16390,12 @@
         "oneOf": [
           {
             "properties": {
+              "clientId": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "content": {
                 "items": {
                   "$ref": "#/definitions/v2/UserInput"
@@ -15970,6 +16693,12 @@
                 "type": "string"
               },
               "mcpAppResourceUri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "pluginId": {
                 "type": [
                   "string",
                   "null"
@@ -16606,7 +17335,6 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
           "includeTurns": {
-            "default": false,
             "description": "When true, include turns and their items from rollout history.",
             "type": "boolean"
           },
@@ -16873,9 +17601,45 @@
         "title": "ThreadRealtimeTranscriptDoneNotification",
         "type": "object"
       },
+      "ThreadResumeInitialTurnsPageParams": {
+        "properties": {
+          "itemsView": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/TurnItemsView"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "How much item detail to include for each returned turn; defaults to summary."
+          },
+          "limit": {
+            "description": "Optional turn page size.",
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "sortDirection": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/SortDirection"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional turn pagination direction; defaults to descending."
+          }
+        },
+        "type": "object"
+      },
       "ThreadResumeParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "description": "There are three ways to resume a thread: 1. By thread_id: load the thread from disk by thread_id and resume it. 2. By history: instantiate the thread from memory and resume it. 3. By path: load the thread from disk by path and resume it.\n\nThe precedence is: history > path > thread_id. If using history or path, the thread_id param will be ignored.\n\nPrefer using thread_id whenever possible.",
+        "description": "There are three ways to resume a thread: 1. By thread_id: load the thread from disk by thread_id and resume it. 2. By history: instantiate the thread from memory and resume it. 3. By path: load the thread from disk by path and resume it.\n\nFor non-running threads, the precedence is: history > non-empty path > thread_id. If using history or a non-empty path for a non-running thread, the thread_id param will be ignored.\n\nIf thread_id identifies a running thread, app-server rejoins that thread and treats a non-empty path as a consistency check against the active rollout path. Empty string path values are treated as absent.\n\nPrefer using thread_id whenever possible.",
         "properties": {
           "approvalPolicy": {
             "anyOf": [
@@ -17019,7 +17783,7 @@
                 "$ref": "#/definitions/v2/SandboxPolicy"
               }
             ],
-            "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `permissionProfile` when they need exact runtime permissions."
+            "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `activePermissionProfile` for profile provenance."
           },
           "serviceTier": {
             "type": [
@@ -17081,6 +17845,21 @@
         "title": "ThreadRollbackResponse",
         "type": "object"
       },
+      "ThreadSearchResult": {
+        "properties": {
+          "snippet": {
+            "type": "string"
+          },
+          "thread": {
+            "$ref": "#/definitions/v2/Thread"
+          }
+        },
+        "required": [
+          "snippet",
+          "thread"
+        ],
+        "type": "object"
+      },
       "ThreadSetNameParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
@@ -17101,6 +17880,104 @@
       "ThreadSetNameResponse": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ThreadSetNameResponse",
+        "type": "object"
+      },
+      "ThreadSettings": {
+        "properties": {
+          "activePermissionProfile": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ActivePermissionProfile"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "approvalPolicy": {
+            "$ref": "#/definitions/v2/AskForApproval"
+          },
+          "approvalsReviewer": {
+            "$ref": "#/definitions/v2/ApprovalsReviewer"
+          },
+          "collaborationMode": {
+            "$ref": "#/definitions/v2/CollaborationMode"
+          },
+          "cwd": {
+            "$ref": "#/definitions/v2/AbsolutePathBuf"
+          },
+          "effort": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ReasoningEffort"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "model": {
+            "type": "string"
+          },
+          "modelProvider": {
+            "type": "string"
+          },
+          "personality": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/Personality"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sandboxPolicy": {
+            "$ref": "#/definitions/v2/SandboxPolicy"
+          },
+          "serviceTier": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ReasoningSummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "approvalPolicy",
+          "approvalsReviewer",
+          "collaborationMode",
+          "cwd",
+          "model",
+          "modelProvider",
+          "sandboxPolicy"
+        ],
+        "type": "object"
+      },
+      "ThreadSettingsUpdatedNotification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "threadId": {
+            "type": "string"
+          },
+          "threadSettings": {
+            "$ref": "#/definitions/v2/ThreadSettings"
+          }
+        },
+        "required": [
+          "threadId",
+          "threadSettings"
+        ],
+        "title": "ThreadSettingsUpdatedNotification",
         "type": "object"
       },
       "ThreadShellCommandParams": {
@@ -17327,7 +18204,7 @@
                 "$ref": "#/definitions/v2/SandboxPolicy"
               }
             ],
-            "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `permissionProfile` when they need exact runtime permissions."
+            "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `activePermissionProfile` for profile provenance."
           },
           "serviceTier": {
             "type": [
@@ -17858,6 +18735,25 @@
           }
         ]
       },
+      "TurnModerationMetadataNotification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "metadata": true,
+          "threadId": {
+            "type": "string"
+          },
+          "turnId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "metadata",
+          "threadId",
+          "turnId"
+        ],
+        "title": "TurnModerationMetadataNotification",
+        "type": "object"
+      },
       "TurnPlanStep": {
         "properties": {
           "status": {
@@ -17935,6 +18831,12 @@
               }
             ],
             "description": "Override where approval requests are routed for review on this turn and subsequent turns."
+          },
+          "clientUserMessageId": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "cwd": {
             "description": "Override the working directory for this turn and subsequent turns.",
@@ -18063,6 +18965,12 @@
       "TurnSteerParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
+          "clientUserMessageId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "expectedTurnId": {
             "description": "Required active turn id precondition. The request fails when it does not match the currently active turn.",
             "type": "string"
@@ -18098,6 +19006,32 @@
         "title": "TurnSteerResponse",
         "type": "object"
       },
+      "TurnsPage": {
+        "properties": {
+          "backwardsCursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "data": {
+            "items": {
+              "$ref": "#/definitions/v2/Turn"
+            },
+            "type": "array"
+          },
+          "nextCursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
       "UserInput": {
         "oneOf": [
           {
@@ -18130,6 +19064,17 @@
           },
           {
             "properties": {
+              "detail": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/v2/ImageDetail"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
               "type": {
                 "enum": [
                   "image"
@@ -18150,6 +19095,17 @@
           },
           {
             "properties": {
+              "detail": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/v2/ImageDetail"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
               "path": {
                 "type": "string"
               },

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -92,6 +92,7 @@
     },
     "AccountRateLimitsUpdatedNotification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "Sparse rolling rate-limit update.\n\nClients should merge available values into the most recent `account/rateLimits/read` response or refetch that snapshot. Nullable account metadata may be unavailable in a rolling update and does not clear a previously observed value.",
       "properties": {
         "rateLimits": {
           "$ref": "#/definitions/RateLimitSnapshot"
@@ -101,6 +102,62 @@
         "rateLimits"
       ],
       "title": "AccountRateLimitsUpdatedNotification",
+      "type": "object"
+    },
+    "AccountTokenUsageDailyBucket": {
+      "properties": {
+        "startDate": {
+          "type": "string"
+        },
+        "tokens": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "startDate",
+        "tokens"
+      ],
+      "type": "object"
+    },
+    "AccountTokenUsageSummary": {
+      "properties": {
+        "currentStreakDays": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "lifetimeTokens": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "longestRunningTurnSec": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "longestStreakDays": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "peakDailyTokens": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
       "type": "object"
     },
     "AccountUpdatedNotification": {
@@ -134,7 +191,7 @@
       "properties": {
         "extends": {
           "default": null,
-          "description": "Parent profile identifier once permissions profiles support inheritance. This is currently always `null`.",
+          "description": "Parent profile identifier from the selected permissions profile's `extends` setting, when present.",
           "type": [
             "string",
             "null"
@@ -161,6 +218,28 @@
       "enum": [
         "sent",
         "cooldown_active"
+      ],
+      "type": "string"
+    },
+    "AdditionalContextEntry": {
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/AdditionalContextKind"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "value"
+      ],
+      "type": "object"
+    },
+    "AdditionalContextKind": {
+      "enum": [
+        "untrusted",
+        "application"
       ],
       "type": "string"
     },
@@ -242,6 +321,30 @@
       "title": "AgentMessageDeltaNotification",
       "type": "object"
     },
+    "AgentMessageInputContent": {
+      "oneOf": [
+        {
+          "properties": {
+            "encrypted_content": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "encrypted_content"
+              ],
+              "title": "EncryptedContentAgentMessageInputContentType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "encrypted_content",
+            "type"
+          ],
+          "title": "EncryptedContentAgentMessageInputContent",
+          "type": "object"
+        }
+      ]
+    },
     "AgentPath": {
       "type": "string"
     },
@@ -301,6 +404,16 @@
     },
     "AppConfig": {
       "properties": {
+        "approvals_reviewer": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ApprovalsReviewer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "default_tools_approval_mode": {
           "anyOf": [
             {
@@ -610,6 +723,69 @@
       ],
       "type": "object"
     },
+    "AppTemplateSummary": {
+      "properties": {
+        "canonicalConnectorId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "logoUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "logoUrlDark": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "materializedAppIds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "reason": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AppTemplateUnavailableReason"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "templateId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "materializedAppIds",
+        "name",
+        "templateId"
+      ],
+      "type": "object"
+    },
+    "AppTemplateUnavailableReason": {
+      "enum": [
+        "NOT_CONFIGURED_FOR_WORKSPACE",
+        "NO_ACTIVE_WORKSPACE"
+      ],
+      "type": "string"
+    },
     "AppToolApproval": {
       "enum": [
         "auto",
@@ -821,6 +997,32 @@
           "description": "Programmatic Codex auth backed by a registered Agent Identity.",
           "enum": [
             "agentIdentity"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Programmatic Codex auth backed by a personal access token.",
+          "enum": [
+            "personalAccessToken"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "AutoCompactTokenLimitScope": {
+      "description": "Selects which part of the active context is charged against `model_auto_compact_token_limit`.",
+      "oneOf": [
+        {
+          "description": "Count the full active context against the limit.",
+          "enum": [
+            "total"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Count sampled output and later growth after the carried window prefix.",
+          "enum": [
+            "body_after_prefix"
           ],
           "type": "string"
         }
@@ -1077,6 +1279,78 @@
             "params"
           ],
           "title": "Thread/name/setRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
+                "thread/goal/set"
+              ],
+              "title": "Thread/goal/setRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadGoalSetParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/goal/setRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
+                "thread/goal/get"
+              ],
+              "title": "Thread/goal/getRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadGoalGetParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/goal/getRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
+                "thread/goal/clear"
+              ],
+              "title": "Thread/goal/clearRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadGoalClearParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/goal/clearRequest",
           "type": "object"
         },
         {
@@ -1351,6 +1625,30 @@
             },
             "method": {
               "enum": [
+                "skills/extraRoots/set"
+              ],
+              "title": "Skills/extraRoots/setRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/SkillsExtraRootsSetParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Skills/extraRoots/setRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
                 "hooks/list"
               ],
               "title": "Hooks/listRequestMethod",
@@ -1462,6 +1760,30 @@
             "params"
           ],
           "title": "Plugin/listRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
+                "plugin/installed"
+              ],
+              "title": "Plugin/installedRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/PluginInstalledParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Plugin/installedRequest",
           "type": "object"
         },
         {
@@ -2119,6 +2441,30 @@
             },
             "method": {
               "enum": [
+                "permissionProfile/list"
+              ],
+              "title": "PermissionProfile/listRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/PermissionProfileListParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "PermissionProfile/listRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
                 "experimentalFeature/enablement/set"
               ],
               "title": "ExperimentalFeature/enablement/setRequestMethod",
@@ -2394,6 +2740,29 @@
             "method"
           ],
           "title": "Account/rateLimits/readRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
+                "account/usage/read"
+              ],
+              "title": "Account/usage/readRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "type": "null"
+            }
+          },
+          "required": [
+            "id",
+            "method"
+          ],
+          "title": "Account/usage/readRequest",
           "type": "object"
         },
         {
@@ -3435,6 +3804,17 @@
       ],
       "type": "object"
     },
+    "ComputerUseRequirements": {
+      "properties": {
+        "allowLockedComputerUse": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "Config": {
       "additionalProperties": true,
       "properties": {
@@ -3527,6 +3907,16 @@
             "null"
           ]
         },
+        "model_auto_compact_token_limit_scope": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AutoCompactTokenLimitScope"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "model_context_window": {
           "format": "int64",
           "type": [
@@ -3569,19 +3959,6 @@
               "type": "null"
             }
           ]
-        },
-        "profile": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "profiles": {
-          "additionalProperties": {
-            "$ref": "#/definitions/ProfileV2"
-          },
-          "default": {},
-          "type": "object"
         },
         "review_model": {
           "type": [
@@ -3780,6 +4157,33 @@
           "type": "object"
         },
         {
+          "description": "Enterprise-managed config layer delivered by the cloud config bundle.",
+          "properties": {
+            "id": {
+              "description": "Stable identifier for the delivered layer.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Admin-facing name for the delivered layer. This is surfaced in diagnostics so users know which cloud layer needs administrator attention.",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "enterpriseManaged"
+              ],
+              "title": "EnterpriseManagedConfigLayerSourceType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "name",
+            "type"
+          ],
+          "title": "EnterpriseManagedConfigLayerSource",
+          "type": "object"
+        },
+        {
           "description": "User config layer from $CODEX_HOME/config.toml. This layer is special in that it is expected to be: - writable by the user - generally outside the workspace directory",
           "properties": {
             "file": {
@@ -3900,7 +4304,6 @@
           ]
         },
         "includeLayers": {
-          "default": false,
           "type": "boolean"
         }
       },
@@ -3938,6 +4341,12 @@
     },
     "ConfigRequirements": {
       "properties": {
+        "allowAppshots": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "allowManagedHooksOnly": {
           "type": [
             "boolean",
@@ -3950,6 +4359,15 @@
           },
           "type": [
             "array",
+            "null"
+          ]
+        },
+        "allowedPermissionProfiles": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "type": [
+            "object",
             "null"
           ]
         },
@@ -3968,6 +4386,31 @@
           },
           "type": [
             "array",
+            "null"
+          ]
+        },
+        "allowedWindowsSandboxImplementations": {
+          "items": {
+            "$ref": "#/definitions/WindowsSandboxSetupMode"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "computerUse": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputerUseRequirements"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "defaultPermissions": {
+          "type": [
+            "string",
             "null"
           ]
         },
@@ -4559,6 +5002,13 @@
             "integer",
             "null"
           ]
+        },
+        "threadId": {
+          "description": "Optional loaded thread id. Pass this when showing feature state for an existing thread so enablement is computed from that thread's refreshed config, including project-local config for the thread's cwd.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "title": "ExperimentalFeatureListParams",
@@ -4776,8 +5226,7 @@
         }
       },
       "required": [
-        "classification",
-        "includeLogs"
+        "classification"
       ],
       "title": "FeedbackUploadParams",
       "type": "object"
@@ -4853,7 +5302,7 @@
       "enum": [
         "read",
         "write",
-        "none"
+        "deny"
       ],
       "type": "string"
     },
@@ -5526,6 +5975,26 @@
           ],
           "title": "InputImageFunctionCallOutputContentItem",
           "type": "object"
+        },
+        {
+          "properties": {
+            "encrypted_content": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "encrypted_content"
+              ],
+              "title": "EncryptedContentFunctionCallOutputContentItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "encrypted_content",
+            "type"
+          ],
+          "title": "EncryptedContentFunctionCallOutputContentItem",
+          "type": "object"
         }
       ]
     },
@@ -5644,7 +6113,6 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
         "refreshToken": {
-          "default": false,
           "description": "When `true`, requests a proactive token refresh before returning.\n\nIn managed auth mode this triggers the normal refresh-token flow. In external auth mode this flag is ignored. Clients should refresh tokens themselves and call `account/login/start` with `chatgptAuthTokens`.",
           "type": "boolean"
         }
@@ -5701,6 +6169,28 @@
         "requiresOpenaiAuth"
       ],
       "title": "GetAccountResponse",
+      "type": "object"
+    },
+    "GetAccountTokenUsageResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "dailyUsageBuckets": {
+          "items": {
+            "$ref": "#/definitions/AccountTokenUsageDailyBucket"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "summary": {
+          "$ref": "#/definitions/AccountTokenUsageSummary"
+        }
+      },
+      "required": [
+        "summary"
+      ],
+      "title": "GetAccountTokenUsageResponse",
       "type": "object"
     },
     "GitInfo": {
@@ -6064,6 +6554,8 @@
         "postCompact",
         "sessionStart",
         "userPromptSubmit",
+        "subagentStart",
+        "subagentStop",
         "stop"
       ],
       "type": "string"
@@ -6318,6 +6810,7 @@
         "sessionFlags",
         "plugin",
         "cloudRequirements",
+        "cloudManagedConfig",
         "legacyManagedConfigFile",
         "legacyManagedConfigMdm",
         "unknown"
@@ -6676,6 +7169,12 @@
             "integer",
             "null"
           ]
+        },
+        "threadId": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "title": "ListMcpServerStatusParams",
@@ -7005,6 +7504,18 @@
           },
           "type": "array"
         },
+        "SubagentStart": {
+          "items": {
+            "$ref": "#/definitions/ConfiguredHookMatcherGroup"
+          },
+          "type": "array"
+        },
+        "SubagentStop": {
+          "items": {
+            "$ref": "#/definitions/ConfiguredHookMatcherGroup"
+          },
+          "type": "array"
+        },
         "UserPromptSubmit": {
           "items": {
             "$ref": "#/definitions/ConfiguredHookMatcherGroup"
@@ -7032,6 +7543,8 @@
         "PreToolUse",
         "SessionStart",
         "Stop",
+        "SubagentStart",
+        "SubagentStop",
         "UserPromptSubmit"
       ],
       "type": "object"
@@ -7253,6 +7766,47 @@
       "title": "McpResourceReadResponse",
       "type": "object"
     },
+    "McpServerInfo": {
+      "description": "Presentation metadata advertised by an initialized MCP server.",
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "icons": {
+          "items": true,
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "version": {
+          "type": "string"
+        },
+        "websiteUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ],
+      "type": "object"
+    },
     "McpServerMigration": {
       "properties": {
         "name": {
@@ -7362,6 +7916,16 @@
             "$ref": "#/definitions/Resource"
           },
           "type": "array"
+        },
+        "serverInfo": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/McpServerInfo"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "tools": {
           "additionalProperties": {
@@ -7663,6 +8227,14 @@
         },
         "defaultReasoningEffort": {
           "$ref": "#/definitions/ReasoningEffort"
+        },
+        "defaultServiceTier": {
+          "default": null,
+          "description": "Catalog default service tier id for this model, when one is configured.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "description": {
           "type": "string"
@@ -8075,7 +8647,7 @@
     "NetworkUnixSocketPermission": {
       "enum": [
         "allow",
-        "none"
+        "deny"
       ],
       "type": "string"
     },
@@ -8170,132 +8742,75 @@
         }
       ]
     },
-    "PermissionProfile": {
-      "oneOf": [
-        {
-          "description": "Codex owns sandbox construction for this profile.",
-          "properties": {
-            "fileSystem": {
-              "$ref": "#/definitions/PermissionProfileFileSystemPermissions"
-            },
-            "network": {
-              "$ref": "#/definitions/PermissionProfileNetworkPermissions"
-            },
-            "type": {
-              "enum": [
-                "managed"
-              ],
-              "title": "ManagedPermissionProfileType",
-              "type": "string"
-            }
-          },
-          "required": [
-            "fileSystem",
-            "network",
-            "type"
-          ],
-          "title": "ManagedPermissionProfile",
-          "type": "object"
-        },
-        {
-          "description": "Do not apply an outer sandbox.",
-          "properties": {
-            "type": {
-              "enum": [
-                "disabled"
-              ],
-              "title": "DisabledPermissionProfileType",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type"
-          ],
-          "title": "DisabledPermissionProfile",
-          "type": "object"
-        },
-        {
-          "description": "Filesystem isolation is enforced by an external caller.",
-          "properties": {
-            "network": {
-              "$ref": "#/definitions/PermissionProfileNetworkPermissions"
-            },
-            "type": {
-              "enum": [
-                "external"
-              ],
-              "title": "ExternalPermissionProfileType",
-              "type": "string"
-            }
-          },
-          "required": [
-            "network",
-            "type"
-          ],
-          "title": "ExternalPermissionProfile",
-          "type": "object"
-        }
-      ]
-    },
-    "PermissionProfileFileSystemPermissions": {
-      "oneOf": [
-        {
-          "properties": {
-            "entries": {
-              "items": {
-                "$ref": "#/definitions/FileSystemSandboxEntry"
-              },
-              "type": "array"
-            },
-            "globScanMaxDepth": {
-              "format": "uint",
-              "minimum": 1.0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "type": {
-              "enum": [
-                "restricted"
-              ],
-              "title": "RestrictedPermissionProfileFileSystemPermissionsType",
-              "type": "string"
-            }
-          },
-          "required": [
-            "entries",
-            "type"
-          ],
-          "title": "RestrictedPermissionProfileFileSystemPermissions",
-          "type": "object"
-        },
-        {
-          "properties": {
-            "type": {
-              "enum": [
-                "unrestricted"
-              ],
-              "title": "UnrestrictedPermissionProfileFileSystemPermissionsType",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type"
-          ],
-          "title": "UnrestrictedPermissionProfileFileSystemPermissions",
-          "type": "object"
-        }
-      ]
-    },
-    "PermissionProfileNetworkPermissions": {
+    "PermissionProfileListParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
-        "enabled": {
-          "type": "boolean"
+        "cursor": {
+          "description": "Opaque pagination cursor returned by a previous call.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cwd": {
+          "description": "Optional working directory to resolve project config layers.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "limit": {
+          "description": "Optional page size; defaults to the full result set.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "title": "PermissionProfileListParams",
+      "type": "object"
+    },
+    "PermissionProfileListResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/PermissionProfileSummary"
+          },
+          "type": "array"
+        },
+        "nextCursor": {
+          "description": "Opaque cursor to pass to the next call to continue after the last item. If None, there are no more items to return.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "enabled"
+        "data"
+      ],
+      "title": "PermissionProfileListResponse",
+      "type": "object"
+    },
+    "PermissionProfileSummary": {
+      "properties": {
+        "description": {
+          "description": "Optional user-facing description for display in clients.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "description": "Available permission profile identifier.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
       ],
       "type": "object"
     },
@@ -8376,6 +8891,12 @@
     },
     "PluginDetail": {
       "properties": {
+        "appTemplates": {
+          "items": {
+            "$ref": "#/definitions/AppTemplateSummary"
+          },
+          "type": "array"
+        },
         "apps": {
           "items": {
             "$ref": "#/definitions/AppSummary"
@@ -8424,6 +8945,7 @@
         }
       },
       "required": [
+        "appTemplates",
         "apps",
         "hooks",
         "marketplaceName",
@@ -8503,6 +9025,56 @@
         "authPolicy"
       ],
       "title": "PluginInstallResponse",
+      "type": "object"
+    },
+    "PluginInstalledParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "cwds": {
+          "description": "Optional working directories used to discover repo marketplaces.",
+          "items": {
+            "$ref": "#/definitions/AbsolutePathBuf"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "installSuggestionPluginNames": {
+          "description": "Additional uninstalled plugin names that should be returned when present locally. This is used by mention surfaces that intentionally expose install entrypoints.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "title": "PluginInstalledParams",
+      "type": "object"
+    },
+    "PluginInstalledResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "marketplaceLoadErrors": {
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/MarketplaceLoadErrorInfo"
+          },
+          "type": "array"
+        },
+        "marketplaces": {
+          "items": {
+            "$ref": "#/definitions/PluginMarketplaceEntry"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "marketplaces"
+      ],
+      "title": "PluginInstalledResponse",
       "type": "object"
     },
     "PluginInterface": {
@@ -8638,6 +9210,7 @@
     "PluginListMarketplaceKind": {
       "enum": [
         "local",
+        "vertical",
         "workspace-directory",
         "shared-with-me"
       ],
@@ -9480,107 +10053,6 @@
       ],
       "type": "object"
     },
-    "ProfileV2": {
-      "additionalProperties": true,
-      "properties": {
-        "approval_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/AskForApproval"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "approvals_reviewer": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ApprovalsReviewer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "[UNSTABLE] Optional profile-level override for where approval requests are routed for review. If omitted, the enclosing config default is used."
-        },
-        "chatgpt_base_url": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "model": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "model_provider": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "model_reasoning_effort": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ReasoningEffort"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "model_reasoning_summary": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ReasoningSummary"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "model_verbosity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Verbosity"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "service_tier": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tools": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ToolsV2"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "web_search": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/WebSearchMode"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "type": "object"
-    },
     "RateLimitReachedType": {
       "enum": [
         "rate_limit_reached",
@@ -9597,6 +10069,16 @@
           "anyOf": [
             {
               "$ref": "#/definitions/CreditsSnapshot"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "individualLimit": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SpendControlLimitSnapshot"
             },
             {
               "type": "null"
@@ -9773,15 +10255,8 @@
       "type": "object"
     },
     "ReasoningEffort": {
-      "description": "See https://platform.openai.com/docs/guides/reasoning?api-mode=responses#get-started-with-reasoning",
-      "enum": [
-        "none",
-        "minimal",
-        "low",
-        "medium",
-        "high",
-        "xhigh"
-      ],
+      "description": "A non-empty reasoning effort value advertised by the model.",
+      "minLength": 1,
       "type": "string"
     },
     "ReasoningEffortOption": {
@@ -9995,12 +10470,16 @@
         "installationId": {
           "type": "string"
         },
+        "serverName": {
+          "type": "string"
+        },
         "status": {
           "$ref": "#/definitions/RemoteControlConnectionStatus"
         }
       },
       "required": [
         "installationId",
+        "serverName",
         "status"
       ],
       "title": "RemoteControlStatusChangedNotification",
@@ -10229,6 +10708,37 @@
             "type"
           ],
           "title": "MessageResponseItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "author": {
+              "type": "string"
+            },
+            "content": {
+              "items": {
+                "$ref": "#/definitions/AgentMessageInputContent"
+              },
+              "type": "array"
+            },
+            "recipient": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "agent_message"
+              ],
+              "title": "AgentMessageResponseItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "author",
+            "content",
+            "recipient",
+            "type"
+          ],
+          "title": "AgentMessageResponseItem",
           "type": "object"
         },
         {
@@ -11282,6 +11792,26 @@
           "properties": {
             "method": {
               "enum": [
+                "thread/settings/updated"
+              ],
+              "title": "Thread/settings/updatedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadSettingsUpdatedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/settings/updatedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
                 "thread/tokenUsage/updated"
               ],
               "title": "Thread/tokenUsage/updatedNotificationMethod",
@@ -12002,6 +12532,26 @@
             "params"
           ],
           "title": "Model/verificationNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "turn/moderationMetadata"
+              ],
+              "title": "Turn/moderationMetadataNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/TurnModerationMetadataNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Turn/moderationMetadataNotification",
           "type": "object"
         },
         {
@@ -12729,6 +13279,27 @@
       "title": "SkillsConfigWriteResponse",
       "type": "object"
     },
+    "SkillsExtraRootsSetParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "extraRoots": {
+          "items": {
+            "$ref": "#/definitions/AbsolutePathBuf"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "extraRoots"
+      ],
+      "title": "SkillsExtraRootsSetParams",
+      "type": "object"
+    },
+    "SkillsExtraRootsSetResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "SkillsExtraRootsSetResponse",
+      "type": "object"
+    },
     "SkillsListEntry": {
       "properties": {
         "cwd": {
@@ -12794,6 +13365,31 @@
         "desc"
       ],
       "type": "string"
+    },
+    "SpendControlLimitSnapshot": {
+      "properties": {
+        "limit": {
+          "type": "string"
+        },
+        "remainingPercent": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "resetsAt": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "used": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "limit",
+        "remainingPercent",
+        "resetsAt",
+        "used"
+      ],
+      "type": "object"
     },
     "SubAgentSource": {
       "oneOf": [
@@ -13039,6 +13635,13 @@
             "null"
           ]
         },
+        "parentThreadId": {
+          "description": "The ID of the parent thread. This will only be set if this thread is a subagent.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "path": {
           "description": "[UNSTABLE] Path to the thread on disk.",
           "type": [
@@ -13203,7 +13806,7 @@
     },
     "ThreadForkParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "description": "There are two ways to fork a thread: 1. By thread_id: load the thread from disk by thread_id and fork it into a new thread. 2. By path: load the thread from disk by path and fork it into a new thread.\n\nIf using path, the thread_id param will be ignored.\n\nPrefer using thread_id whenever possible.",
+      "description": "There are two ways to fork a thread: 1. By thread_id: load the thread from disk by thread_id and fork it into a new thread. 2. By path: load the thread from disk by path and fork it into a new thread.\n\nIf using a non-empty path, the thread_id param will be ignored. Empty string path values are treated as absent.\n\nPrefer using thread_id whenever possible.",
       "properties": {
         "approvalPolicy": {
           "anyOf": [
@@ -13351,7 +13954,7 @@
               "$ref": "#/definitions/SandboxPolicy"
             }
           ],
-          "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `permissionProfile` when they need exact runtime permissions."
+          "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `activePermissionProfile` for profile provenance."
         },
         "serviceTier": {
           "type": [
@@ -13421,6 +14024,32 @@
       ],
       "type": "object"
     },
+    "ThreadGoalClearParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId"
+      ],
+      "title": "ThreadGoalClearParams",
+      "type": "object"
+    },
+    "ThreadGoalClearResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "cleared": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "cleared"
+      ],
+      "title": "ThreadGoalClearResponse",
+      "type": "object"
+    },
     "ThreadGoalClearedNotification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
@@ -13434,10 +14063,91 @@
       "title": "ThreadGoalClearedNotification",
       "type": "object"
     },
+    "ThreadGoalGetParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId"
+      ],
+      "title": "ThreadGoalGetParams",
+      "type": "object"
+    },
+    "ThreadGoalGetResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "goal": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadGoal"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "title": "ThreadGoalGetResponse",
+      "type": "object"
+    },
+    "ThreadGoalSetParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "objective": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadGoalStatus"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "tokenBudget": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "threadId"
+      ],
+      "title": "ThreadGoalSetParams",
+      "type": "object"
+    },
+    "ThreadGoalSetResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "goal": {
+          "$ref": "#/definitions/ThreadGoal"
+        }
+      },
+      "required": [
+        "goal"
+      ],
+      "title": "ThreadGoalSetResponse",
+      "type": "object"
+    },
     "ThreadGoalStatus": {
       "enum": [
         "active",
         "paused",
+        "blocked",
+        "usageLimited",
         "budgetLimited",
         "complete"
       ],
@@ -13497,6 +14207,12 @@
       "oneOf": [
         {
           "properties": {
+            "clientId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "content": {
               "items": {
                 "$ref": "#/definitions/UserInput"
@@ -13794,6 +14510,12 @@
               "type": "string"
             },
             "mcpAppResourceUri": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pluginId": {
               "type": [
                 "string",
                 "null"
@@ -14430,7 +15152,6 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
         "includeTurns": {
-          "default": false,
           "description": "When true, include turns and their items from rollout history.",
           "type": "boolean"
         },
@@ -14697,9 +15418,45 @@
       "title": "ThreadRealtimeTranscriptDoneNotification",
       "type": "object"
     },
+    "ThreadResumeInitialTurnsPageParams": {
+      "properties": {
+        "itemsView": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TurnItemsView"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How much item detail to include for each returned turn; defaults to summary."
+        },
+        "limit": {
+          "description": "Optional turn page size.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "sortDirection": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SortDirection"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional turn pagination direction; defaults to descending."
+        }
+      },
+      "type": "object"
+    },
     "ThreadResumeParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "description": "There are three ways to resume a thread: 1. By thread_id: load the thread from disk by thread_id and resume it. 2. By history: instantiate the thread from memory and resume it. 3. By path: load the thread from disk by path and resume it.\n\nThe precedence is: history > path > thread_id. If using history or path, the thread_id param will be ignored.\n\nPrefer using thread_id whenever possible.",
+      "description": "There are three ways to resume a thread: 1. By thread_id: load the thread from disk by thread_id and resume it. 2. By history: instantiate the thread from memory and resume it. 3. By path: load the thread from disk by path and resume it.\n\nFor non-running threads, the precedence is: history > non-empty path > thread_id. If using history or a non-empty path for a non-running thread, the thread_id param will be ignored.\n\nIf thread_id identifies a running thread, app-server rejoins that thread and treats a non-empty path as a consistency check against the active rollout path. Empty string path values are treated as absent.\n\nPrefer using thread_id whenever possible.",
       "properties": {
         "approvalPolicy": {
           "anyOf": [
@@ -14843,7 +15600,7 @@
               "$ref": "#/definitions/SandboxPolicy"
             }
           ],
-          "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `permissionProfile` when they need exact runtime permissions."
+          "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `activePermissionProfile` for profile provenance."
         },
         "serviceTier": {
           "type": [
@@ -14905,6 +15662,21 @@
       "title": "ThreadRollbackResponse",
       "type": "object"
     },
+    "ThreadSearchResult": {
+      "properties": {
+        "snippet": {
+          "type": "string"
+        },
+        "thread": {
+          "$ref": "#/definitions/Thread"
+        }
+      },
+      "required": [
+        "snippet",
+        "thread"
+      ],
+      "type": "object"
+    },
     "ThreadSetNameParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
@@ -14925,6 +15697,104 @@
     "ThreadSetNameResponse": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ThreadSetNameResponse",
+      "type": "object"
+    },
+    "ThreadSettings": {
+      "properties": {
+        "activePermissionProfile": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ActivePermissionProfile"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "approvalPolicy": {
+          "$ref": "#/definitions/AskForApproval"
+        },
+        "approvalsReviewer": {
+          "$ref": "#/definitions/ApprovalsReviewer"
+        },
+        "collaborationMode": {
+          "$ref": "#/definitions/CollaborationMode"
+        },
+        "cwd": {
+          "$ref": "#/definitions/AbsolutePathBuf"
+        },
+        "effort": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ReasoningEffort"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "model": {
+          "type": "string"
+        },
+        "modelProvider": {
+          "type": "string"
+        },
+        "personality": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Personality"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sandboxPolicy": {
+          "$ref": "#/definitions/SandboxPolicy"
+        },
+        "serviceTier": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "summary": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ReasoningSummary"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "approvalPolicy",
+        "approvalsReviewer",
+        "collaborationMode",
+        "cwd",
+        "model",
+        "modelProvider",
+        "sandboxPolicy"
+      ],
+      "type": "object"
+    },
+    "ThreadSettingsUpdatedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "threadId": {
+          "type": "string"
+        },
+        "threadSettings": {
+          "$ref": "#/definitions/ThreadSettings"
+        }
+      },
+      "required": [
+        "threadId",
+        "threadSettings"
+      ],
+      "title": "ThreadSettingsUpdatedNotification",
       "type": "object"
     },
     "ThreadShellCommandParams": {
@@ -15151,7 +16021,7 @@
               "$ref": "#/definitions/SandboxPolicy"
             }
           ],
-          "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `permissionProfile` when they need exact runtime permissions."
+          "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer `activePermissionProfile` for profile provenance."
         },
         "serviceTier": {
           "type": [
@@ -15682,6 +16552,25 @@
         }
       ]
     },
+    "TurnModerationMetadataNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "metadata": true,
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "metadata",
+        "threadId",
+        "turnId"
+      ],
+      "title": "TurnModerationMetadataNotification",
+      "type": "object"
+    },
     "TurnPlanStep": {
       "properties": {
         "status": {
@@ -15759,6 +16648,12 @@
             }
           ],
           "description": "Override where approval requests are routed for review on this turn and subsequent turns."
+        },
+        "clientUserMessageId": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "cwd": {
           "description": "Override the working directory for this turn and subsequent turns.",
@@ -15887,6 +16782,12 @@
     "TurnSteerParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
+        "clientUserMessageId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "expectedTurnId": {
           "description": "Required active turn id precondition. The request fails when it does not match the currently active turn.",
           "type": "string"
@@ -15922,6 +16823,32 @@
       "title": "TurnSteerResponse",
       "type": "object"
     },
+    "TurnsPage": {
+      "properties": {
+        "backwardsCursor": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "data": {
+          "items": {
+            "$ref": "#/definitions/Turn"
+          },
+          "type": "array"
+        },
+        "nextCursor": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "type": "object"
+    },
     "UserInput": {
       "oneOf": [
         {
@@ -15954,6 +16881,17 @@
         },
         {
           "properties": {
+            "detail": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ImageDetail"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
             "type": {
               "enum": [
                 "image"
@@ -15974,6 +16912,17 @@
         },
         {
           "properties": {
+            "detail": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ImageDetail"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
             "path": {
               "type": "string"
             },


### PR DESCRIPTION
Resolves #137.

Re-snapshots the Codex app-server schema from `openai/codex@main` (Codex CLI 0.137.0) and regenerates every wire type. Both snapshot files are now **byte-identical to upstream** (drift check exits 0).

## Schema drift absorbed
- **31** definitions added, **4** removed (`PermissionProfile`, `PermissionProfileFileSystemPermissions`, `PermissionProfileNetworkPermissions`, `ProfileV2`), **40** bodies changed.
- `TurnStartParams` gains `client_user_message_id: Option<String>` — the bundled examples were updated to supply it.

## New methods modeled (coverage stays 100%)
- **Client requests:** `account/usage/read`, `permissionProfile/list`, `plugin/installed`, `skills/extraRoots/set`, `thread/goal/{get,set,clear}`
- **Notifications:** `thread/settings/updated` → `Notification::ThreadSettingsUpdated`, `turn/moderationMetadata` → `Notification::TurnModerationMetadata` (full enum variants + envelope round-trip, not just registry entries)

## Verification
- `cargo run --example schema_coverage` → **158/158 modeled (100%)**, 158/158 with sample, 0 drift
- `scripts/check_codex_schema_drift.py` → byte-identical to upstream, exit 0
- `cargo test -p codex-codes` → all pass; examples build
- Version bumped 0.129.3 → 0.137.0; CHANGELOG, README, `version.rs` `TESTED_VERSION`, and lib doc updated