### PR TITLE
codex-codes: typed thread_resume and thread_fork helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.137.0"
+version = "0.137.1"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version mirrors the Claude CLI version it has been tested against. For example, `claude-codes 2.1.150` is tested against Claude CLI `2.1.150`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.137.0`, tested against Codex CLI `0.137.0`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.137.1`, tested against Codex CLI `0.137.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.
 

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.137.1] - 2026-06-08
+
+### Added
+
+Typed client helpers mirroring `thread_start`, so callers no longer need to
+drop down to the low-level `request::<P, R>` primitive:
+
+- `AsyncClient::thread_resume` / `SyncClient::thread_resume` (`thread/resume`)
+- `AsyncClient::thread_fork` / `SyncClient::thread_fork` (`thread/fork`)
+
 ## [0.137.0] - 2026-06-07
 
 ### Changed (breaking)

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.137.0"
+version = "0.137.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/src/client_async.rs
+++ b/codex-codes/src/client_async.rs
@@ -50,6 +50,7 @@ use crate::jsonrpc::{
 use crate::messages::{Notification, ServerMessage, ServerRequest};
 use crate::protocol::{
     ClientInfo, InitializeParams, InitializeResponse, ThreadArchiveParams, ThreadArchiveResponse,
+    ThreadForkParams, ThreadForkResponse, ThreadResumeParams, ThreadResumeResponse,
     ThreadStartParams, ThreadStartResponse, TurnInterruptParams, TurnInterruptResponse,
     TurnStartParams, TurnStartResponse,
 };
@@ -244,6 +245,23 @@ impl AsyncClient {
         params: &ThreadStartParams,
     ) -> Result<ThreadStartResponse> {
         self.request(crate::protocol::methods::THREAD_START, params)
+            .await
+    }
+
+    /// Resume a previously persisted thread by id.
+    ///
+    /// Replays the thread's history so turns can continue where they left off.
+    pub async fn thread_resume(
+        &mut self,
+        params: &ThreadResumeParams,
+    ) -> Result<ThreadResumeResponse> {
+        self.request(crate::protocol::methods::THREAD_RESUME, params)
+            .await
+    }
+
+    /// Fork an existing thread into a new independent thread.
+    pub async fn thread_fork(&mut self, params: &ThreadForkParams) -> Result<ThreadForkResponse> {
+        self.request(crate::protocol::methods::THREAD_FORK, params)
             .await
     }
 

--- a/codex-codes/src/client_sync.rs
+++ b/codex-codes/src/client_sync.rs
@@ -50,6 +50,7 @@ use crate::jsonrpc::{
 use crate::messages::{Notification, ServerMessage, ServerRequest};
 use crate::protocol::{
     ClientInfo, InitializeParams, InitializeResponse, ThreadArchiveParams, ThreadArchiveResponse,
+    ThreadForkParams, ThreadForkResponse, ThreadResumeParams, ThreadResumeResponse,
     ThreadStartParams, ThreadStartResponse, TurnInterruptParams, TurnInterruptResponse,
     TurnStartParams, TurnStartResponse,
 };
@@ -234,6 +235,18 @@ impl SyncClient {
     /// [`ThreadStartResponse`] contains the `thread_id` needed for subsequent calls.
     pub fn thread_start(&mut self, params: &ThreadStartParams) -> Result<ThreadStartResponse> {
         self.request(crate::protocol::methods::THREAD_START, params)
+    }
+
+    /// Resume a previously persisted thread by id.
+    ///
+    /// Replays the thread's history so turns can continue where they left off.
+    pub fn thread_resume(&mut self, params: &ThreadResumeParams) -> Result<ThreadResumeResponse> {
+        self.request(crate::protocol::methods::THREAD_RESUME, params)
+    }
+
+    /// Fork an existing thread into a new independent thread.
+    pub fn thread_fork(&mut self, params: &ThreadForkParams) -> Result<ThreadForkResponse> {
+        self.request(crate::protocol::methods::THREAD_FORK, params)
     }
 
     /// Start a new turn within a thread.


### PR DESCRIPTION
Closes #144.

Adds typed client helpers for `thread/resume` and `thread/fork`, mirroring the existing `thread_start` shape. The params/response types and method constants already existed; this just adds the thin discoverable wrappers so callers no longer drop down to the low-level `request::<P, R>` primitive.

## Added
- `AsyncClient::thread_resume` / `SyncClient::thread_resume` → `thread/resume`
- `AsyncClient::thread_fork` / `SyncClient::thread_fork` → `thread/fork`

(`thread_fork` bundled in per the issue's explicit invitation.)

## Verification
- `cargo test -p codex-codes` — all pass
- `cargo fmt` clean; version-consistency strings updated
- Version bumped 0.137.0 → 0.137.1 (additive); CHANGELOG + root README updated