### PR TITLE
claude-codes: typed model_usage map on ResultMessage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.152"
+version = "2.1.153"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.152`, tested against Claude CLI `2.1.150`.
+- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.153`, tested against Claude CLI `2.1.150`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.137.1`, tested against Codex CLI `0.137.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.153] - 2026-06-08
+
+### Changed (breaking)
+
+- **`ResultMessage::model_usage`** is now
+  `Option<BTreeMap<String, ModelUsageEntry>>` instead of
+  `Option<serde_json::Value>`. Consumers read typed per-model usage
+  (`input_tokens`, `output_tokens`, `cache_read_input_tokens`,
+  `cache_creation_input_tokens`, `cost_usd`, `web_search_requests`)
+  keyed by model name, instead of poking the `Value`. Unmodeled wire
+  keys are preserved in `ModelUsageEntry::extra`.
+
+### Added
+
+- **`ModelUsageEntry`** — typed per-model usage/cost record (re-exported
+  from `claude_codes::io`).
+
 ## [2.1.152] - 2026-06-08
 
 ### Added

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.152"
+version = "2.1.153"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/src/io/result.rs
+++ b/claude-codes/src/io/result.rs
@@ -49,9 +49,33 @@ pub struct ResultMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fast_mode_state: Option<String>,
 
-    /// Per-model cost breakdown, keyed by model name
+    /// Per-model cost breakdown, keyed by model name (e.g. `"claude-opus-4-8"`).
     #[serde(skip_serializing_if = "Option::is_none", rename = "modelUsage")]
-    pub model_usage: Option<Value>,
+    pub model_usage: Option<std::collections::BTreeMap<String, ModelUsageEntry>>,
+}
+
+/// Usage and cost for a single model within a session, as found in
+/// [`ResultMessage::model_usage`].
+///
+/// The `extra` field captures any keys the CLI adds that aren't modeled here,
+/// so new wire fields deserialize without error.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelUsageEntry {
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub cache_read_input_tokens: u64,
+    #[serde(default)]
+    pub cache_creation_input_tokens: u64,
+    #[serde(default, rename = "costUSD")]
+    pub cost_usd: f64,
+    #[serde(default)]
+    pub web_search_requests: u32,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
 /// A record of a tool permission that was denied during the session.
@@ -316,7 +340,13 @@ mod tests {
             assert_eq!(res.stop_reason.as_deref(), Some("end_turn"));
             assert_eq!(res.terminal_reason.as_deref(), Some("completed"));
             assert_eq!(res.fast_mode_state.as_deref(), Some("off"));
-            assert!(res.model_usage.is_some());
+            let model_usage = res.model_usage.as_ref().unwrap();
+            let entry = model_usage
+                .get("claude-opus-4-7[1m]")
+                .expect("per-model entry present");
+            assert_eq!(entry.input_tokens, 3817);
+            assert_eq!(entry.output_tokens, 14);
+            assert_eq!(entry.cost_usd, 0.06);
             assert!(res.api_error_status.is_none());
 
             let usage = res.usage.unwrap();


### PR DESCRIPTION
Closes #140.

Replaces `ResultMessage::model_usage: Option<serde_json::Value>` with a typed map so downstream consumers stop JSON-poking per-model cost data and lose nothing to silent field renames.

## Changed (breaking)
- `model_usage: Option<BTreeMap<String, ModelUsageEntry>>` (was `Option<Value>`), keyed by model name.

## Added
- `ModelUsageEntry` — typed record with `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `cost_usd` (wire `costUSD`), `web_search_requests`, plus a `#[serde(flatten)] extra` map that catches future fields without breaking deserialization. Re-exported from `claude_codes::io`.

## Versioning
No version bump (per the version↔CLI invariant); the entry sits under `## [Unreleased]`. Heads-up: this and #141 both add an `## [Unreleased]` section, so whichever merges second will need a trivial CHANGELOG conflict resolution.

## Verification
- `cargo test -p claude-codes` — all pass; `test_result_with_new_fields` extended to assert the typed entry (`inputTokens`/`outputTokens`/`costUSD`) parses from the real-world wire sample