### PR TITLE
codex-codes: 0.143.0 — re-snapshot schema drift (#172)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.142.0"
+version = "0.143.0"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.158`, tested against Claude CLI `2.1.178`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.142.0`, tested against Codex CLI `0.142.0`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.143.0`, tested against Codex CLI `0.143.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.
 

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   structs (resolves the codex-schema-drift report, issue #172). Schema coverage
   remains 165/165 (100%).
 - Bumped tested Codex CLI version to `0.143.0`.
+- Enriched the crate description, `keywords`, and `categories` for crates.io
+  discoverability (agent / Codex / OpenAI / async terms).
 
 ## [0.142.0] - 2026-06-24
 

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.143.0] - 2026-06-27
+
+### Added
+
+- **`McpServerStartupFailureReason`** enum (`reauthenticationRequired`) and a new
+  `failure_reason` field on `McpServerStatusUpdatedNotification`, distinguishing
+  why an MCP server failed to start.
+- **`ModelsRequirements`** / **`NewThreadModelDefaults`** types and a `models`
+  field on `ConfigRequirements`, carrying default model / reasoning-effort /
+  service-tier for new threads.
+- **`PluginSource::Npm`** variant (`package`, optional `registry` / `version`)
+  for npm-sourced plugins.
+- New optional fields on existing types: `thread_id` on
+  `McpServerOauthLoginCompletedNotification` and `McpServerOauthLoginParams`;
+  `action_name`, `app_name`, and `template_id` on `McpToolCallAppContext`;
+  `last_turn_id` on `ThreadForkParams`.
+
+### Changed
+
+- Re-snapshotted `codex_app_server_protocol{,.v2}.schemas.json` from
+  `openai/codex@main` (commit `6509f314`, 2026-06-26), regenerating the typed
+  structs (resolves the codex-schema-drift report, issue #172). Schema coverage
+  remains 165/165 (100%).
+- Bumped tested Codex CLI version to `0.143.0`.
+
 ## [0.142.0] - 2026-06-24
 
 ### Added

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.143.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]
-description = "A tightly typed Rust interface for the OpenAI Codex CLI JSON protocol"
+description = "Typed Rust SDK for the OpenAI Codex agent CLI: serde models of the codex app-server JSON-RPC protocol, plus sync and async (Tokio) clients for multi-turn Codex agent sessions, tool calls, and approvals."
 documentation = "https://docs.rs/codex-codes"
 homepage = "https://github.com/meawoppl/rust-code-agent-sdks"
 repository = "https://github.com/meawoppl/rust-code-agent-sdks"
 license = "Apache-2.0"
 readme = "README.md"
-keywords = ["codex", "openai", "ai", "json", "protocol"]
-categories = ["api-bindings", "encoding", "parsing"]
+keywords = ["codex", "openai", "agent", "llm", "cli"]
+categories = ["api-bindings", "asynchronous", "encoding", "parsing"]
 exclude = [
     "test_cases/",
     ".claude/",

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.142.0"
+version = "0.143.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/README.md
+++ b/codex-codes/README.md
@@ -14,7 +14,7 @@ Part of the [rust-code-agent-sdks](https://github.com/meawoppl/rust-code-agent-s
 
 This crate provides type-safe Rust representations of the Codex CLI's JSON-RPC protocol, used by `codex app-server`. It includes optional sync and async clients for multi-turn conversations with the Codex agent.
 
-**Tested against:** Codex CLI 0.142.0
+**Tested against:** Codex CLI 0.143.0
 
 ## Installation
 
@@ -193,7 +193,7 @@ Discriminated union of agent action items (shared between exec and app-server):
 
 ## Compatibility
 
-**Tested against:** Codex CLI 0.142.0
+**Tested against:** Codex CLI 0.143.0
 
 The crate version tracks the Codex CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -1309,6 +1309,8 @@ pub struct ConfigRequirements {
         skip_serializing_if = "Option::is_none"
     )]
     pub feature_requirements: Option<std::collections::BTreeMap<String, bool>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub models: Option<ModelsRequirements>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -3356,6 +3358,8 @@ pub struct McpServerOauthLoginCompletedNotification {
     pub name: String,
     #[serde(default)]
     pub success: bool,
+    #[serde(rename = "threadId", default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -3365,6 +3369,8 @@ pub struct McpServerOauthLoginParams {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scopes: Option<Vec<String>>,
+    #[serde(rename = "threadId", default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
     #[serde(
         rename = "timeoutSecs",
         default,
@@ -3385,6 +3391,12 @@ pub struct McpServerOauthLoginResponse {
 pub struct McpServerRefreshResponse {
     #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
     pub extra: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum McpServerStartupFailureReason {
+    #[serde(rename = "reauthenticationRequired")]
+    ReauthenticationRequired,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -3433,6 +3445,12 @@ pub enum McpServerStatusDetail {
 pub struct McpServerStatusUpdatedNotification {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    #[serde(
+        rename = "failureReason",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub failure_reason: Option<McpServerStartupFailureReason>,
     #[serde(default)]
     pub name: String,
     #[serde()]
@@ -3476,6 +3494,14 @@ pub struct McpServerToolCallResponse {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct McpToolCallAppContext {
+    #[serde(
+        rename = "actionName",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub action_name: Option<String>,
+    #[serde(rename = "appName", default, skip_serializing_if = "Option::is_none")]
+    pub app_name: Option<String>,
     #[serde(rename = "connectorId", default)]
     pub connector_id: String,
     #[serde(rename = "linkId", default, skip_serializing_if = "Option::is_none")]
@@ -3486,6 +3512,12 @@ pub struct McpToolCallAppContext {
         skip_serializing_if = "Option::is_none"
     )]
     pub resource_uri: Option<String>,
+    #[serde(
+        rename = "templateId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub template_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -3813,6 +3845,13 @@ pub struct ModelVerificationNotification {
     pub verifications: Vec<ModelVerification>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelsRequirements {
+    #[serde(rename = "newThread", default, skip_serializing_if = "Option::is_none")]
+    pub new_thread: Option<NewThreadModelDefaults>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum NetworkAccess {
     #[serde(rename = "restricted")]
@@ -3857,6 +3896,25 @@ pub enum NetworkPolicyRuleAction {
     Allow,
     #[serde(rename = "deny")]
     Deny,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewThreadModelDefaults {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(
+        rename = "modelReasoningEffort",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub model_reasoning_effort: Option<ReasoningEffort>,
+    #[serde(
+        rename = "serviceTier",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub service_tier: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -4611,6 +4669,13 @@ pub enum PluginSource {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         sha: Option<String>,
         url: String,
+    },
+    Npm {
+        package: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        registry: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        version: Option<String>,
     },
     Remote,
 }
@@ -5657,6 +5722,12 @@ pub struct ThreadForkParams {
     pub developer_instructions: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ephemeral: Option<bool>,
+    #[serde(
+        rename = "lastTurnId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub last_turn_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(

--- a/codex-codes/src/version.rs
+++ b/codex-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Codex CLI version we've tested against.
-const TESTED_VERSION: &str = "0.142.0";
+const TESTED_VERSION: &str = "0.143.0";
 
 /// Ensures version warning is only shown once per session.
 static VERSION_CHECK: Once = Once::new();

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -8414,6 +8414,16 @@
               "object",
               "null"
             ]
+          },
+          "models": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ModelsRequirements"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object"
@@ -12026,6 +12036,12 @@
           },
           "success": {
             "type": "boolean"
+          },
+          "threadId": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
@@ -12047,6 +12063,12 @@
             },
             "type": [
               "array",
+              "null"
+            ]
+          },
+          "threadId": {
+            "type": [
+              "string",
               "null"
             ]
           },
@@ -12081,6 +12103,12 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "McpServerRefreshResponse",
         "type": "object"
+      },
+      "McpServerStartupFailureReason": {
+        "enum": [
+          "reauthenticationRequired"
+        ],
+        "type": "string"
       },
       "McpServerStartupState": {
         "enum": [
@@ -12153,6 +12181,16 @@
               "null"
             ]
           },
+          "failureReason": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/McpServerStartupFailureReason"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "name": {
             "type": "string"
           },
@@ -12220,6 +12258,18 @@
       },
       "McpToolCallAppContext": {
         "properties": {
+          "actionName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "appName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "connectorId": {
             "type": "string"
           },
@@ -12230,6 +12280,12 @@
             ]
           },
           "resourceUri": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "templateId": {
             "type": [
               "string",
               "null"
@@ -12788,6 +12844,21 @@
         "title": "ModelVerificationNotification",
         "type": "object"
       },
+      "ModelsRequirements": {
+        "properties": {
+          "newThread": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/NewThreadModelDefaults"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
       "MultiAgentMode": {
         "description": "Controls whether the model receives multi-agent delegation instructions and, when it does, whether it should only spawn sub-agents after an explicit user request or may delegate proactively when doing so would help. `none` leaves the multi-agent tools available without injecting delegation instructions.",
         "enum": [
@@ -12934,6 +13005,33 @@
           "deny"
         ],
         "type": "string"
+      },
+      "NewThreadModelDefaults": {
+        "properties": {
+          "model": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "modelReasoningEffort": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ReasoningEffort"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "serviceTier": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
       },
       "NonSteerableTurnKind": {
         "enum": [
@@ -14107,6 +14205,40 @@
               "url"
             ],
             "title": "GitPluginSource",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "package": {
+                "type": "string"
+              },
+              "registry": {
+                "description": "Optional HTTPS registry URL. Authentication stays in the user's npm config.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "enum": [
+                  "npm"
+                ],
+                "title": "NpmPluginSourceType",
+                "type": "string"
+              },
+              "version": {
+                "description": "Optional npm version or version range.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "package",
+              "type"
+            ],
+            "title": "NpmPluginSource",
             "type": "object"
           },
           {
@@ -17189,6 +17321,13 @@
               }
             ],
             "description": "Optional client-supplied analytics source classification for this forked thread."
+          },
+        "lastTurnId": {
+          "description": "Optional last turn id to fork through, inclusive.\n\nWhen specified, turns after `last_turn_id` are omitted from the fork. The referenced turn cannot be in progress.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
@@ -17465,6 +17604,13 @@
         ],
         "title": "ThreadGoalUpdatedNotification",
         "type": "object"
+      },
+      "ThreadHistoryMode": {
+        "enum": [
+          "legacy",
+          "paginated"
+        ],
+        "type": "string"
       },
       "ThreadId": {
         "type": "string"
@@ -18985,6 +19131,7 @@
       },
       "ThreadRollbackParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "DEPRECATED: `thread/rollback` will be removed soon.",
         "properties": {
           "numTurns": {
             "description": "The number of turns to drop from the end of the thread. Must be >= 1.\n\nThis only modifies the thread's history and does not revert local file changes that have been made by the agent. Clients are responsible for reverting these changes.",

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -4654,6 +4654,16 @@
             "object",
             "null"
           ]
+        },
+        "models": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModelsRequirements"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "type": "object"
@@ -8430,6 +8440,12 @@
         },
         "success": {
           "type": "boolean"
+        },
+        "threadId": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -8451,6 +8467,12 @@
           },
           "type": [
             "array",
+            "null"
+          ]
+        },
+        "threadId": {
+          "type": [
+            "string",
             "null"
           ]
         },
@@ -8485,6 +8507,12 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "McpServerRefreshResponse",
       "type": "object"
+    },
+    "McpServerStartupFailureReason": {
+      "enum": [
+        "reauthenticationRequired"
+      ],
+      "type": "string"
     },
     "McpServerStartupState": {
       "enum": [
@@ -8557,6 +8585,16 @@
             "null"
           ]
         },
+        "failureReason": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/McpServerStartupFailureReason"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "name": {
           "type": "string"
         },
@@ -8624,6 +8662,18 @@
     },
     "McpToolCallAppContext": {
       "properties": {
+        "actionName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "appName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "connectorId": {
           "type": "string"
         },
@@ -8634,6 +8684,12 @@
           ]
         },
         "resourceUri": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "templateId": {
           "type": [
             "string",
             "null"
@@ -9192,6 +9248,21 @@
       "title": "ModelVerificationNotification",
       "type": "object"
     },
+    "ModelsRequirements": {
+      "properties": {
+        "newThread": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NewThreadModelDefaults"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
     "MultiAgentMode": {
       "description": "Controls whether the model receives multi-agent delegation instructions and, when it does, whether it should only spawn sub-agents after an explicit user request or may delegate proactively when doing so would help. `none` leaves the multi-agent tools available without injecting delegation instructions.",
       "enum": [
@@ -9338,6 +9409,33 @@
         "deny"
       ],
       "type": "string"
+    },
+    "NewThreadModelDefaults": {
+      "properties": {
+        "model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "modelReasoningEffort": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ReasoningEffort"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "serviceTier": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
     },
     "NonSteerableTurnKind": {
       "enum": [
@@ -10511,6 +10609,40 @@
             "url"
           ],
           "title": "GitPluginSource",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "package": {
+              "type": "string"
+            },
+            "registry": {
+              "description": "Optional HTTPS registry URL. Authentication stays in the user's npm config.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "enum": [
+                "npm"
+              ],
+              "title": "NpmPluginSourceType",
+              "type": "string"
+            },
+            "version": {
+              "description": "Optional npm version or version range.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "package",
+            "type"
+          ],
+          "title": "NpmPluginSource",
           "type": "object"
         },
         {
@@ -14968,6 +15100,13 @@
             }
           ],
           "description": "Optional client-supplied analytics source classification for this forked thread."
+        },
+        "lastTurnId": {
+          "description": "Optional last turn id to fork through, inclusive.\n\nWhen specified, turns after `last_turn_id` are omitted from the fork. The referenced turn cannot be in progress.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -15244,6 +15383,13 @@
       ],
       "title": "ThreadGoalUpdatedNotification",
       "type": "object"
+    },
+    "ThreadHistoryMode": {
+      "enum": [
+        "legacy",
+        "paginated"
+      ],
+      "type": "string"
     },
     "ThreadId": {
       "type": "string"
@@ -16764,6 +16910,7 @@
     },
     "ThreadRollbackParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "DEPRECATED: `thread/rollback` will be removed soon.",
       "properties": {
         "numTurns": {
           "description": "The number of turns to drop from the end of the thread. Must be >= 1.\n\nThis only modifies the thread's history and does not revert local file changes that have been made by the agent. Clients are responsible for reverting these changes.",


### PR DESCRIPTION
Resolves #172.

## Schema re-snapshot
Re-snapshotted `codex_app_server_protocol{,.v2}.schemas.json` from `openai/codex@main` (commit `6509f314`, 2026-06-26) and regenerated the typed structs via `scripts/codegen_protocol.py`. Schema coverage stays at 165/165 (100%).

### Added types / fields
- `McpServerStartupFailureReason` enum + `failure_reason` on `McpServerStatusUpdatedNotification`
- `ModelsRequirements` / `NewThreadModelDefaults` + `models` on `ConfigRequirements`
- `PluginSource::Npm` variant
- New optional fields: `thread_id` on `McpServerOauthLoginCompletedNotification` and `McpServerOauthLoginParams`; `action_name` / `app_name` / `template_id` on `McpToolCallAppContext`; `last_turn_id` on `ThreadForkParams`

The diff is fully additive. Bumped crate + tested CLI version to `0.143.0` (the `0.143` line on main).

## Crate metadata (discoverability)
Enriched the `codex-codes` crate `description`, `keywords`, and `categories` for crates.io search placement — agent / Codex / OpenAI / async terms, plus the `asynchronous` category. (`cargo package` validates the 5-keyword / category limits.)

## Verification
- `cargo run --example schema_coverage` → 165/165 (100%)
- `cargo test -p codex-codes` → 19 passed + doc-tests green
- `cargo build` clean