### PR TITLE
codex-codes: 0.137.4 — re-snapshot schema drift, model thread/delete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.137.3"
+version = "0.137.4"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.157`, tested against Claude CLI `2.1.170`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.137.3`, tested against Codex CLI `0.137.0`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.137.4`, tested against Codex CLI `0.137.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.
 

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.137.4] - 2026-06-11
+
+### Added
+
+- **`thread/delete` request** — `thread_delete()` on both `AsyncClient` and
+  `SyncClient`, with `ThreadDeleteParams` / `ThreadDeleteResponse`.
+- **`Notification::ThreadDeleted`** — typed variant for the new
+  `thread/deleted` server notification.
+- **`ThreadItem::SubAgentActivity`** item variant and the
+  `SubAgentActivityKind` enum (started / interacted / interrupted).
+- **`AuthMode::BedrockApiKey`** auth-mode variant.
+
+### Changed (breaking)
+
+- **`ThreadSource`** is now an open transparent newtype `ThreadSource(pub
+  String)` instead of a closed enum, matching upstream's move to a free-form
+  string. Consumers matching on the old `User`/`Subagent` variants should
+  compare against the string value instead.
+- Re-snapshotted `codex_app_server_protocol{,.v2}.schemas.json` from
+  `openai/codex@main`, regenerating the typed structs (resolves the
+  codex-schema-drift report). Schema coverage is back to 160/160 (100%).
+
 ## [0.137.3] - 2026-06-08
 
 ### Changed

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -24,8 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   string. Consumers matching on the old `User`/`Subagent` variants should
   compare against the string value instead.
 - Re-snapshotted `codex_app_server_protocol{,.v2}.schemas.json` from
-  `openai/codex@main`, regenerating the typed structs (resolves the
-  codex-schema-drift report). Schema coverage is back to 160/160 (100%).
+  `openai/codex@main` (commit `f4278010`, 2026-06-11), regenerating the typed
+  structs (resolves the codex-schema-drift report). This is a strict superset
+  of the rust-v0.139.0 release schema — everything in CLI 0.139.0 is modeled,
+  plus the not-yet-released thread/delete, SubAgentActivity, ThreadSource,
+  and BedrockApiKey changes. Schema coverage is back to 160/160 (100%).
 
 ## [0.137.3] - 2026-06-08
 

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.137.3"
+version = "0.137.4"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/examples/schema_coverage.rs
+++ b/codex-codes/examples/schema_coverage.rs
@@ -462,6 +462,7 @@ mod samples {
             methods::WINDOWS_SANDBOX_SETUP_COMPLETED,
             methods::THREAD_SETTINGS_UPDATED,
             methods::TURN_MODERATION_METADATA,
+            methods::THREAD_DELETED,
         ]
         .into_iter()
         .collect()
