### PR TITLE
codex-codes: 0.137.2 — re-snapshot schema drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.137.1"
+version = "0.137.2"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.153`, tested against Claude CLI `2.1.150`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.137.1`, tested against Codex CLI `0.137.0`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.137.2`, tested against Codex CLI `0.137.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.
 

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.137.2] - 2026-06-08
+
+### Changed
+
+Re-snapshotted the Codex app-server schema from `openai/codex@main`; both
+snapshots are byte-identical to upstream again. The only wire change:
+`McpServerStatusUpdatedNotification` gains an optional
+`thread_id: Option<String>` field. Schema coverage stays at 100%.
+
 ## [0.137.1] - 2026-06-08
 
 ### Added

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.137.1"
+version = "0.137.2"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -3260,6 +3260,8 @@ pub struct McpServerStatusUpdatedNotification {
     pub name: String,
     #[serde()]
     pub status: McpServerStartupState,
+    #[serde(rename = "threadId", default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -11462,6 +11462,12 @@
           },
           "status": {
             "$ref": "#/definitions/v2/McpServerStartupState"
+          },
+          "threadId": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -7964,6 +7964,12 @@
         },
         "status": {
           "$ref": "#/definitions/McpServerStartupState"
+        },
+        "threadId": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [


### PR DESCRIPTION
Closes #149.

Re-snapshots the Codex app-server schema from `openai/codex@main`; both snapshot files are byte-identical to upstream again (drift check exits 0).

## Drift absorbed
Tiny this round — the only wire change is `McpServerStatusUpdatedNotification` gaining an optional `thread_id: Option<String>` field. Additive, non-breaking.

## Verification
- `cargo run --example schema_coverage` → **158/158 modeled (100%)**, 0 drift
- `scripts/check_codex_schema_drift.py` → byte-identical, exit 0
- `cargo test -p codex-codes` → all pass
- Patch bump 0.137.1 → 0.137.2 (CLI tested version unchanged at 0.137.0); CHANGELOG + root README updated