### PR TITLE
docs: Claude CLI re-snapshotting guide and schema extraction script

### DIFF
--- a/claude-codes/RESNAPSHOTTING.md
+++ b/claude-codes/RESNAPSHOTTING.md
@@ -1,0 +1,112 @@
+# Re-snapshotting claude-codes against a new Claude Code CLI
+
+The Claude Code stream-json protocol evolves with every CLI release. This doc
+describes how to extract the CLI's actual wire schemas from the shipped binary
+and diff them against this crate, so any agent or contributor can repeat the
+process. It was first run against CLI 2.1.205 (PR #180, issues #181–#191).
+
+## Where the code lives
+
+The npm package `@anthropic-ai/claude-code` is only a downloader shim — there
+is no `cli.js` in it anymore. The real bundle is a **Bun-compiled ELF** with
+the JavaScript embedded as plain bytes:
+
+```bash
+claude update                      # get the newest version first
+readlink -f "$(which claude)"      # → ~/.local/share/claude/versions/<version>
+```
+
+Because the JS is embedded uncompressed, everything below is byte-level
+`grep -a` / Python `re` over the ELF. No unpacking required.
+
+## Step 1 — extract the SDK output schemas
+
+```bash
+python3 scripts/extract_claude_sdk_schemas.py -o /tmp/claude_sdk_schemas.txt
+```
+
+The CLI defines its wire types as lazy zod schemas,
+`NAME=Se(()=>E.object({type:E.literal("..."),...}))`, and the SDK output
+union is an `E.union([NAME(), ...])` over ~40 of them. Minified names change
+every release; the structure does not. The script anchors on the
+`rate_limit_event` literal, finds the union that references it, and dumps
+every member schema plus transitive references, each labeled with its
+resolved `type`/`subtype`.
+
+If the script fails to find the anchor or union, the bundle layout changed;
+fall back to manual spelunking (below) and update the script.
+
+## Step 2 — diff against the crate
+
+Map each extracted schema to its crate type and compare field-by-field:
+
+| Wire type | Crate type (in `claude-codes/src/io/`) |
+|---|---|
+| `assistant` / `user` | `AssistantMessage`, `UserMessage` (`message_types.rs`) |
+| `result` (success + error subtypes) | `ResultMessage` (`result.rs`) |
+| `system/<subtype>` | `SystemSubtype` + per-subtype structs (`message_types.rs`) |
+| `rate_limit_event` | `RateLimitEvent` (`rate_limit.rs`) |
+| `control_request` / `control_response` | `control.rs` |
+| everything else | `ClaudeOutput` variants (`claude_output.rs`) |
+
+Things to check, in priority order:
+
+1. **New top-level `type` literals.** `ClaudeOutput` is `#[serde(tag = "type")]`
+   with no catch-all — an unmodeled type fails typed decode outright.
+2. **Closed enums.** Any derive-serde enum without an `Unknown(String)`
+   fallback hard-fails the whole frame when the CLI adds a value. Prefer the
+   manual `as_str` / `From<&str>` / serde pattern used throughout the crate.
+3. **Required → optional flips.** A crate field that is required while the
+   wire schema says `.optional()` fails to parse frames that omit it.
+4. **New fields.** Dropped on round-trip; the `assert_fully_wrapped` audit
+   catches these for `system` frames.
+
+Two caveats that save confusion:
+
+- The `message` payloads of `assistant`/`user`, the `stream_event` `event`,
+  and the result `usage` are `E.unknown()` in the CLI's own schema — raw
+  Anthropic API passthrough. The crate types those against the API shape,
+  not the CLI schema, so "the zod says unknown" is not drift.
+- Minified names collide across bundle modules. When extracting by hand,
+  prefer the definition nearest the union's byte offset.
+
+## Manual spelunking recipes
+
+Enumerate every wire `type`/`subtype` literal (broader than the SDK union —
+includes internal orchestrator frames):
+
+```bash
+grep -aoE 'type:E\.literal\("[a-z_]+"\)' <binary> | sort | uniq -c
+grep -aoE 'subtype:E\.literal\("[a-z_0-9]+"\)' <binary> | sort | uniq -c
+```
+
+Pull context around any anchor string (Python is much faster than grep's
+regex context on a ~250 MB binary):
+
+```python
+data = open(BINARY, 'rb').read()
+i = data.find(b'some_anchor_string')
+print(data[i-500:i+1500].decode('utf-8', 'replace'))
+```
+
+Definitions end where the next `NAME=Se(` begins — split on that boundary
+rather than balanced-paren parsing (regex literals in the minified JS break
+paren counting).
+
+Non-protocol provenance worth knowing (for fixtures and header-derived
+state): live quota values in `rate_limit_event` come from
+`anthropic-ratelimit-unified-*` response headers (including per-window
+`-{5h|7d|7d_oi|overage}-utilization` / `-reset` pairs), the `/usage` panel
+comes from `GET /api/oauth/usage`, and the CLI fires a 1-max-token probe
+request (body `"quota"`, `source: "quota_check"`) at startup purely to
+harvest those headers.
+
+## Step 3 — land the changes
+
+- File one issue per drifted type/area with the extracted schema excerpt
+  (see #181–#191 for the shape), or fix directly.
+- Follow the crate conventions: `skip_serializing_if = "Option::is_none"`,
+  `Unknown(String)` fallbacks, round-trip tests against a full-fat JSON
+  frame, `CHANGELOG.md` entry under `[Unreleased]`.
+- Update the tested CLI version pin when the integration suite passes
+  against the new binary.

--- a/claude.md
+++ b/claude.md
@@ -13,6 +13,21 @@ This project follows a test-driven development approach for implementing the Cla
 5. **Verify Implementation**: Run `cargo test deserialization` to ensure the new types deserialize correctly
 6. **Lock in Progress**: Successful test cases prove our protocol implementation is correct
 
+### Re-snapshotting against a new Claude CLI
+
+To check claude-codes against the wire schema a new CLI version actually
+ships, extract the zod schemas straight from the compiled binary and diff:
+
+```bash
+claude update
+python3 scripts/extract_claude_sdk_schemas.py -o /tmp/claude_sdk_schemas.txt
+```
+
+Full procedure — where the bundle lives, how to map schemas to crate types,
+what counts as drift, manual spelunking recipes — is documented in
+**`claude-codes/RESNAPSHOTTING.md`**. Run this whenever the CLI version moves
+meaningfully past the crate's tested pin.
+
 ## Git Workflow Requirements
 
 **CRITICAL: This repository enforces a strict PR-based workflow**

--- a/scripts/extract_claude_sdk_schemas.py
+++ b/scripts/extract_claude_sdk_schemas.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Extract the Claude Code CLI's SDK stream-json output schemas from the
+compiled CLI binary, for diffing against the claude-codes crate.
+
+The CLI ships as a Bun-compiled ELF with the bundled JavaScript embedded as
+plain bytes, so the zod schema definitions are recoverable with byte-level
+regex work — no unpacking needed. The wire schemas are lazy zod definitions
+of the form `NAME=Se(()=>E.object({type:E.literal("..."),...}))`, and the
+SDK output union is an `E.union([NAME(), ...])` over ~40 of them.
+
+Minified names change every release; the *structure* does not. This script
+anchors on the `rate_limit_event` literal (a stable, unique member), finds
+the union that references it, then extracts every member schema plus
+transitive references.
+
+Usage:
+  python3 scripts/extract_claude_sdk_schemas.py [BINARY] [-o OUT.txt]
+
+BINARY defaults to the resolved `claude` on PATH (follow the symlink to
+~/.local/share/claude/versions/<version>). Output is one block per schema,
+labeled with its resolved type/subtype, written to stdout or -o.
+
+Exits 0 on success, 1 if the anchor or union cannot be located (usually
+means the bundle layout changed — see claude-codes/RESNAPSHOTTING.md).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+from pathlib import Path
+
+# A schema definition ends where the next `NAME=Se(` begins.
+BOUNDARY = re.compile(rb"[,;({\[]\s*[A-Za-z_$][\w$]{1,6}=Se\(")
+# Calls to other lazy schemas inside a definition body: `ref()`.
+REF_CALL = re.compile(r"\b([A-Za-z_$][\w$]{1,6})\(\)")
+
+
+def resolve_binary(arg: str | None) -> Path:
+    if arg:
+        return Path(arg)
+    on_path = shutil.which("claude")
+    if not on_path:
+        sys.exit("error: no `claude` on PATH; pass the binary path explicitly")
+    return Path(on_path).resolve()
+
+
+def find_definitions(data: bytes, name: str) -> list[tuple[int, bytes]]:
+    """Every `NAME=Se(...)` definition as (offset, body-bytes).
+
+    Minified names collide across bundle modules, so callers must pick the
+    candidate nearest the union (see `pick_definition`).
+    """
+    pat = re.compile(rb"[^\w$]" + re.escape(name.encode()) + rb"=Se\(")
+    out = []
+    for m in pat.finditer(data):
+        nxt = BOUNDARY.search(data, m.end())
+        end = nxt.start() + 1 if nxt else m.end() + 20_000
+        out.append((m.start() + 1, data[m.start() + 1 : end]))
+    return out
+
+
+def pick_definition(cands: list[tuple[int, bytes]], anchor: int) -> bytes | None:
+    if not cands:
+        return None
+    return min(cands, key=lambda c: abs(c[0] - anchor))[1]
+
+
+def label_of(body: str) -> str:
+    t = re.search(r'type:E\.literal\("([a-z_]+)"\)', body)
+    s = re.search(r'subtype:E\.literal\("([a-z_0-9]+)"\)', body)
+    if t and s:
+        return f"{t.group(1)}/{s.group(1)}"
+    if t:
+        return t.group(1)
+    return "(nested)"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("binary", nargs="?", help="path to the claude CLI ELF")
+    ap.add_argument("-o", "--out", help="write schemas here instead of stdout")
+    args = ap.parse_args()
+
+    binary = resolve_binary(args.binary)
+    data = binary.read_bytes()
+    print(f"# read {binary} ({len(data):,} bytes)", file=sys.stderr)
+
+    # 1. Anchor: the schema whose body contains the rate_limit_event literal.
+    m = re.search(
+        rb'([A-Za-z_$][\w$]{1,6})=Se\(\(\)=>E\.object\(\{type:E\.literal\("rate_limit_event"\)',
+        data,
+    )
+    if not m:
+        sys.exit("error: rate_limit_event anchor schema not found — bundle layout changed?")
+    anchor_name, anchor_off = m.group(1).decode(), m.start()
+    print(f"# anchor: {anchor_name} at {anchor_off}", file=sys.stderr)
+
+    # 2. The union that calls the anchor: `=Se(()=>E.union([...anchor()...]))`.
+    union_pat = re.compile(rb"[A-Za-z_$][\w$]{1,6}=Se\(\(\)=>E\.union\(\[[^\]]*\]\)\)")
+    union = None
+    for um in union_pat.finditer(data):
+        if (anchor_name + "()").encode() in um.group(0):
+            union = um
+            break
+    if union is None:
+        sys.exit("error: SDK output union referencing the anchor not found")
+    members = re.findall(r"([A-Za-z_$][\w$]{1,6})\(\)", union.group(0).decode())
+    print(f"# union at {union.start()}: {len(members)} members", file=sys.stderr)
+
+    # 3. Extract members + transitive refs, nearest-to-union on name collisions.
+    blocks: list[str] = [f"// SDK output union ({len(members)} members)\n{union.group(0).decode()}"]
+    seen: set[str] = set()
+    queue = list(dict.fromkeys(members))
+    while queue:
+        name = queue.pop(0)
+        if name in seen:
+            continue
+        seen.add(name)
+        body = pick_definition(find_definitions(data, name), union.start())
+        if body is None:
+            blocks.append(f"// {name}: NOT FOUND")
+            continue
+        text = body.decode("utf-8", "replace")
+        blocks.append(f"// {name}: {label_of(text)}\n{text}")
+        for ref in REF_CALL.findall(text):
+            if ref not in seen and ref not in queue:
+                queue.append(ref)
+
+    out = "\n\n".join(blocks) + "\n"
+    if args.out:
+        Path(args.out).write_text(out)
+        print(f"# wrote {len(blocks)} schemas to {args.out}", file=sys.stderr)
+    else:
+        sys.stdout.write(out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Makes the CLI schema-spelunking process repeatable by any agent or contributor:

- **`claude-codes/RESNAPSHOTTING.md`** — full procedure: where the Bun-compiled bundle lives (the npm package is just a downloader shim now), how to extract the zod wire schemas, how to map them to crate types, what counts as drift (missing top-level types, closed enums, required→optional flips, new fields), manual spelunking recipes, and the `E.unknown()` passthrough caveat.
- **`scripts/extract_claude_sdk_schemas.py`** — automated extraction. Anchors on the `rate_limit_event` literal (stable across releases, unlike minified names), resolves the SDK output union, and dumps all members plus transitive refs, each labeled with its resolved `type`/`subtype`. Verified end-to-end against CLI 2.1.205: 39 union members, 69 schemas total, all labeled correctly.
- **`claude.md`** — pointer section under Development Strategy so future sessions find it.

This is the process behind PR #180 and issues #181–#191. No version bump — docs and tooling only.