@@ -475,6 +476,7 @@ mod samples {
             methods::INITIALIZED,
             methods::THREAD_START,
             methods::THREAD_ARCHIVE,
+            methods::THREAD_DELETE,
             methods::TURN_START,
             methods::TURN_INTERRUPT,
             methods::TURN_STEER,

--- a/codex-codes/src/client_async.rs
+++ b/codex-codes/src/client_async.rs
@@ -50,9 +50,9 @@ use crate::jsonrpc::{
 use crate::messages::{Notification, ServerMessage, ServerRequest};
 use crate::protocol::{
     ClientInfo, InitializeParams, InitializeResponse, ThreadArchiveParams, ThreadArchiveResponse,
-    ThreadForkParams, ThreadForkResponse, ThreadResumeParams, ThreadResumeResponse,
-    ThreadStartParams, ThreadStartResponse, TurnInterruptParams, TurnInterruptResponse,
-    TurnStartParams, TurnStartResponse,
+    ThreadDeleteParams, ThreadDeleteResponse, ThreadForkParams, ThreadForkResponse,
+    ThreadResumeParams, ThreadResumeResponse, ThreadStartParams, ThreadStartResponse,
+    TurnInterruptParams, TurnInterruptResponse, TurnStartParams, TurnStartResponse,
 };
 use log::{debug, error, warn};
 use serde::de::DeserializeOwned;
@@ -289,6 +289,15 @@ impl AsyncClient {
         params: &ThreadArchiveParams,
     ) -> Result<ThreadArchiveResponse> {
         self.request(crate::protocol::methods::THREAD_ARCHIVE, params)
+            .await
+    }
+
+    /// Delete a thread.
+    pub async fn thread_delete(
+        &mut self,
+        params: &ThreadDeleteParams,
+    ) -> Result<ThreadDeleteResponse> {
+        self.request(crate::protocol::methods::THREAD_DELETE, params)
             .await
     }
 

--- a/codex-codes/src/client_sync.rs
+++ b/codex-codes/src/client_sync.rs
@@ -50,9 +50,9 @@ use crate::jsonrpc::{
 use crate::messages::{Notification, ServerMessage, ServerRequest};
 use crate::protocol::{
     ClientInfo, InitializeParams, InitializeResponse, ThreadArchiveParams, ThreadArchiveResponse,
-    ThreadForkParams, ThreadForkResponse, ThreadResumeParams, ThreadResumeResponse,
-    ThreadStartParams, ThreadStartResponse, TurnInterruptParams, TurnInterruptResponse,
-    TurnStartParams, TurnStartResponse,
+    ThreadDeleteParams, ThreadDeleteResponse, ThreadForkParams, ThreadForkResponse,
+    ThreadResumeParams, ThreadResumeResponse, ThreadStartParams, ThreadStartResponse,
+    TurnInterruptParams, TurnInterruptResponse, TurnStartParams, TurnStartResponse,
 };
 use log::{debug, warn};
 use serde::de::DeserializeOwned;
@@ -271,6 +271,11 @@ impl SyncClient {
         params: &ThreadArchiveParams,
     ) -> Result<ThreadArchiveResponse> {
         self.request(crate::protocol::methods::THREAD_ARCHIVE, params)
+    }
+
+    /// Delete a thread.
+    pub fn thread_delete(&mut self, params: &ThreadDeleteParams) -> Result<ThreadDeleteResponse> {
+        self.request(crate::protocol::methods::THREAD_DELETE, params)
     }
 
     /// Perform the `initialize` handshake with the app-server.

--- a/codex-codes/src/messages.rs
+++ b/codex-codes/src/messages.rs
@@ -42,13 +42,13 @@ use crate::protocol::{
     ReasoningSummaryPartAddedNotification, ReasoningSummaryTextDeltaNotification,
     ReasoningTextDeltaNotification, RemoteControlStatusChangedNotification,
     ServerRequestResolvedNotification, SkillsChangedNotification, TerminalInteractionNotification,
-    ThreadArchivedNotification, ThreadClosedNotification, ThreadGoalClearedNotification,
-    ThreadGoalUpdatedNotification, ThreadNameUpdatedNotification, ThreadRealtimeClosedNotification,
-    ThreadRealtimeErrorNotification, ThreadRealtimeItemAddedNotification,
-    ThreadRealtimeOutputAudioDeltaNotification, ThreadRealtimeSdpNotification,
-    ThreadRealtimeStartedNotification, ThreadRealtimeTranscriptDeltaNotification,
-    ThreadRealtimeTranscriptDoneNotification, ThreadSettingsUpdatedNotification,
-    ThreadStartedNotification, ThreadStatusChangedNotification,
+    ThreadArchivedNotification, ThreadClosedNotification, ThreadDeletedNotification,
+    ThreadGoalClearedNotification, ThreadGoalUpdatedNotification, ThreadNameUpdatedNotification,
+    ThreadRealtimeClosedNotification, ThreadRealtimeErrorNotification,
+    ThreadRealtimeItemAddedNotification, ThreadRealtimeOutputAudioDeltaNotification,
+    ThreadRealtimeSdpNotification, ThreadRealtimeStartedNotification,
+    ThreadRealtimeTranscriptDeltaNotification, ThreadRealtimeTranscriptDoneNotification,
+    ThreadSettingsUpdatedNotification, ThreadStartedNotification, ThreadStatusChangedNotification,
     ThreadTokenUsageUpdatedNotification, ThreadUnarchivedNotification, TurnCompletedNotification,
     TurnDiffUpdatedNotification, TurnModerationMetadataNotification, TurnPlanUpdatedNotification,
     TurnStartedNotification, WarningNotification, WindowsSandboxSetupCompletedNotification,
@@ -120,6 +120,8 @@ pub enum Notification {
     ThreadArchived(ThreadArchivedNotification),
     /// `thread/closed`
     ThreadClosed(ThreadClosedNotification),
+    /// `thread/deleted`
+    ThreadDeleted(ThreadDeletedNotification),
     /// `thread/unarchived`
     ThreadUnarchived(ThreadUnarchivedNotification),
     /// `thread/goal/cleared`
@@ -235,6 +237,7 @@ impl Notification {
             Self::Warning(_) => methods::WARNING,
             Self::ThreadArchived(_) => methods::THREAD_ARCHIVED,
             Self::ThreadClosed(_) => methods::THREAD_CLOSED,
+            Self::ThreadDeleted(_) => methods::THREAD_DELETED,
             Self::ThreadUnarchived(_) => methods::THREAD_UNARCHIVED,
             Self::ThreadGoalCleared(_) => methods::THREAD_GOAL_CLEARED,
             Self::ThreadNameUpdated(_) => methods::THREAD_NAME_UPDATED,
@@ -369,6 +372,9 @@ impl Notification {
                 serde_json::from_value(params_value).map(Self::ThreadArchived)
             }
             methods::THREAD_CLOSED => serde_json::from_value(params_value).map(Self::ThreadClosed),
+            methods::THREAD_DELETED => {
+                serde_json::from_value(params_value).map(Self::ThreadDeleted)
+            }
             methods::THREAD_UNARCHIVED => {
                 serde_json::from_value(params_value).map(Self::ThreadUnarchived)
             }
@@ -524,6 +530,7 @@ impl Notification {
             Self::Warning(v) => pack(methods::WARNING, v),
             Self::ThreadArchived(v) => pack(methods::THREAD_ARCHIVED, v),
             Self::ThreadClosed(v) => pack(methods::THREAD_CLOSED, v),
+            Self::ThreadDeleted(v) => pack(methods::THREAD_DELETED, v),
             Self::ThreadUnarchived(v) => pack(methods::THREAD_UNARCHIVED, v),
             Self::ThreadGoalCleared(v) => pack(methods::THREAD_GOAL_CLEARED, v),
             Self::ThreadNameUpdated(v) => pack(methods::THREAD_NAME_UPDATED, v),

--- a/codex-codes/src/protocol.rs
+++ b/codex-codes/src/protocol.rs
@@ -31,6 +31,7 @@ pub mod methods {
     pub const INITIALIZED: &str = "initialized";
     pub const THREAD_START: &str = "thread/start";
     pub const THREAD_ARCHIVE: &str = "thread/archive";
+    pub const THREAD_DELETE: &str = "thread/delete";
     pub const TURN_START: &str = "turn/start";
     pub const TURN_INTERRUPT: &str = "turn/interrupt";
     pub const TURN_STEER: &str = "turn/steer";
@@ -141,6 +142,7 @@ pub mod methods {
     pub const WARNING: &str = "warning";
     pub const THREAD_ARCHIVED: &str = "thread/archived";
     pub const THREAD_CLOSED: &str = "thread/closed";
+    pub const THREAD_DELETED: &str = "thread/deleted";
     pub const THREAD_UNARCHIVED: &str = "thread/unarchived";
     pub const THREAD_GOAL_CLEARED: &str = "thread/goal/cleared";
     pub const THREAD_NAME_UPDATED: &str = "thread/name/updated";

--- a/codex-codes/src/protocol_generated/samples.rs
+++ b/codex-codes/src/protocol_generated/samples.rs
@@ -130,6 +130,7 @@ pub fn server_notification_samples() -> Vec<(&'static str, Value)> {
         ("thread/archived", json!({"threadId": "x"})),
         ("thread/closed", json!({"threadId": "x"})),
         ("thread/compacted", json!({"threadId": "x", "turnId": "x"})),
+        ("thread/deleted", json!({"threadId": "x"})),
         ("thread/goal/cleared", json!({"threadId": "x"})),
         (
             "thread/goal/updated",
@@ -315,6 +316,7 @@ pub fn client_request_samples() -> Vec<(&'static str, Value)> {
         ),
         ("thread/archive", json!({"threadId": "x"})),
         ("thread/compact/start", json!({"threadId": "x"})),
+        ("thread/delete", json!({"threadId": "x"})),
         ("thread/fork", json!({"threadId": "x"})),
         ("thread/goal/clear", json!({"threadId": "x"})),
         ("thread/goal/get", json!({"threadId": "x"})),

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -354,8 +354,6 @@ pub struct AppSummary {
     pub install_url: Option<String>,
     #[serde(default)]
     pub name: String,
-    #[serde(rename = "needsAuth", default)]
-    pub needs_auth: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -505,6 +503,8 @@ pub enum AuthMode {
     AgentIdentity,
     #[serde(rename = "personalAccessToken")]
     PersonalAccessToken,
+    #[serde(rename = "bedrockApiKey")]
+    BedrockApiKey,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -5147,6 +5147,16 @@ pub struct SpendControlLimitSnapshot {
     pub used: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SubAgentActivityKind {
+    #[serde(rename = "started")]
+    Started,
+    #[serde(rename = "interacted")]
+    Interacted,
+    #[serde(rename = "interrupted")]
+    Interrupted,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum SubAgentSource {
     #[serde(rename = "review")]
@@ -5344,6 +5354,27 @@ pub struct ThreadCompactStartParams {
 pub struct ThreadCompactStartResponse {
     #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
     pub extra: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadDeleteParams {
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadDeleteResponse {
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadDeletedNotification {
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -5715,6 +5746,15 @@ pub enum ThreadItem {
         sender_thread_id: String,
         status: Value,
         tool: Value,
+    },
+    #[serde(rename = "subAgentActivity")]
+    SubAgentActivity {
+        #[serde(rename = "agentPath")]
+        agent_path: String,
+        #[serde(rename = "agentThreadId")]
+        agent_thread_id: String,
+        id: String,
+        kind: SubAgentActivityKind,
     },
     #[serde(rename = "webSearch")]
     WebSearch {
@@ -6204,15 +6244,9 @@ pub enum ThreadSortKey {
     Updated_at,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum ThreadSource {
-    #[serde(rename = "user")]
-    User,
-    #[serde(rename = "subagent")]
-    Subagent,
-    #[serde(rename = "memory_consolidation")]
-    Memory_consolidation,
-}
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+pub struct ThreadSource(pub String);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ThreadSourceKind {

--- a/codex-codes/tests/live_client_tests.rs
+++ b/codex-codes/tests/live_client_tests.rs
@@ -528,6 +528,7 @@ async fn test_typed_message_audit_strict() {
                     }
                     Notification::ThreadRealtimeSdp(_) => "ThreadRealtimeSdp",
                     Notification::ThreadRealtimeStarted(_) => "ThreadRealtimeStarted",
+                    Notification::ThreadDeleted(_) => "ThreadDeleted",
                     Notification::ThreadSettingsUpdated(_) => "ThreadSettingsUpdated",
                     Notification::TurnModerationMetadata(_) => "TurnModerationMetadata",
                     Notification::ThreadRealtimeTranscriptDelta(_) => {

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -331,6 +331,30 @@
             },
             "method": {
               "enum": [
+                "thread/delete"
+              ],
+              "title": "Thread/deleteRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadDeleteParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/deleteRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
                 "thread/unsubscribe"
               ],
               "title": "Thread/unsubscribeRequestMethod",
@@ -4065,6 +4089,26 @@
           "properties": {
             "method": {
               "enum": [
+                "thread/deleted"
+              ],
+              "title": "Thread/deletedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadDeletedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/deletedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
                 "thread/unarchived"
               ],
               "title": "Thread/unarchivedNotificationMethod",
@@ -6389,15 +6433,11 @@
           },
           "name": {
             "type": "string"
-          },
-          "needsAuth": {
-            "type": "boolean"
           }
         },
         "required": [
           "id",
-          "name",
-          "needsAuth"
+          "name"
         ],
         "type": "object"
       },
@@ -6684,6 +6724,13 @@
               "personalAccessToken"
             ],
             "type": "string"
+          },
+          {
+            "description": "Amazon Bedrock bearer token managed by Codex.",
+            "enum": [
+              "bedrockApiKey"
+            ],
+            "type": "string"
           }
         ]
       },
@@ -6764,6 +6811,36 @@
           "notFound"
         ],
         "type": "string"
+      },
+      "CapabilityRootLocation": {
+        "description": "Location used to resolve a selected capability root.",
+        "oneOf": [
+          {
+            "description": "A path owned by an execution environment.",
+            "properties": {
+              "environmentId": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "environment"
+                ],
+                "title": "EnvironmentCapabilityRootLocationType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "environmentId",
+              "path",
+              "type"
+            ],
+            "title": "EnvironmentCapabilityRootLocation",
+            "type": "object"
+          }
+        ]
       },
       "CodexErrorInfo": {
         "description": "This translation layer make sure that we expose codex error code in camel case.\n\nWhen an upstream HTTP status is available (for example, from the Responses API or a provider), it is forwarded in `httpStatusCode` on the relevant `codexErrorInfo` variant.",
@@ -15061,6 +15138,28 @@
         },
         "type": "object"
       },
+      "SelectedCapabilityRoot": {
+        "description": "A user-selected root that can expose one or more runtime capabilities.",
+        "properties": {
+          "id": {
+            "description": "Stable identifier supplied by the capability selection platform.",
+            "type": "string"
+          },
+          "location": {
+            "allOf": [
+              {
+                "$ref": "#/definitions/v2/CapabilityRootLocation"
+              }
+            ],
+            "description": "Where the selected root can be resolved."
+          }
+        },
+        "required": [
+          "id",
+          "location"
+        ],
+        "type": "object"
+      },
       "SendAddCreditsNudgeEmailParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
@@ -15580,6 +15679,14 @@
         ],
         "type": "object"
       },
+      "SubAgentActivityKind": {
+        "enum": [
+          "started",
+          "interacted",
+          "interrupted"
+        ],
+        "type": "string"
+      },
       "SubAgentSource": {
         "oneOf": [
           {
@@ -15991,6 +16098,37 @@
       "ThreadCompactStartResponse": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ThreadCompactStartResponse",
+        "type": "object"
+      },
+      "ThreadDeleteParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "threadId"
+        ],
+        "title": "ThreadDeleteParams",
+        "type": "object"
+      },
+      "ThreadDeleteResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ThreadDeleteResponse",
+        "type": "object"
+      },
+      "ThreadDeletedNotification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "threadId"
+        ],
+        "title": "ThreadDeletedNotification",
         "type": "object"
       },
       "ThreadForkParams": {
@@ -16890,6 +17028,38 @@
               "type"
             ],
             "title": "CollabAgentToolCallThreadItem",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "agentPath": {
+                "type": "string"
+              },
+              "agentThreadId": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "kind": {
+                "$ref": "#/definitions/v2/SubAgentActivityKind"
+              },
+              "type": {
+                "enum": [
+                  "subAgentActivity"
+                ],
+                "title": "SubAgentActivityThreadItemType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "agentPath",
+              "agentThreadId",
+              "id",
+              "kind",
+              "type"
+            ],
+            "title": "SubAgentActivityThreadItem",
             "type": "object"
           },
           {
@@ -18017,11 +18187,6 @@
         "type": "string"
       },
       "ThreadSource": {
-        "enum": [
-          "user",
-          "subagent",
-          "memory_consolidation"
-        ],
         "type": "string"
       },
       "ThreadSourceKind": {

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -711,15 +711,11 @@
         },
         "name": {
           "type": "string"
-        },
-        "needsAuth": {
-          "type": "boolean"
         }
       },
       "required": [
         "id",
-        "name",
-        "needsAuth"
+        "name"
       ],
       "type": "object"
     },
@@ -1006,6 +1002,13 @@
             "personalAccessToken"
           ],
           "type": "string"
+        },
+        {
+          "description": "Amazon Bedrock bearer token managed by Codex.",
+          "enum": [
+            "bedrockApiKey"
+          ],
+          "type": "string"
         }
       ]
     },
@@ -1086,6 +1089,36 @@
         "notFound"
       ],
       "type": "string"
+    },
+    "CapabilityRootLocation": {
+      "description": "Location used to resolve a selected capability root.",
+      "oneOf": [
+        {
+          "description": "A path owned by an execution environment.",
+          "properties": {
+            "environmentId": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "environment"
+              ],
+              "title": "EnvironmentCapabilityRootLocationType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "environmentId",
+            "path",
+            "type"
+          ],
+          "title": "EnvironmentCapabilityRootLocation",
+          "type": "object"
+        }
+      ]
     },
     "ClientInfo": {
       "properties": {
@@ -1231,6 +1264,30 @@
             "params"
           ],
           "title": "Thread/archiveRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
+                "thread/delete"
+              ],
+              "title": "Thread/deleteRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadDeleteParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/deleteRequest",
           "type": "object"
         },
         {
@@ -11563,6 +11620,28 @@
       },
       "type": "object"
     },
