### PR TITLE
claude-codes: add transcript corpus parser coverage

### DIFF
--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -37,6 +37,7 @@ types = []
 sync-client = ["types", "anyhow", "log", "uuid/v4", "dep:which"]
 async-client = ["types", "anyhow", "tokio", "log", "uuid/v4", "dep:which"]
 integration-tests = []
+corpus-test = []
 log = ["dep:log"]
 
 [dev-dependencies]

--- a/claude-codes/examples/basic_repl.rs
+++ b/claude-codes/examples/basic_repl.rs
@@ -315,5 +315,19 @@ fn handle_output(output: ClaudeOutput) {
                 reset.session_id, reset.new_conversation_id
             );
         }
+        ClaudeOutput::TranscriptResult(msg)
+        | ClaudeOutput::Progress(msg)
+        | ClaudeOutput::QueueOperation(msg)
+        | ClaudeOutput::PrLink(msg)
+        | ClaudeOutput::FileHistorySnapshot(msg)
+        | ClaudeOutput::Summary(msg)
+        | ClaudeOutput::Mode(msg)
+        | ClaudeOutput::PermissionMode(msg)
+        | ClaudeOutput::Attachment(msg)
+        | ClaudeOutput::AiTitle(msg)
+        | ClaudeOutput::LastPrompt(msg)
+        | ClaudeOutput::Started(msg) => {
+            debug!("Transcript-only message with {} field(s)", msg.data.len());
+        }
     }
 }

--- a/claude-codes/src/io/claude_output.rs
+++ b/claude-codes/src/io/claude_output.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::{Map, Value};
 
 use super::content_blocks::{ContentBlock, ToolUseBlock};
 use super::control::{ControlRequest, ControlResponse};
