### PR TITLE
codex-codes: re-snapshot schema drift (#175)

### DIFF
--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -15510,6 +15510,12 @@
               "name": {
                 "type": "string"
               },
+              "namespace": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "status": {
                 "type": [
                   "string",
@@ -17279,6 +17285,13 @@
           "ephemeral": {
             "type": "boolean"
           },
+          "lastTurnId": {
+            "description": "Optional last turn id to fork through, inclusive.\n\nWhen specified, turns after `last_turn_id` are omitted from the fork. The referenced turn cannot be in progress.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "model": {
             "description": "Configuration overrides for the forked thread, if any.",
             "type": [
@@ -17321,13 +17334,6 @@
               }
             ],
             "description": "Optional client-supplied analytics source classification for this forked thread."
-          },
-        "lastTurnId": {
-          "description": "Optional last turn id to fork through, inclusive.\n\nWhen specified, turns after `last_turn_id` are omitted from the fork. The referenced turn cannot be in progress.",
-            "type": [
-              "string",
-              "null"
-            ]
           }
         },
         "required": [

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -11914,6 +11914,12 @@
             "name": {
               "type": "string"
             },
+            "namespace": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "status": {
               "type": [
                 "string",
@@ -15058,6 +15064,13 @@
         "ephemeral": {
           "type": "boolean"
         },
+        "lastTurnId": {
+          "description": "Optional last turn id to fork through, inclusive.\n\nWhen specified, turns after `last_turn_id` are omitted from the fork. The referenced turn cannot be in progress.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "model": {
           "description": "Configuration overrides for the forked thread, if any.",
           "type": [
@@ -15100,13 +15113,6 @@
             }
           ],
           "description": "Optional client-supplied analytics source classification for this forked thread."
-        },
-        "lastTurnId": {
-          "description": "Optional last turn id to fork through, inclusive.\n\nWhen specified, turns after `last_turn_id` are omitted from the fork. The referenced turn cannot be in progress.",
-          "type": [
-            "string",
-            "null"
-          ]
         }
       },
       "required": [


### PR DESCRIPTION
Resolves #175.

Re-snapshotted `codex_app_server_protocol{,.v2}.schemas.json` from `openai/codex@main` and regenerated via `scripts/codegen_protocol.py`.

**No generated-code change.** The upstream drift is schema-only:
- A `namespace` field added to an MCP-related `ResponseItem` sub-object.
- `lastTurnId` reordered within `ThreadForkParams` (codegen sorts fields → no Rust change).
- Trailing newline removed at EOF.

The typed structs and samples are byte-identical to before; this PR just re-syncs the committed snapshot so the drift check passes.

**No version bump** (not publishing right away).

## Verification
- `cargo run --example schema_coverage` → 165/165 (100%)
- `cargo test -p codex-codes` → all pass (57 + 19 + doc-tests)