+    "SelectedCapabilityRoot": {
+      "description": "A user-selected root that can expose one or more runtime capabilities.",
+      "properties": {
+        "id": {
+          "description": "Stable identifier supplied by the capability selection platform.",
+          "type": "string"
+        },
+        "location": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/CapabilityRootLocation"
+            }
+          ],
+          "description": "Where the selected root can be resolved."
+        }
+      },
+      "required": [
+        "id",
+        "location"
+      ],
+      "type": "object"
+    },
     "SendAddCreditsNudgeEmailParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
@@ -11672,6 +11751,26 @@
             "params"
           ],
           "title": "Thread/archivedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "thread/deleted"
+              ],
+              "title": "Thread/deletedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadDeletedNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/deletedNotification",
           "type": "object"
         },
         {
@@ -13397,6 +13496,14 @@
       ],
       "type": "object"
     },
+    "SubAgentActivityKind": {
+      "enum": [
+        "started",
+        "interacted",
+        "interrupted"
+      ],
+      "type": "string"
+    },
     "SubAgentSource": {
       "oneOf": [
         {
@@ -13808,6 +13915,37 @@
     "ThreadCompactStartResponse": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ThreadCompactStartResponse",
+      "type": "object"
+    },
+    "ThreadDeleteParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId"
+      ],
+      "title": "ThreadDeleteParams",
+      "type": "object"
+    },
+    "ThreadDeleteResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ThreadDeleteResponse",
+      "type": "object"
+    },
+    "ThreadDeletedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId"
+      ],
+      "title": "ThreadDeletedNotification",
       "type": "object"
     },
     "ThreadForkParams": {
@@ -14707,6 +14845,38 @@
             "type"
           ],
           "title": "CollabAgentToolCallThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "agentPath": {