@@ -9,7 +9,7 @@ use super::rate_limit::RateLimitEvent;
 use super::result::ResultMessage;
 
 /// Top-level enum for all possible Claude output messages
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ClaudeOutput {
     /// System initialization message
@@ -23,6 +23,10 @@ pub enum ClaudeOutput {
 
     /// Result message (completion of a query)
     Result(ResultMessage),
+
+    /// Claude Code internal workflow-journal result event.
+    #[serde(rename = "result")]
+    TranscriptResult(TranscriptMessage),
 
     /// Control request from CLI (tool permissions, hooks, etc.)
     ControlRequest(ControlRequest),
@@ -53,6 +57,45 @@ pub enum ClaudeOutput {
 
     /// Conversation reset notification.
     ConversationReset(ConversationResetMessage),
+
+    /// Claude Code internal transcript progress event.
+    Progress(TranscriptMessage),
+
+    /// Claude Code internal queue event.
+    #[serde(rename = "queue-operation")]
+    QueueOperation(TranscriptMessage),
+
+    /// Claude Code internal PR link metadata event.
+    #[serde(rename = "pr-link")]
+    PrLink(TranscriptMessage),
+
+    /// Claude Code internal file history snapshot event.
+    #[serde(rename = "file-history-snapshot")]
+    FileHistorySnapshot(TranscriptMessage),
+
+    /// Claude Code internal session summary event.
+    Summary(TranscriptMessage),
+
+    /// Claude Code internal mode metadata event.
+    Mode(TranscriptMessage),
+
+    /// Claude Code internal permission mode metadata event.
+    #[serde(rename = "permission-mode")]
+    PermissionMode(TranscriptMessage),
+
+    /// Claude Code internal attachment metadata event.
+    Attachment(TranscriptMessage),
+
+    /// Claude Code internal AI-generated title event.
+    #[serde(rename = "ai-title")]
+    AiTitle(TranscriptMessage),
+
+    /// Claude Code internal last prompt pointer event.
+    #[serde(rename = "last-prompt")]
+    LastPrompt(TranscriptMessage),
+
+    /// Claude Code internal session started event.
+    Started(TranscriptMessage),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -112,6 +155,18 @@ pub struct ConversationResetMessage {
     pub session_id: String,
 }
 
+/// Raw preserved record for Claude Code transcript-only message types.
+///
+/// These events are emitted in `~/.claude/projects/**/*.jsonl`, not in the
+/// public `--output-format stream-json` protocol. Keeping them typed at the
+/// top level lets corpus tests parse real transcript files without losing the
+/// original payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TranscriptMessage {
+    #[serde(flatten)]
+    pub data: Map<String, Value>,
+}
+
 impl ClaudeOutput {
     /// Get the message type as a string
     pub fn message_type(&self) -> String {
@@ -120,6 +175,7 @@ impl ClaudeOutput {
             ClaudeOutput::User(_) => "user".to_string(),
             ClaudeOutput::Assistant(_) => "assistant".to_string(),
             ClaudeOutput::Result(_) => "result".to_string(),
+            ClaudeOutput::TranscriptResult(_) => "result".to_string(),
             ClaudeOutput::ControlRequest(_) => "control_request".to_string(),
             ClaudeOutput::ControlResponse(_) => "control_response".to_string(),
             ClaudeOutput::Error(_) => "error".to_string(),
@@ -130,6 +186,17 @@ impl ClaudeOutput {
             ClaudeOutput::ToolUseSummary(_) => "tool_use_summary".to_string(),
             ClaudeOutput::PromptSuggestion(_) => "prompt_suggestion".to_string(),
             ClaudeOutput::ConversationReset(_) => "conversation_reset".to_string(),
+            ClaudeOutput::Progress(_) => "progress".to_string(),
+            ClaudeOutput::QueueOperation(_) => "queue-operation".to_string(),
+            ClaudeOutput::PrLink(_) => "pr-link".to_string(),
+            ClaudeOutput::FileHistorySnapshot(_) => "file-history-snapshot".to_string(),
+            ClaudeOutput::Summary(_) => "summary".to_string(),
+            ClaudeOutput::Mode(_) => "mode".to_string(),
+            ClaudeOutput::PermissionMode(_) => "permission-mode".to_string(),
+            ClaudeOutput::Attachment(_) => "attachment".to_string(),
+            ClaudeOutput::AiTitle(_) => "ai-title".to_string(),
+            ClaudeOutput::LastPrompt(_) => "last-prompt".to_string(),
+            ClaudeOutput::Started(_) => "started".to_string(),
         }
     }
 
@@ -237,9 +304,18 @@ impl ClaudeOutput {
     /// ```
     pub fn session_id(&self) -> Option<&str> {
         match self {
-            ClaudeOutput::System(sys) => sys.data.get("session_id").and_then(|v| v.as_str()),
+            ClaudeOutput::System(sys) => sys
+                .data
+                .get("session_id")
+                .or_else(|| sys.data.get("sessionId"))
+                .and_then(|v| v.as_str()),
             ClaudeOutput::Assistant(ass) => Some(&ass.session_id),
             ClaudeOutput::Result(res) => Some(&res.session_id),
+            ClaudeOutput::TranscriptResult(msg) => msg
+                .data
+                .get("session_id")
+                .or_else(|| msg.data.get("sessionId"))
+                .and_then(|v| v.as_str()),
             ClaudeOutput::User(_) => None,
             ClaudeOutput::ControlRequest(_) => None,
             ClaudeOutput::ControlResponse(_) => None,
@@ -251,6 +327,21 @@ impl ClaudeOutput {
             ClaudeOutput::ToolUseSummary(msg) => Some(&msg.session_id),
             ClaudeOutput::PromptSuggestion(msg) => Some(&msg.session_id),
             ClaudeOutput::ConversationReset(msg) => Some(&msg.session_id),
+            ClaudeOutput::Progress(msg)
+            | ClaudeOutput::QueueOperation(msg)
+            | ClaudeOutput::PrLink(msg)
+            | ClaudeOutput::FileHistorySnapshot(msg)
+            | ClaudeOutput::Summary(msg)
+            | ClaudeOutput::Mode(msg)
+            | ClaudeOutput::PermissionMode(msg)
+            | ClaudeOutput::Attachment(msg)
+            | ClaudeOutput::AiTitle(msg)
+            | ClaudeOutput::LastPrompt(msg)
+            | ClaudeOutput::Started(msg) => msg
+                .data
+                .get("session_id")
+                .or_else(|| msg.data.get("sessionId"))
+                .and_then(|v| v.as_str()),
         }
     }
 
@@ -451,6 +542,87 @@ impl ClaudeOutput {
     }
 }
 
+impl<'de> Deserialize<'de> for ClaudeOutput {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = Value::deserialize(deserializer)?;
+        let message_type = value
+            .get("type")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| serde::de::Error::missing_field("type"))?;
+        let mut payload = value.clone();
+        if let Some(obj) = payload.as_object_mut() {
+            obj.remove("type");
+        }
+
+        fn parse<T, E>(value: Value) -> Result<T, E>
+        where
+            T: serde::de::DeserializeOwned,
+            E: serde::de::Error,
+        {
+            serde_json::from_value(value).map_err(E::custom)
+        }
+
+        match message_type {
+            "system" => parse(payload).map(Self::System),
+            "user" => parse(payload).map(Self::User),
+            "assistant" => parse(payload).map(Self::Assistant),
+            "result" if value.get("subtype").is_some() => parse(payload).map(Self::Result),
+            "result" => parse(payload).map(Self::TranscriptResult),
+            "control_request" => parse(payload).map(Self::ControlRequest),
+            "control_response" => parse(payload).map(Self::ControlResponse),
+            "error" => parse(payload).map(Self::Error),
+            "rate_limit_event" => parse(payload).map(Self::RateLimitEvent),
+            "stream_event" => parse(payload).map(Self::StreamEvent),
+            "tool_progress" => parse(payload).map(Self::ToolProgress),
+            "auth_status" => parse(payload).map(Self::AuthStatus),
+            "tool_use_summary" => parse(payload).map(Self::ToolUseSummary),
+            "prompt_suggestion" => parse(payload).map(Self::PromptSuggestion),
+            "conversation_reset" => parse(payload).map(Self::ConversationReset),
+            "progress" => parse(payload).map(Self::Progress),
+            "queue-operation" => parse(payload).map(Self::QueueOperation),
+            "pr-link" => parse(payload).map(Self::PrLink),
+            "file-history-snapshot" => parse(payload).map(Self::FileHistorySnapshot),
+            "summary" => parse(payload).map(Self::Summary),
+            "mode" => parse(payload).map(Self::Mode),
+            "permission-mode" => parse(payload).map(Self::PermissionMode),
+            "attachment" => parse(payload).map(Self::Attachment),
+            "ai-title" => parse(payload).map(Self::AiTitle),
+            "last-prompt" => parse(payload).map(Self::LastPrompt),
+            "started" => parse(payload).map(Self::Started),
+            other => Err(serde::de::Error::unknown_variant(
+                other,
+                &[
+                    "system",
+                    "user",
+                    "assistant",
+                    "result",
+                    "control_request",
+                    "control_response",
+                    "error",
+                    "rate_limit_event",
+                    "stream_event",
+                    "tool_progress",
+                    "auth_status",
+                    "tool_use_summary",
+                    "prompt_suggestion",
+                    "conversation_reset",
+                    "progress",
+                    "queue-operation",
+                    "pr-link",
+                    "file-history-snapshot",
+                    "summary",
+                    "mode",
+                    "permission-mode",
+                    "attachment",
+                    "ai-title",
+                    "last-prompt",
+                    "started",
+                ],
+            )),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -506,6 +678,91 @@ mod tests {
             assert_eq!(output.message_type(), message_type);
             assert!(output.session_id().is_some());
         }
+    }
+
+    #[test]
+    fn test_deserialize_transcript_only_message_types() {
+        let cases = [
+            (
+                r#"{"type":"progress","sessionId":"s1","content":"delta"}"#,
+                "progress",
+                Some("s1"),
+            ),
+            (
+                r#"{"type":"queue-operation","sessionId":"s2","operation":"push"}"#,
+                "queue-operation",
+                Some("s2"),
+            ),
+            (
+                r#"{"type":"pr-link","sessionId":"s3","url":"https://example.invalid/pr"}"#,
+                "pr-link",
+                Some("s3"),
+            ),
+            (
+                r#"{"type":"file-history-snapshot","sessionId":"s4","files":[]}"#,
+                "file-history-snapshot",
+                Some("s4"),
+            ),
+            (r#"{"type":"summary","summary":"Done"}"#, "summary", None),
+            (
+                r#"{"type":"mode","mode":"normal","sessionId":"s5"}"#,
+                "mode",
+                Some("s5"),
+            ),
+            (
+                r#"{"type":"permission-mode","permissionMode":"default","sessionId":"s6"}"#,
+                "permission-mode",
+                Some("s6"),
+            ),
+            (
+                r#"{"type":"attachment","attachment":{"type":"task_reminder"},"sessionId":"s7"}"#,
+                "attachment",
+                Some("s7"),
+            ),
+            (
+                r#"{"type":"ai-title","aiTitle":"Title","sessionId":"s8"}"#,
+                "ai-title",
+                Some("s8"),
+            ),
+            (
+                r#"{"type":"last-prompt","lastPrompt":"prompt","sessionId":"s9"}"#,
+                "last-prompt",
+                Some("s9"),
+            ),
+            (
+                r#"{"type":"started","sessionId":"s10"}"#,
+                "started",
+                Some("s10"),
+            ),
+            (
+                r#"{"type":"result","key":"k","agentId":"a","result":{"ok":true}}"#,
+                "result",
+                None,
+            ),
+        ];
+
+        for (json, message_type, session_id) in cases {
+            let output: ClaudeOutput = serde_json::from_str(json).unwrap();
+            assert_eq!(output.message_type(), message_type);
+            assert_eq!(output.session_id(), session_id);
+        }
+    }
+
+    #[test]
+    fn test_transcript_assistant_accepts_camel_case_session_id() {
+        let json = r#"{
+            "type": "assistant",
+            "sessionId": "camel-session",
+            "message": {
+                "id": "msg_123",
+                "role": "assistant",
+                "model": "claude-3-sonnet",
+                "content": [{"type": "text", "text": "Hello"}]
+            }
+        }"#;
+
+        let output: ClaudeOutput = serde_json::from_str(json).unwrap();
+        assert_eq!(output.session_id(), Some("camel-session"));
     }
 
     #[test]

--- a/claude-codes/src/io/message_types.rs
+++ b/claude-codes/src/io/message_types.rs
@@ -568,7 +568,7 @@ pub struct McpMeta {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserMessage {
     pub message: MessageContent,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "sessionId")]
     #[serde(
         serialize_with = "serialize_optional_uuid",
         deserialize_with = "deserialize_optional_uuid"
@@ -1870,6 +1870,7 @@ pub struct ToolUseMeta {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssistantMessage {
     pub message: AssistantMessageContent,
+    #[serde(alias = "sessionId")]
     pub session_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uuid: Option<String>,

--- a/claude-codes/src/io/rate_limit.rs
+++ b/claude-codes/src/io/rate_limit.rs
@@ -252,6 +252,7 @@ pub struct RateLimitEvent {
     /// Rate limit status details
     pub rate_limit_info: RateLimitInfo,
     /// Session identifier
+    #[serde(alias = "sessionId")]
     pub session_id: String,
     /// Unique identifier for this message
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/claude-codes/src/io/result.rs
+++ b/claude-codes/src/io/result.rs
@@ -39,6 +39,7 @@ pub struct ResultMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<String>,
 
+    #[serde(alias = "sessionId")]
     pub session_id: String,
     pub total_cost_usd: f64,
 

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -122,7 +122,7 @@ pub mod version;
 pub use error::{Error, Result};
 pub use io::{
     AnthropicError, AnthropicErrorDetails, ApiErrorType, AssistantMessageContent, ClaudeInput,
-    ClaudeOutput, ParseError,
+    ClaudeOutput, ParseError, TranscriptMessage,
 };
 pub use messages::*;
 pub use protocol::{MessageEnvelope, Protocol};

--- a/claude-codes/tests/README.md
+++ b/claude-codes/tests/README.md
@@ -25,6 +25,21 @@ cargo test --features integration-tests -- --nocapture
 cargo test --features integration-tests test_async_client_basic_query
 ```
 
+## Running Corpus Tests
+
+Real Claude Code transcript JSONL coverage is opt-in because the corpus lives
+outside the repository and can be large:
+
+```bash
+CLAUDE_CODES_CORPUS_DIR="$HOME/.claude/projects" \
+  cargo test --features corpus-test parse_configured_claude_transcript_corpus -- --nocapture
+```
+
+The corpus test recursively scans every `.jsonl` file under the configured
+directory, skips malformed JSON lines, parses valid lines with
+`ClaudeOutput::parse_json_tolerant()`, prints counts by message type, and fails
+on any valid JSON line that cannot be represented by the crate.
+
 ### Test Coverage
 
 The integration tests cover:

--- a/claude-codes/tests/corpus_tests.rs
+++ b/claude-codes/tests/corpus_tests.rs
@@ -1,0 +1,139 @@
+#![cfg(feature = "corpus-test")]
+
+use claude_codes::ClaudeOutput;
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+struct ParseFailure {
+    path: PathBuf,
+    line_number: usize,
+    message_type: Option<String>,
+    error: String,
+    raw: String,
+}
+
+#[test]
+fn parse_configured_claude_transcript_corpus() {
+    let Some(root) = std::env::var_os("CLAUDE_CODES_CORPUS_DIR").map(PathBuf::from) else {
+        eprintln!("CLAUDE_CODES_CORPUS_DIR is not set; skipping corpus test");
+        return;
+    };
+
+    let files = jsonl_files(&root).expect("read corpus directory");
+    assert!(
+        !files.is_empty(),
+        "no .jsonl files found under {}",
+        root.display()
+    );
+
+    let mut total_lines = 0usize;
+    let mut invalid_json = 0usize;
+    let mut parsed_by_type: BTreeMap<String, usize> = BTreeMap::new();
+    let mut failures = Vec::new();
+
+    for path in files {
+        scan_file(
+            &path,
+            &mut total_lines,
+            &mut invalid_json,
+            &mut parsed_by_type,
+            &mut failures,
+        )
+        .unwrap_or_else(|e| panic!("scan {}: {}", path.display(), e));
+    }
+
+    eprintln!("corpus lines: {}", total_lines);
+    eprintln!("invalid json lines skipped: {}", invalid_json);
+    eprintln!("parsed message types:");
+    for (message_type, count) in &parsed_by_type {
+        eprintln!("  {}: {}", message_type, count);
+    }
+
+    if !failures.is_empty() {
+        eprintln!("parse failures: {}", failures.len());
+        for failure in failures.iter().take(25) {
+            eprintln!(
+                "{}:{} type={:?}: {}\n{}",
+                failure.path.display(),
+                failure.line_number,
+                failure.message_type,
+                failure.error,
+                failure.raw
+            );
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} valid JSON corpus line(s) failed ClaudeOutput parsing",
+        failures.len()
+    );
+}
+
+fn jsonl_files(root: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+
+    while let Some(path) = stack.pop() {
+        let meta = fs::metadata(&path)?;
+        if meta.is_dir() {
+            for entry in fs::read_dir(&path)? {
+                stack.push(entry?.path());
+            }
+        } else if path.extension().and_then(|s| s.to_str()) == Some("jsonl") {
+            files.push(path);
+        }
+    }
+
+    files.sort();
+    Ok(files)
+}
+
+fn scan_file(
+    path: &Path,
+    total_lines: &mut usize,
+    invalid_json: &mut usize,
+    parsed_by_type: &mut BTreeMap<String, usize>,
+    failures: &mut Vec<ParseFailure>,
+) -> std::io::Result<()> {
+    let file = File::open(path)?;
+    for (idx, line) in BufReader::new(file).lines().enumerate() {
+        let line = line?;
+        let line_number = idx + 1;
+        if line.trim().is_empty() {
+            continue;
+        }
+        *total_lines += 1;
+
+        let raw_value = match serde_json::from_str::<Value>(&line) {
+            Ok(value) => value,
+            Err(_) => {
+                *invalid_json += 1;
+                continue;
+            }
+        };
+
+        let message_type = raw_value
+            .get("type")
+            .and_then(|v| v.as_str())
+            .map(ToOwned::to_owned);
+
+        match ClaudeOutput::parse_json_tolerant(&line) {
+            Ok(output) => {
+                *parsed_by_type.entry(output.message_type()).or_default() += 1;
+            }
+            Err(error) => failures.push(ParseFailure {
+                path: path.to_path_buf(),
+                line_number,
+                message_type,
+                error: error.error_message,
+                raw: line,
+            }),
+        }
+    }
+    Ok(())
+}

--- a/claude-codes/tests/corpus_tests.rs
+++ b/claude-codes/tests/corpus_tests.rs
@@ -62,7 +62,7 @@ fn parse_configured_claude_transcript_corpus() {
                 failure.line_number,
                 failure.message_type,
                 failure.error,
-                failure.raw
+                raw_preview(&failure.raw)
             );
         }
     }
@@ -136,4 +136,40 @@ fn scan_file(
         }
     }
     Ok(())
+}
+
+fn raw_preview(raw: &str) -> String {
+    const MAX_CHARS: usize = 500;
+
+    let mut chars = raw.chars();
+    let preview: String = chars.by_ref().take(MAX_CHARS).collect();
+    let remaining = chars.count();
+
+    if remaining == 0 {
+        preview
+    } else {
+        format!("{preview}... <truncated {remaining} chars>")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::raw_preview;
+
+    #[test]
+    fn raw_preview_keeps_short_lines_unchanged() {
+        assert_eq!(
+            raw_preview(r#"{"type":"unknown"}"#),
+            r#"{"type":"unknown"}"#
+        );
+    }
+
+    #[test]
+    fn raw_preview_truncates_long_lines_on_char_boundaries() {
+        let raw = format!("{}{}", "a".repeat(500), "b".repeat(3));
+        assert_eq!(
+            raw_preview(&raw),
+            format!("{}... <truncated 3 chars>", "a".repeat(500))
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add raw-preserving ClaudeOutput variants for Claude Code transcript-only JSONL records
- accept camelCase sessionId aliases on strict output structs used by transcripts
- add an opt-in corpus-test feature that scans CLAUDE_CODES_CORPUS_DIR recursively and fails on valid JSONL lines that ClaudeOutput cannot parse

Closes #97.

## Verification
- cargo test -p claude-codes
- cargo test -p claude-codes --features corpus-test parse_configured_claude_transcript_corpus -- --nocapture
- CLAUDE_CODES_CORPUS_DIR=$HOME/.claude/projects cargo test -p claude-codes --features corpus-test parse_configured_claude_transcript_corpus -- --nocapture
  - parsed 60,761 local transcript lines with 0 failures
- cargo test