### PR TITLE
claude-codes: 2.1.156 — typed Fallback content block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.155"
+version = "2.1.156"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.155`, tested against Claude CLI `2.1.150`.
+- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.156`, tested against Claude CLI `2.1.150`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.137.3`, tested against Codex CLI `0.137.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.156] - 2026-06-10
+
+### Added
+
+- **`ContentBlock::Fallback`** — typed variant for model-fallback content
+  blocks (`{"type": "fallback", "from": {"model": ...}, "to": {"model": ...}}`),
+  emitted when the CLI switches the response to a fallback model mid-turn.
+  Previously these deserialized as `ContentBlock::Unknown`. The wire shape was
+  verified against the claude CLI 2.1.172 binary and real session transcripts;
+  it carries no fields beyond the from/to models (no reason field exists).
+  New types `FallbackBlock` and `FallbackModel` are exported from the crate
+  root and `claude_codes::io`. (#160)
+
 ## [2.1.155] - 2026-06-08
 
 ### Changed (breaking)

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.155"
+version = "2.1.156"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/examples/basic_repl.rs
+++ b/claude-codes/examples/basic_repl.rs
@@ -221,6 +221,12 @@ fn handle_output(output: ClaudeOutput) {
                     claude_codes::io::ContentBlock::ContainerUpload(_) => {
                         println!("\n[Container Upload]");
                     }
+                    claude_codes::io::ContentBlock::Fallback(fallback) => {
+                        println!(
+                            "\n[Model fallback: {} -> {}]",
+                            fallback.from.model, fallback.to.model
+                        );
+                    }
                     claude_codes::io::ContentBlock::Unknown(value) => {
                         println!(
                             "\n[Unknown block: {}]",

--- a/claude-codes/src/io/content_blocks.rs
+++ b/claude-codes/src/io/content_blocks.rs
@@ -45,6 +45,9 @@ pub enum ContentBlock {
     McpToolResult(McpToolResultBlock),
     /// Container file upload content block.
     ContainerUpload(ContainerUploadBlock),
+    /// Model fallback event, emitted when a request falls back from one
+    /// model to another (e.g. on overload).
+    Fallback(FallbackBlock),
     /// A content block type not yet known to this version of the crate.
     /// Contains the raw JSON value for caller inspection.
     Unknown(Value),
@@ -65,6 +68,7 @@ impl ContentBlock {
             Self::McpToolUse(_) => "mcp_tool_use",
             Self::McpToolResult(_) => "mcp_tool_result",
             Self::ContainerUpload(_) => "container_upload",
+            Self::Fallback(_) => "fallback",
             Self::Unknown(v) => v.get("type").and_then(|t| t.as_str()).unwrap_or("unknown"),
         }
     }
@@ -93,6 +97,7 @@ impl Serialize for ContentBlock {
             Self::McpToolUse(v) => serialize_tagged("mcp_tool_use", v, serializer),
             Self::McpToolResult(v) => serialize_tagged("mcp_tool_result", v, serializer),
             Self::ContainerUpload(v) => serialize_tagged("container_upload", v, serializer),
+            Self::Fallback(v) => serialize_tagged("fallback", v, serializer),
             Self::Unknown(v) => v.serialize(serializer),
         }
     }
@@ -139,6 +144,9 @@ impl<'de> Deserialize<'de> for ContentBlock {
                 .map_err(serde::de::Error::custom),
             "container_upload" => serde_json::from_value(value)
                 .map(ContentBlock::ContainerUpload)
+                .map_err(serde::de::Error::custom),
+            "fallback" => serde_json::from_value(value)
+                .map(ContentBlock::Fallback)
                 .map_err(serde::de::Error::custom),
             _ => Ok(ContentBlock::Unknown(value)),
         }
@@ -445,6 +453,25 @@ pub struct ContainerUploadBlock {
     pub data: Value,
 }
 
+/// Model fallback content block.
+///
+/// Marks the point in `content` where the response switched from one model
+/// to another (e.g. when the primary model is overloaded). Blocks after this
+/// marker were produced by the `to` model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FallbackBlock {
+    /// The model the response is switching away from.
+    pub from: FallbackModel,
+    /// The model now serving the response.
+    pub to: FallbackModel,
+}
+
+/// A model reference inside a [`FallbackBlock`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FallbackModel {
+    pub model: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -585,6 +612,29 @@ mod tests {
         let block: ContentBlock = serde_json::from_value(json).unwrap();
         assert_eq!(block.block_type(), "container_upload");
         assert!(matches!(block, ContentBlock::ContainerUpload(_)));
+    }
+
+    #[test]
+    fn test_fallback_block_deserializes() {
+        // Exact shape emitted by the CLI (verified against claude 2.1.172).
+        let json = json!({
+            "from": { "model": "claude-fable-5" },
+            "to": { "model": "claude-opus-4-8" },
+            "type": "fallback"
+        });
+
+        let block: ContentBlock = serde_json::from_value(json.clone()).unwrap();
+        assert!(!block.is_unknown());
+        assert_eq!(block.block_type(), "fallback");
+        if let ContentBlock::Fallback(b) = &block {
+            assert_eq!(b.from.model, "claude-fable-5");
+            assert_eq!(b.to.model, "claude-opus-4-8");
+        } else {
+            panic!("Expected Fallback variant");
+        }
+        // roundtrip
+        let reserialized = serde_json::to_value(&block).unwrap();
+        assert_eq!(json, reserialized);
     }
 
     #[test]

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -130,9 +130,10 @@ pub use types::*;
 
 // Content block types for message parsing
 pub use io::{
-    CodeExecutionToolResultBlock, ContainerUploadBlock, ContentBlock, ImageBlock, ImageSource,
-    ImageSourceType, McpToolResultBlock, McpToolUseBlock, MediaType, ServerToolUseBlock, TextBlock,
-    ThinkingBlock, ToolResultBlock, ToolResultContent, WebSearchToolResultBlock,
+    CodeExecutionToolResultBlock, ContainerUploadBlock, ContentBlock, FallbackBlock, FallbackModel,
+    ImageBlock, ImageSource, ImageSourceType, McpToolResultBlock, McpToolUseBlock, MediaType,
+    ServerToolUseBlock, TextBlock, ThinkingBlock, ToolResultBlock, ToolResultContent,
+    WebSearchToolResultBlock,
 };
 
 // Control protocol types for tool permission handling

--- a/claude-codes/tests/integration_tests.rs
+++ b/claude-codes/tests/integration_tests.rs
@@ -392,10 +392,8 @@ async fn test_file_edit_tool_use() {
                         println!("Tool use: name={}, input={:?}", tool.name, tool.input);
                         tool_uses.push(tool.name.clone());
                     }
-                    claude_codes::io::ContentBlock::Text(text) => {
-                        if text.text.len() < 200 {
-                            println!("Text: {}", text.text);
-                        }
+                    claude_codes::io::ContentBlock::Text(text) if text.text.len() < 200 => {
+                        println!("Text: {}", text.text);
                     }
                     _ => {}
                 }


### PR DESCRIPTION
## Summary

Adds `ContentBlock::Fallback` — a typed variant for the model-fallback marker the CLI emits mid-turn (closes #160):

```json
{"type": "fallback", "from": {"model": "claude-fable-5"}, "to": {"model": "claude-opus-4-8"}}
```

Previously these deserialized as `ContentBlock::Unknown`, forcing consumers (Agent Portal) to JSON-poke the raw value.

## Wire-shape verification

- **Binary inspection** (claude CLI 2.1.172): the emitter constructs exactly `{type:"fallback", from:{model}, to:{model}}` — there is **no reason/why field** upstream, so none is modeled.
- **Real transcripts**: all observed fallback blocks match this shape; the new code parses an actual transcript line end-to-end.

## Changes

- New `FallbackBlock` / `FallbackModel` types, wired through `ContentBlock` serialize/deserialize/`block_type`, exported from crate root and `claude_codes::io`.
- Unit test with the exact wire shape, including roundtrip.
- `basic_repl` example renders the fallback transition.
- Version bump to 2.1.156 + CHANGELOG entry.
- Drive-by: collapse a nested `if` in `integration_tests.rs` that newer clippy flags as `collapsible_match`.

Note: `cargo clippy --all-targets --all-features` on the full workspace fails on **main** already (8 pre-existing E0063 errors in `codex-codes/tests/live_client_tests.rs` — `TurnStartParams` grew `client_user_message_id`); not addressed here.