### PR TITLE
Typed Citation (#142); release claude 2.1.155, codex 0.137.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.154"
+version = "2.1.155"
 dependencies = [
  "anyhow",
  "base64",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.137.2"
+version = "0.137.3"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This workspace provides two independent crates for interacting with [Claude Code
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.154`, tested against Claude CLI `2.1.150`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.137.2`, tested against Codex CLI `0.137.0`.
+- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.155`, tested against Claude CLI `2.1.150`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.137.3`, tested against Codex CLI `0.137.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.
 

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.155] - 2026-06-08
+
+### Changed (breaking)
+
+- **`TextBlock::citations`** is now `Vec<Citation>` instead of
+  `Vec<serde_json::Value>`. Consumers read typed fields (`citation_type`,
+  `url`, `title`, `cited_text`, `document_index`, `document_title`) instead of
+  JSON-poking each entry. Unmodeled location fields (start/end indices,
+  `encrypted_index`, …) are preserved verbatim in `Citation::extra`, so the
+  type round-trips losslessly across all citation shapes.
+
+### Added
+
+- **`Citation`** — typed content-block citation struct (re-exported from
+  `claude_codes::io`).
+
 ## [2.1.154] - 2026-06-08
 
 ### Added

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.154"
+version = "2.1.155"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/src/io/content_blocks.rs
+++ b/claude-codes/src/io/content_blocks.rs
@@ -165,7 +165,41 @@ pub struct TextBlock {
     /// Citations associated with this text block, if any.
     /// Populated when the model references web search results or other sources.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub citations: Vec<Value>,
+    pub citations: Vec<Citation>,
+}
+
+/// A citation attached to a [`TextBlock`], linking generated text back to a
+/// source.
+///
+/// Anthropic emits several citation shapes — `web_search_result_location`,
+/// `char_location`, `page_location`, `content_block_location`, … — that share a
+/// `type` tag and overlapping fields. This models the fields consumers commonly
+/// render as typed optionals and preserves any remaining variant-specific
+/// fields (start/end indices, `encrypted_index`, …) verbatim in
+/// [`Citation::extra`], so unmodeled or future shapes deserialize without loss.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Citation {
+    /// Citation variant tag, e.g. `"web_search_result_location"`.
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub citation_type: Option<String>,
+    /// Source URL (web-search citations).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Human-readable source title.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// The span of source text being cited.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cited_text: Option<String>,
+    /// Index of the source document (document-location citations).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub document_index: Option<u32>,
+    /// Title of the source document.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub document_title: Option<String>,
+    /// Any additional location fields not modeled above, preserved verbatim.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, Value>,
 }
 
 /// Image content block (follows Anthropic API structure)
@@ -633,13 +667,47 @@ mod tests {
         if let ContentBlock::Text(t) = &block {
             assert_eq!(t.text, "According to the documentation...");
             assert_eq!(t.citations.len(), 1);
-            assert_eq!(t.citations[0]["url"], "https://example.com");
+            let cite = &t.citations[0];
+            assert_eq!(
+                cite.citation_type.as_deref(),
+                Some("web_search_result_location")
+            );
+            assert_eq!(cite.url.as_deref(), Some("https://example.com"));
+            assert_eq!(cite.title.as_deref(), Some("Example"));
         } else {
             panic!("Expected Text variant");
         }
         // roundtrip preserves citations
         let reserialized = serde_json::to_value(&block).unwrap();
         assert_eq!(json, reserialized);
+    }
+
+    #[test]
+    fn test_citation_preserves_unmodeled_location_fields() {
+        // A char_location citation carries indices we don't model as named
+        // fields; they must survive in `extra` and round-trip intact.
+        let json = json!({
+            "type": "char_location",
+            "cited_text": "the quick brown fox",
+            "document_index": 0,
+            "document_title": "Doc A",
+            "start_char_index": 12,
+            "end_char_index": 31
+        });
+        let cite: Citation = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(cite.citation_type.as_deref(), Some("char_location"));
+        assert_eq!(cite.cited_text.as_deref(), Some("the quick brown fox"));
+        assert_eq!(cite.document_index, Some(0));
+        assert_eq!(
+            cite.extra.get("start_char_index").and_then(|v| v.as_u64()),
+            Some(12)
+        );
+        assert_eq!(
+            cite.extra.get("end_char_index").and_then(|v| v.as_u64()),
+            Some(31)
+        );
+        // Round-trips without losing the unmodeled fields.
+        assert_eq!(serde_json::to_value(&cite).unwrap(), json);
     }
 
     #[test]

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.137.3] - 2026-06-08
+
+### Changed
+
+- Release/version bump to publish alongside `claude-codes`; no library or
+  schema changes since 0.137.2.
+
 ## [0.137.2] - 2026-06-08
 
 ### Changed

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.137.2"
+version = "0.137.3"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]


### PR DESCRIPTION
Closes #142.

## #142 — typed `Citation`
Replaces `TextBlock::citations: Vec<serde_json::Value>` with `Vec<Citation>`.

`Citation` is a flat struct exposing the commonly-rendered fields as typed optionals — `citation_type` (wire `type`), `url`, `title`, `cited_text`, `document_index`, `document_title` — with a `#[serde(flatten)] extra` map that preserves variant-specific location fields (`start_char_index`, `end_page_number`, `encrypted_index`, …) verbatim. This covers all four documented citation shapes in one type, never fails to deserialize, and round-trips losslessly. (Chose the robust flat-struct option over a tagged enum precisely because we're publishing right after — a tagged enum would hard-fail on any unmodeled shape.)

Tests: typed-field access on a web-search citation, `extra` preservation + lossless round-trip on a `char_location` citation.

## Release bumps
- **claude-codes 2.1.154 → 2.1.155** (carries the breaking `Citation` change)
- **codex-codes 0.137.2 → 0.137.3** (version/release bump only — no library or schema changes since 0.137.2)

CHANGELOGs and root README updated; version-consistency checks pass.

## Verification
- `cargo test --workspace` — all pass
- `cargo clippy --workspace --all-targets -- -D warnings` on Rust 1.96 — clean

After merge, both crates will be `cargo publish`ed at these versions.