### PR TITLE
claude-codes: bump tested Claude CLI version to 2.1.170

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.156`, tested against Claude CLI `2.1.150`.
+- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.156`, tested against Claude CLI `2.1.170`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.137.3`, tested against Codex CLI `0.137.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -138,7 +138,7 @@ let serialized = Protocol::serialize(&output)?;
 
 ## Compatibility
 
-**Tested against:** Claude CLI 2.1.150
+**Tested against:** Claude CLI 2.1.170
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.150";
+const TESTED_VERSION: &str = "2.1.170";
 
 /// Ensures version warning is only shown once per session
 static VERSION_CHECK: Once = Once::new();


### PR DESCRIPTION
Bumps `TESTED_VERSION` in `claude-codes/src/version.rs` from 2.1.150 to **2.1.170** — two patch versions behind the locally installed CLI (2.1.172), against which the full integration suite (`cargo test -p claude-codes --features integration-tests`, 26 live-CLI tests) passes clean.

Also updates the matching strings in the root and crate READMEs that the Check Version Consistency CI job enforces.