+              "type": "string"
+            },
+            "agentThreadId": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "kind": {
+              "$ref": "#/definitions/SubAgentActivityKind"
+            },
+            "type": {
+              "enum": [
+                "subAgentActivity"
+              ],
+              "title": "SubAgentActivityThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "agentPath",
+            "agentThreadId",
+            "id",
+            "kind",
+            "type"
+          ],
+          "title": "SubAgentActivityThreadItem",
           "type": "object"
         },
         {
@@ -15834,11 +16004,6 @@
       "type": "string"
     },
     "ThreadSource": {
-      "enum": [
-        "user",
-        "subagent",
-        "memory_consolidation"
-      ],
       "type": "string"
     },
     "ThreadSourceKind": {


### PR DESCRIPTION
## Summary

Resolves the codex-schema-drift report (#159) by re-snapshotting both `codex_app_server_protocol{,.v2}.schemas.json` from `openai/codex@main` and regenerating the typed structs via `scripts/codegen_protocol.py`.

## Upstream changes picked up

- **`ThreadSource`** (breaking): closed enum → open transparent newtype `ThreadSource(pub String)`, matching upstream's move to a free-form string.
- **`ThreadItem::SubAgentActivity`** + new `SubAgentActivityKind` enum (`started`/`interacted`/`interrupted`).
- **`AuthMode::BedrockApiKey`**.
- **New `thread/delete` request and `thread/deleted` notification** (landed upstream after the drift report) — hand-wired through: `Notification` dispatch in `messages.rs`, method constants in `protocol.rs`, `thread_delete()` on both `AsyncClient`/`SyncClient`, the schema-coverage modeled registry, and the live-test exhaustive match.

## Verification

- `cargo run -p codex-codes --example schema_coverage` → **160/160 modeled (100%), all samples validate**
- `cargo clippy --all-targets --all-features -- -D warnings` clean workspace-wide
- All tests pass

Releases as **0.137.4** (version bump + CHANGELOG + README string).