### PR TITLE
workspace: hoist shared deps and lint policy to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,19 @@
 [workspace]
 members = ["claude-codes", "codex-codes"]
 resolver = "2"
+
+# Dependencies shared across workspace crates. Members reference these with
+# `dep = { workspace = true }` so versions move in lockstep.
+[workspace.dependencies]
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.143"
+thiserror = "2.0.16"
+tokio = { version = "1.49.0", features = ["full"] }
+log = "0.4.29"
+which = "8.0.2"
+env_logger = "0.11.9"
+
+# Lint policy shared across workspace crates. Members opt in with
+# `[lints] workspace = true`.
+[workspace.lints.rust]
+unsafe_code = "forbid"

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Shared dependencies and lint policy moved to the workspace root: this crate now
+  references `serde`, `serde_json`, `thiserror`, `tokio`, `log`, `which`, and dev
+  `env_logger` via `{ workspace = true }`, and opts into `[workspace.lints]`
+  (`unsafe_code = "forbid"`) via `[lints] workspace = true`. No dependency version
+  or runtime behavior change. Not yet released.
+
 ## [2.1.159] - 2026-06-27
 
 ### Added

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -17,19 +17,22 @@ exclude = [
     "*.sh",
 ]
 
+[lints]
+workspace = true
+
 [dependencies]
 # Core dependencies always needed for types
 chrono = { version = "0.4.41", features = ["serde"] }
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.143"
-thiserror = "2.0.16"
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 uuid = { version = "1.18.0", default-features = false, features = ["serde"] }
 
 # Optional dependencies for clients
 anyhow = { version = "1.0.99", optional = true }
-tokio = { version = "1.47.1", features = ["full"], optional = true }
-log = { version = "0.4.27", optional = true }
-which = { version = "8.0.2", optional = true }
+tokio = { workspace = true, optional = true }
+log = { workspace = true, optional = true }
+which = { workspace = true, optional = true }
 
 [features]
 default = ["types", "sync-client", "async-client"]
@@ -40,10 +43,10 @@ integration-tests = []
 log = ["dep:log"]
 
 [dev-dependencies]
-env_logger = "0.11.8"
+env_logger = { workspace = true }
 base64 = "0.22.1"
 uuid = { version = "1.18.0", features = ["v4"] }
-tokio = { version = "1.47.1", features = ["full"] }
+tokio = { workspace = true }
 anyhow = "1.0.99"
 
 [[example]]

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Shared dependencies and lint policy moved to the workspace root: this crate now
+  references `serde`, `serde_json`, `thiserror`, `tokio`, `log`, `which`, and dev
+  `env_logger` via `{ workspace = true }`, and opts into `[workspace.lints]`
+  (`unsafe_code = "forbid"`) via `[lints] workspace = true`. No dependency version
+  or runtime behavior change. Not yet released.
+
 ## [0.143.0] - 2026-06-27
 
 ### Added

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -18,19 +18,22 @@ exclude = [
     "*.sh",
 ]
 
+[lints]
+workspace = true
+
 [dependencies]
-log = { version = "0.4.29", optional = true }
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.143"
-thiserror = "2.0.16"
-tokio = { version = "1.49.0", features = ["full"], optional = true }
-which = { version = "8.0.2", optional = true }
+log = { workspace = true, optional = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, optional = true }
+which = { workspace = true, optional = true }
 
 [dev-dependencies]
-env_logger = "0.11.9"
+env_logger = { workspace = true }
 jsonschema = "0.46.5"
-serde_json = "1.0.143"
-tokio = { version = "1.49.0", features = ["full"] }
+serde_json = { workspace = true }
+tokio = { workspace = true }
 
 [features]
 default = ["types", "sync-client", "async-client"]


### PR DESCRIPTION
Implements maintainability bump #3.

## What
- **`[workspace.dependencies]`** — hoisted the deps shared by both crates (`serde`, `serde_json`, `thiserror`, `tokio`, `log`, `which`, dev `env_logger`). Members now reference them via `dep = { workspace = true }`, keeping versions in lockstep. Crate-specific deps (`chrono`, `uuid`, `anyhow`, `base64`, `jsonschema`) stay local.
- **`[workspace.lints]`** — added a shared lint policy (`unsafe_code = "forbid"`; no `unsafe` exists in either crate) with both crates opting in via `[lints] workspace = true`. Single place to evolve lint policy going forward.

## Why
The manifests had drifted: claude declared `tokio 1.47.1` / `log 0.4.27` while codex declared `tokio 1.49.0` / `log 0.4.29` (and `env_logger` 0.11.8 vs 0.11.9). The resolver already unified these in the lockfile, so this is manifest hygiene — but it stops the declared minimums from diverging further and gives one source of truth.

`Cargo.lock` is unchanged (versions were already unified by the resolver).

## Verification
- `cargo build --workspace --all-features` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` (the CI gate) — clean, incl. types-only feature combo
- `cargo test --workspace` — all pass

No version bump (internal build change, nothing to publish).