### PR TITLE
codex-codes: record #175 schema re-snapshot under Unreleased

### DIFF
--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Re-snapshotted `codex_app_server_protocol{,.v2}.schemas.json` from
+  `openai/codex@main` (resolves the codex-schema-drift report, issue #175, via
+  #176). Schema-only delta — the generated structs and samples are byte-identical:
+  upstream added an optional `namespace` field to an MCP `ResponseItem`
+  sub-object, reordered `lastTurnId` within `ThreadForkParams` (codegen sorts
+  fields), and dropped the trailing newline. Schema coverage stays 165/165
+  (100%). Not yet released.
+
 ## [0.143.0] - 2026-06-27
 
 ### Added


### PR DESCRIPTION
Closes the changelog gap from #176: the #175 schema re-snapshot merged without a CHANGELOG note because we intentionally skipped the version bump.

Adds an `## [Unreleased]` section (per the Keep a Changelog format the file already follows) recording the schema-only delta. The next `codex-codes` release renames `[Unreleased]` to its version.

No code or version change.