### PR TITLE
claude-codes: cover Claude 2.1.205 schema drift

### DIFF
--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- **Claude Code CLI 2.1.205 output coverage.** Added typed coverage for new
+  top-level SDK frames (`stream_event`, `tool_progress`, `auth_status`,
+  `tool_use_summary`, `prompt_suggestion`, `conversation_reset`), 19 newer
+  `system` subtypes, richer result/init/status/compact/user/assistant wrapper
+  fields, and `get_usage` control-response quota payloads.
+
+### Changed (breaking)
+
+- `ClaudeOutput` gained additional variants, so exhaustive matches must handle
+  the new top-level frame types.
+- `ResultSubtype`, `TaskStatus`, and `TaskType` are now forward-compatible open
+  enums with `Unknown(String)` fallbacks.
+- `TaskStartedMessage.task_type`, `TaskStartedMessage.tool_use_id`, and
+  `TaskProgressMessage.last_tool_name` are now optional to match CLI 2.1.205
+  wire frames.
+
 ## [2.1.159] - 2026-06-27
 
 ### Added

--- a/claude-codes/examples/basic_repl.rs
+++ b/claude-codes/examples/basic_repl.rs
@@ -283,5 +283,37 @@ fn handle_output(output: ClaudeOutput) {
                 evt.rate_limit_info.resets_at
             );
         }
+        ClaudeOutput::StreamEvent(evt) => {
+            debug!("Stream event received for session {}", evt.session_id);
+        }
+        ClaudeOutput::ToolProgress(progress) => {
+            debug!(
+                "Tool progress: {} ({}) after {:.2}s",
+                progress.tool_name, progress.tool_use_id, progress.elapsed_time_seconds
+            );
+        }
+        ClaudeOutput::AuthStatus(status) => {
+            debug!(
+                "Auth status: authenticating={}, lines={}",
+                status.is_authenticating,
+                status.output.len()
+            );
+        }
+        ClaudeOutput::ToolUseSummary(summary) => {
+            debug!(
+                "Tool-use summary over {} tool(s): {}",
+                summary.preceding_tool_use_ids.len(),
+                summary.summary
+            );
+        }
+        ClaudeOutput::PromptSuggestion(suggestion) => {
+            debug!("Prompt suggestion: {}", suggestion.suggestion);
+        }
+        ClaudeOutput::ConversationReset(reset) => {
+            debug!(
+                "Conversation reset: {} -> {}",
+                reset.session_id, reset.new_conversation_id
+            );
+        }
     }
 }

--- a/claude-codes/src/io/claude_input.rs
+++ b/claude-codes/src/io/claude_input.rs
@@ -6,7 +6,10 @@ use super::content_blocks::{ContentBlock, ImageBlock, ImageSource, TextBlock};
 use super::control::{ControlRequest, ControlResponse};
 use super::message_types::{MessageContent, UserMessage};
 
-/// Top-level enum for all possible Claude input messages
+/// Top-level enum for all possible Claude input messages.
+///
+/// Keep variants unboxed so pattern matches and constructors stay ergonomic.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ClaudeInput {
@@ -42,6 +45,23 @@ impl ClaudeInput {
             tool_use_result: None,
             subagent_type: None,
             task_description: None,
+            origin: None,
+            priority: None,
+            is_synthetic: None,
+            should_query: None,
+            is_meta: None,
+            is_visible_in_transcript_only: None,
+            is_virtual: None,
+            is_compact_summary: None,
+            summarize_metadata: None,
+            mcp_meta: None,
+            source_tool_use_id: None,
+            source_tool_assistant_uuid: None,
+            image_paste_ids: None,
+            client_platform: None,
+            inbound_origin: None,
+            is_replay: None,
+            file_attachments: None,
         })
     }
 
@@ -59,6 +79,23 @@ impl ClaudeInput {
             tool_use_result: None,
             subagent_type: None,
             task_description: None,
+            origin: None,
+            priority: None,
+            is_synthetic: None,
+            should_query: None,
+            is_meta: None,
+            is_visible_in_transcript_only: None,
+            is_virtual: None,
+            is_compact_summary: None,
+            summarize_metadata: None,
+            mcp_meta: None,
+            source_tool_use_id: None,
+            source_tool_assistant_uuid: None,
+            image_paste_ids: None,
+            client_platform: None,
+            inbound_origin: None,
+            is_replay: None,
+            file_attachments: None,
         })
     }
 

--- a/claude-codes/src/io/claude_output.rs
+++ b/claude-codes/src/io/claude_output.rs
@@ -35,6 +35,81 @@ pub enum ClaudeOutput {
 
     /// Rate limit status event
     RateLimitEvent(RateLimitEvent),
+
+    /// Raw API stream event emitted with `--include-partial-messages`.
+    StreamEvent(StreamEventMessage),
+
+    /// Progress update for a running tool.
+    ToolProgress(ToolProgressMessage),
+
+    /// Authentication status update.
+    AuthStatus(AuthStatusMessage),
+
+    /// Summary of preceding tool uses.
+    ToolUseSummary(ToolUseSummaryMessage),
+
+    /// Predicted next user prompt.
+    PromptSuggestion(PromptSuggestionMessage),
+
+    /// Conversation reset notification.
+    ConversationReset(ConversationResetMessage),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamEventMessage {
+    pub event: Value,
+    pub parent_tool_use_id: Option<String>,
+    pub uuid: String,
+    pub session_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttft_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolProgressMessage {
+    pub tool_use_id: String,
+    pub tool_name: String,
+    pub parent_tool_use_id: Option<String>,
+    pub elapsed_time_seconds: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    pub uuid: String,
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthStatusMessage {
+    #[serde(rename = "isAuthenticating")]
+    pub is_authenticating: bool,
+    pub output: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    pub uuid: String,
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolUseSummaryMessage {
+    pub summary: String,
+    pub preceding_tool_use_ids: Vec<String>,
+    pub uuid: String,
+    pub session_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromptSuggestionMessage {
+    pub suggestion: String,
+    pub uuid: String,
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationResetMessage {
+    pub new_conversation_id: String,
+    pub uuid: String,
+    pub session_id: String,
 }
 
 impl ClaudeOutput {
@@ -49,6 +124,12 @@ impl ClaudeOutput {
             ClaudeOutput::ControlResponse(_) => "control_response".to_string(),
             ClaudeOutput::Error(_) => "error".to_string(),
             ClaudeOutput::RateLimitEvent(_) => "rate_limit_event".to_string(),
+            ClaudeOutput::StreamEvent(_) => "stream_event".to_string(),
+            ClaudeOutput::ToolProgress(_) => "tool_progress".to_string(),
+            ClaudeOutput::AuthStatus(_) => "auth_status".to_string(),
+            ClaudeOutput::ToolUseSummary(_) => "tool_use_summary".to_string(),
+            ClaudeOutput::PromptSuggestion(_) => "prompt_suggestion".to_string(),
+            ClaudeOutput::ConversationReset(_) => "conversation_reset".to_string(),
         }
     }
 
@@ -164,6 +245,12 @@ impl ClaudeOutput {
             ClaudeOutput::ControlResponse(_) => None,
             ClaudeOutput::Error(_) => None,
             ClaudeOutput::RateLimitEvent(evt) => Some(&evt.session_id),
+            ClaudeOutput::StreamEvent(msg) => Some(&msg.session_id),
+            ClaudeOutput::ToolProgress(msg) => Some(&msg.session_id),
+            ClaudeOutput::AuthStatus(msg) => Some(&msg.session_id),
+            ClaudeOutput::ToolUseSummary(msg) => Some(&msg.session_id),
+            ClaudeOutput::PromptSuggestion(msg) => Some(&msg.session_id),
+            ClaudeOutput::ConversationReset(msg) => Some(&msg.session_id),
         }
     }
 
@@ -383,6 +470,42 @@ mod tests {
 
         let output: ClaudeOutput = serde_json::from_str(json).unwrap();
         assert!(output.is_assistant_message());
+    }
+
+    #[test]
+    fn test_deserialize_new_top_level_message_types() {
+        let cases = [
+            (
+                r#"{"type":"stream_event","event":{"type":"content_block_delta"},"parent_tool_use_id":null,"uuid":"u1","session_id":"s1","ttft_ms":12}"#,
+                "stream_event",
+            ),
+            (
+                r#"{"type":"tool_progress","tool_use_id":"toolu_1","tool_name":"Bash","parent_tool_use_id":null,"elapsed_time_seconds":1.25,"task_id":"task-1","uuid":"u2","session_id":"s2"}"#,
+                "tool_progress",
+            ),
+            (
+                r#"{"type":"auth_status","isAuthenticating":true,"output":["login"],"uuid":"u3","session_id":"s3"}"#,
+                "auth_status",
+            ),
+            (
+                r#"{"type":"tool_use_summary","summary":"read files","preceding_tool_use_ids":["toolu_1"],"uuid":"u4","session_id":"s4","timestamp":"2026-07-09T17:46:33Z"}"#,
+                "tool_use_summary",
+            ),
+            (
+                r#"{"type":"prompt_suggestion","suggestion":"Run tests","uuid":"u5","session_id":"s5"}"#,
+                "prompt_suggestion",
+            ),
+            (
+                r#"{"type":"conversation_reset","new_conversation_id":"new-session","uuid":"u6","session_id":"s6"}"#,
+                "conversation_reset",
+            ),
+        ];
+
+        for (json, message_type) in cases {
+            let output: ClaudeOutput = serde_json::from_str(json).unwrap();
+            assert_eq!(output.message_type(), message_type);
+            assert!(output.session_id().is_some());
+        }
     }
 
     #[test]

--- a/claude-codes/src/io/control.rs
+++ b/claude-codes/src/io/control.rs
@@ -919,6 +919,17 @@ impl ControlResponse {
             },
         }
     }
+
+    /// Parse a successful response payload as the CLI `get_usage` response.
+    pub fn get_usage_response(&self) -> Option<Result<GetUsageResponse, serde_json::Error>> {
+        match &self.response {
+            ControlResponsePayload::Success {
+                response: Some(value),
+                ..
+            } => Some(serde_json::from_value(value.clone())),
+            _ => None,
+        }
+    }
 }
 
 /// Control response payload
@@ -934,6 +945,110 @@ pub enum ControlResponsePayload {
         request_id: String,
         error: String,
     },
+}
+
+/// Typed payload returned by the CLI `get_usage` control request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetUsageResponse {
+    pub session: UsageSession,
+    pub subscription_type: Option<String>,
+    pub rate_limits_available: bool,
+    pub rate_limits: Option<UsageRateLimits>,
+    pub behaviors: UsageBehaviors,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UsageSession {
+    pub total_cost_usd: f64,
+    pub total_api_duration_ms: u64,
+    pub total_duration_ms: u64,
+    pub total_lines_added: u64,
+    pub total_lines_removed: u64,
+    pub model_usage: HashMap<String, UsageModelUsage>,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UsageModelUsage {
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub cache_read_input_tokens: u64,
+    #[serde(default)]
+    pub cache_creation_input_tokens: u64,
+    #[serde(default)]
+    pub web_search_requests: u64,
+    #[serde(default, rename = "costUSD")]
+    pub cost_usd: f64,
+    #[serde(default)]
+    pub context_window: u64,
+    #[serde(default)]
+    pub max_output_tokens: u64,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UsageRateLimits {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub five_hour: Option<UsageRateLimitWindow>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seven_day: Option<UsageRateLimitWindow>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seven_day_oauth_apps: Option<UsageRateLimitWindow>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seven_day_opus: Option<UsageRateLimitWindow>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seven_day_sonnet: Option<UsageRateLimitWindow>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_scoped: Option<Vec<ModelScopedRateLimit>>,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UsageRateLimitWindow {
+    pub utilization: Option<f64>,
+    pub resets_at: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ModelScopedRateLimit {
+    pub display_name: String,
+    pub utilization: Option<f64>,
+    pub resets_at: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UsageBehaviors {
+    pub request_count: u64,
+    pub session_count: u64,
+    pub behaviors: Vec<UsageBehavior>,
+    pub agents: Value,
+    pub skills: Value,
+    pub plugins: Value,
+    pub mcp_servers: Value,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageBehavior {
+    pub key: String,
+    pub pct: f64,
+    pub count: u64,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, Value>,
 }
 
 /// Wrapper for outgoing control responses (includes type tag)
@@ -1222,6 +1337,60 @@ mod tests {
         let json = serde_json::to_string(&message).unwrap();
         assert!(json.contains("\"subtype\":\"error\""));
         assert!(json.contains("\"error\":\"Something went wrong\""));
+    }
+
+    #[test]
+    fn test_get_usage_response_parses_model_scoped_limits() {
+        let response = ControlResponse::success(
+            "usage-1",
+            serde_json::json!({
+                "session": {
+                    "total_cost_usd": 0.5,
+                    "total_api_duration_ms": 100,
+                    "total_duration_ms": 200,
+                    "total_lines_added": 3,
+                    "total_lines_removed": 1,
+                    "model_usage": {
+                        "claude-sonnet-4-6": {
+                            "inputTokens": 10,
+                            "outputTokens": 2,
+                            "cacheReadInputTokens": 1,
+                            "cacheCreationInputTokens": 0,
+                            "webSearchRequests": 0,
+                            "costUSD": 0.01,
+                            "contextWindow": 200000,
+                            "maxOutputTokens": 64000
+                        }
+                    }
+                },
+                "subscription_type": "pro",
+                "rate_limits_available": true,
+                "rate_limits": {
+                    "five_hour": {"utilization": 0.2, "resets_at": "2026-07-09T22:00:00Z"},
+                    "model_scoped": [
+                        {"display_name": "Sonnet", "utilization": 0.4, "resets_at": "2026-07-16T00:00:00Z"}
+                    ]
+                },
+                "behaviors": {
+                    "request_count": 1,
+                    "session_count": 1,
+                    "behaviors": [{"key": "cron", "pct": 100.0, "count": 1}],
+                    "agents": [],
+                    "skills": [],
+                    "plugins": [],
+                    "mcp_servers": []
+                }
+            }),
+        );
+
+        let usage = response.get_usage_response().unwrap().unwrap();
+        assert_eq!(usage.subscription_type.as_deref(), Some("pro"));
+        let model = usage.session.model_usage.get("claude-sonnet-4-6").unwrap();
+        assert_eq!(model.context_window, 200000);
+        assert_eq!(model.max_output_tokens, 64000);
+        let limits = usage.rate_limits.unwrap();
+        assert_eq!(limits.five_hour.unwrap().utilization, Some(0.2));
+        assert_eq!(limits.model_scoped.unwrap()[0].display_name, "Sonnet");
     }
 
     #[test]

--- a/claude-codes/src/io/message_types.rs
+++ b/claude-codes/src/io/message_types.rs
@@ -20,6 +20,26 @@ pub enum SystemSubtype {
     TaskProgress,
     TaskUpdated,
     TaskNotification,
+    ApiRetry,
+    ControlRequestProgress,
+    ModelRefusalFallback,
+    ModelRefusalNoFallback,
+    LocalCommandOutput,
+    HookStarted,
+    HookProgress,
+    HookResponse,
+    PluginInstall,
+    BackgroundTasksChanged,
+    SessionStateChanged,
+    WorkerShuttingDown,
+    CommandsChanged,
+    Notification,
+    FilesPersisted,
+    MemoryRecall,
+    ElicitationComplete,
+    PermissionDenied,
+    MirrorError,
+    Informational,
     /// A subtype not yet known to this version of the crate.
     Unknown(String),
 }
@@ -35,6 +55,26 @@ impl SystemSubtype {
             Self::TaskProgress => "task_progress",
             Self::TaskUpdated => "task_updated",
             Self::TaskNotification => "task_notification",
+            Self::ApiRetry => "api_retry",
+            Self::ControlRequestProgress => "control_request_progress",
+            Self::ModelRefusalFallback => "model_refusal_fallback",
+            Self::ModelRefusalNoFallback => "model_refusal_no_fallback",
+            Self::LocalCommandOutput => "local_command_output",
+            Self::HookStarted => "hook_started",
+            Self::HookProgress => "hook_progress",
+            Self::HookResponse => "hook_response",
+            Self::PluginInstall => "plugin_install",
+            Self::BackgroundTasksChanged => "background_tasks_changed",
+            Self::SessionStateChanged => "session_state_changed",
+            Self::WorkerShuttingDown => "worker_shutting_down",
+            Self::CommandsChanged => "commands_changed",
+            Self::Notification => "notification",
+            Self::FilesPersisted => "files_persisted",
+            Self::MemoryRecall => "memory_recall",
+            Self::ElicitationComplete => "elicitation_complete",
+            Self::PermissionDenied => "permission_denied",
+            Self::MirrorError => "mirror_error",
+            Self::Informational => "informational",
             Self::Unknown(s) => s.as_str(),
         }
     }
@@ -57,6 +97,26 @@ impl From<&str> for SystemSubtype {
             "task_progress" => Self::TaskProgress,
             "task_updated" => Self::TaskUpdated,
             "task_notification" => Self::TaskNotification,
+            "api_retry" => Self::ApiRetry,
+            "control_request_progress" => Self::ControlRequestProgress,
+            "model_refusal_fallback" => Self::ModelRefusalFallback,
+            "model_refusal_no_fallback" => Self::ModelRefusalNoFallback,
+            "local_command_output" => Self::LocalCommandOutput,
+            "hook_started" => Self::HookStarted,
+            "hook_progress" => Self::HookProgress,
+            "hook_response" => Self::HookResponse,
+            "plugin_install" => Self::PluginInstall,
+            "background_tasks_changed" => Self::BackgroundTasksChanged,
+            "session_state_changed" => Self::SessionStateChanged,
+            "worker_shutting_down" => Self::WorkerShuttingDown,
+            "commands_changed" => Self::CommandsChanged,
+            "notification" => Self::Notification,
+            "files_persisted" => Self::FilesPersisted,
+            "memory_recall" => Self::MemoryRecall,
+            "elicitation_complete" => Self::ElicitationComplete,
+            "permission_denied" => Self::PermissionDenied,
+            "mirror_error" => Self::MirrorError,
+            "informational" => Self::Informational,
             other => Self::Unknown(other.to_string()),
         }
     }
@@ -235,6 +295,11 @@ impl<'de> Deserialize<'de> for StopReason {
 pub enum ApiKeySource {
     /// No API key provided.
     None,
+    User,
+    Project,
+    Org,
+    Temporary,
+    Oauth,
     /// A source not yet known to this version of the crate.
     Unknown(String),
 }
@@ -243,6 +308,11 @@ impl ApiKeySource {
     pub fn as_str(&self) -> &str {
         match self {
             Self::None => "none",
+            Self::User => "user",
+            Self::Project => "project",
+            Self::Org => "org",
+            Self::Temporary => "temporary",
+            Self::Oauth => "oauth",
             Self::Unknown(s) => s.as_str(),
         }
     }
@@ -258,6 +328,11 @@ impl From<&str> for ApiKeySource {
     fn from(s: &str) -> Self {
         match s {
             "none" => Self::None,
+            "user" => Self::User,
+            "project" => Self::Project,
+            "org" => Self::Org,
+            "temporary" => Self::Temporary,
+            "oauth" => Self::Oauth,
             other => Self::Unknown(other.to_string()),
         }
     }
@@ -327,6 +402,11 @@ impl<'de> Deserialize<'de> for OutputStyle {
 pub enum InitPermissionMode {
     /// Default permission mode.
     Default,
+    AcceptEdits,
+    BypassPermissions,
+    Plan,
+    DontAsk,
+    Auto,
     /// A mode not yet known to this version of the crate.
     Unknown(String),
 }
@@ -335,6 +415,11 @@ impl InitPermissionMode {
     pub fn as_str(&self) -> &str {
         match self {
             Self::Default => "default",
+            Self::AcceptEdits => "acceptEdits",
+            Self::BypassPermissions => "bypassPermissions",
+            Self::Plan => "plan",
+            Self::DontAsk => "dontAsk",
+            Self::Auto => "auto",
             Self::Unknown(s) => s.as_str(),
         }
     }
@@ -350,6 +435,11 @@ impl From<&str> for InitPermissionMode {
     fn from(s: &str) -> Self {
         match s {
             "default" => Self::Default,
+            "acceptEdits" => Self::AcceptEdits,
+            "bypassPermissions" => Self::BypassPermissions,
+            "plan" => Self::Plan,
+            "dontAsk" => Self::DontAsk,
+            "auto" => Self::Auto,
             other => Self::Unknown(other.to_string()),
         }
     }
@@ -373,6 +463,8 @@ impl<'de> Deserialize<'de> for InitPermissionMode {
 pub enum StatusMessageStatus {
     /// Context compaction is in progress.
     Compacting,
+    /// The CLI is issuing a request.
+    Requesting,
     /// A status not yet known to this version of the crate.
     Unknown(String),
 }
@@ -381,6 +473,7 @@ impl StatusMessageStatus {
     pub fn as_str(&self) -> &str {
         match self {
             Self::Compacting => "compacting",
+            Self::Requesting => "requesting",
             Self::Unknown(s) => s.as_str(),
         }
     }
@@ -396,6 +489,7 @@ impl From<&str> for StatusMessageStatus {
     fn from(s: &str) -> Self {
         match s {
             "compacting" => Self::Compacting,
+            "requesting" => Self::Requesting,
             other => Self::Unknown(other.to_string()),
         }
     }
@@ -442,6 +536,34 @@ where
     }
 }
 
+/// Message provenance. The `kind` field is the stable discriminator; variant
+/// specific fields are preserved in `extra` for forward-compatible access.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MessageOrigin {
+    pub kind: String,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+/// Metadata attached when user-visible transcript content summarizes prior messages.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SummarizeMetadata {
+    pub messages_summarized: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_context: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub direction: Option<String>,
+}
+
+/// MCP metadata passed through on user-message wrappers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct McpMeta {
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "_meta")]
+    pub meta: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub structured_content: Option<Value>,
+}
+
 /// User message
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserMessage {
@@ -476,6 +598,40 @@ pub struct UserMessage {
     /// Short description of the subagent task, present alongside `subagent_type`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin: Option<MessageOrigin>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "isSynthetic")]
+    pub is_synthetic: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "shouldQuery")]
+    pub should_query: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_meta: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_visible_in_transcript_only: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_virtual: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_compact_summary: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summarize_metadata: Option<SummarizeMetadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcp_meta: Option<McpMeta>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_tool_use_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_tool_assistant_uuid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_paste_ids: Option<Vec<u64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_platform: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inbound_origin: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "isReplay")]
+    pub is_replay: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_attachments: Option<Vec<Value>>,
 }
 
 impl UserMessage {
@@ -708,6 +864,65 @@ impl SystemMessage {
         serde_json::from_value(self.data.clone()).ok()
     }
 
+    /// Parse any typed system subtype known to this crate version.
+    pub fn as_known_system_event(&self) -> Option<KnownSystemEvent> {
+        macro_rules! parse {
+            ($variant:ident, $ty:ty) => {
+                serde_json::from_value::<$ty>(self.data.clone())
+                    .ok()
+                    .map(KnownSystemEvent::$variant)
+            };
+        }
+
+        match self.subtype {
+            SystemSubtype::Init => parse!(Init, InitMessage),
+            SystemSubtype::Status => parse!(Status, StatusMessage),
+            SystemSubtype::CompactBoundary => parse!(CompactBoundary, CompactBoundaryMessage),
+            SystemSubtype::ThinkingTokens => parse!(ThinkingTokens, ThinkingTokensMessage),
+            SystemSubtype::TaskStarted => parse!(TaskStarted, TaskStartedMessage),
+            SystemSubtype::TaskProgress => parse!(TaskProgress, TaskProgressMessage),
+            SystemSubtype::TaskUpdated => parse!(TaskUpdated, TaskUpdatedMessage),
+            SystemSubtype::TaskNotification => parse!(TaskNotification, TaskNotificationMessage),
+            SystemSubtype::ApiRetry => parse!(ApiRetry, ApiRetryMessage),
+            SystemSubtype::ControlRequestProgress => {
+                parse!(ControlRequestProgress, ControlRequestProgressMessage)
+            }
+            SystemSubtype::ModelRefusalFallback => {
+                parse!(ModelRefusalFallback, ModelRefusalFallbackMessage)
+            }
+            SystemSubtype::ModelRefusalNoFallback => {
+                parse!(ModelRefusalNoFallback, ModelRefusalNoFallbackMessage)
+            }
+            SystemSubtype::LocalCommandOutput => {
+                parse!(LocalCommandOutput, LocalCommandOutputMessage)
+            }
+            SystemSubtype::HookStarted => parse!(HookStarted, HookStartedMessage),
+            SystemSubtype::HookProgress => parse!(HookProgress, HookProgressMessage),
+            SystemSubtype::HookResponse => parse!(HookResponse, HookResponseMessage),
+            SystemSubtype::PluginInstall => parse!(PluginInstall, PluginInstallMessage),
+            SystemSubtype::BackgroundTasksChanged => {
+                parse!(BackgroundTasksChanged, BackgroundTasksChangedMessage)
+            }
+            SystemSubtype::SessionStateChanged => {
+                parse!(SessionStateChanged, SessionStateChangedMessage)
+            }
+            SystemSubtype::WorkerShuttingDown => {
+                parse!(WorkerShuttingDown, WorkerShuttingDownMessage)
+            }
+            SystemSubtype::CommandsChanged => parse!(CommandsChanged, CommandsChangedMessage),
+            SystemSubtype::Notification => parse!(Notification, NotificationMessage),
+            SystemSubtype::FilesPersisted => parse!(FilesPersisted, FilesPersistedMessage),
+            SystemSubtype::MemoryRecall => parse!(MemoryRecall, MemoryRecallMessage),
+            SystemSubtype::ElicitationComplete => {
+                parse!(ElicitationComplete, ElicitationCompleteMessage)
+            }
+            SystemSubtype::PermissionDenied => parse!(PermissionDenied, PermissionDeniedMessage),
+            SystemSubtype::MirrorError => parse!(MirrorError, MirrorErrorMessage),
+            SystemSubtype::Informational => parse!(Informational, InformationalMessage),
+            SystemSubtype::Unknown(_) => None,
+        }
+    }
+
     /// Re-serialize this system message's payload through the typed view that
     /// matches its `subtype`, returning the result as JSON.
     ///
@@ -729,9 +944,398 @@ impl SystemMessage {
             SystemSubtype::TaskProgress => reserialize(self.as_task_progress()),
             SystemSubtype::TaskUpdated => reserialize(self.as_task_updated()),
             SystemSubtype::TaskNotification => reserialize(self.as_task_notification()),
+            SystemSubtype::ApiRetry => reserialize(parse_system::<ApiRetryMessage>(self)),
+            SystemSubtype::ControlRequestProgress => {
+                reserialize(parse_system::<ControlRequestProgressMessage>(self))
+            }
+            SystemSubtype::ModelRefusalFallback => {
+                reserialize(parse_system::<ModelRefusalFallbackMessage>(self))
+            }
+            SystemSubtype::ModelRefusalNoFallback => {
+                reserialize(parse_system::<ModelRefusalNoFallbackMessage>(self))
+            }
+            SystemSubtype::LocalCommandOutput => {
+                reserialize(parse_system::<LocalCommandOutputMessage>(self))
+            }
+            SystemSubtype::HookStarted => reserialize(parse_system::<HookStartedMessage>(self)),
+            SystemSubtype::HookProgress => reserialize(parse_system::<HookProgressMessage>(self)),
+            SystemSubtype::HookResponse => reserialize(parse_system::<HookResponseMessage>(self)),
+            SystemSubtype::PluginInstall => reserialize(parse_system::<PluginInstallMessage>(self)),
+            SystemSubtype::BackgroundTasksChanged => {
+                reserialize(parse_system::<BackgroundTasksChangedMessage>(self))
+            }
+            SystemSubtype::SessionStateChanged => {
+                reserialize(parse_system::<SessionStateChangedMessage>(self))
+            }
+            SystemSubtype::WorkerShuttingDown => {
+                reserialize(parse_system::<WorkerShuttingDownMessage>(self))
+            }
+            SystemSubtype::CommandsChanged => {
+                reserialize(parse_system::<CommandsChangedMessage>(self))
+            }
+            SystemSubtype::Notification => reserialize(parse_system::<NotificationMessage>(self)),
+            SystemSubtype::FilesPersisted => {
+                reserialize(parse_system::<FilesPersistedMessage>(self))
+            }
+            SystemSubtype::MemoryRecall => reserialize(parse_system::<MemoryRecallMessage>(self)),
+            SystemSubtype::ElicitationComplete => {
+                reserialize(parse_system::<ElicitationCompleteMessage>(self))
+            }
+            SystemSubtype::PermissionDenied => {
+                reserialize(parse_system::<PermissionDeniedMessage>(self))
+            }
+            SystemSubtype::MirrorError => reserialize(parse_system::<MirrorErrorMessage>(self)),
+            SystemSubtype::Informational => reserialize(parse_system::<InformationalMessage>(self)),
             SystemSubtype::Unknown(_) => None,
         }
     }
+}
+
+fn parse_system<T: serde::de::DeserializeOwned>(message: &SystemMessage) -> Option<T> {
+    serde_json::from_value(message.data.clone()).ok()
+}
+
+/// Owned typed view over any known system message subtype.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum KnownSystemEvent {
+    Init(InitMessage),
+    Status(StatusMessage),
+    CompactBoundary(CompactBoundaryMessage),
+    ThinkingTokens(ThinkingTokensMessage),
+    TaskStarted(TaskStartedMessage),
+    TaskProgress(TaskProgressMessage),
+    TaskUpdated(TaskUpdatedMessage),
+    TaskNotification(TaskNotificationMessage),
+    ApiRetry(ApiRetryMessage),
+    ControlRequestProgress(ControlRequestProgressMessage),
+    ModelRefusalFallback(ModelRefusalFallbackMessage),
+    ModelRefusalNoFallback(ModelRefusalNoFallbackMessage),
+    LocalCommandOutput(LocalCommandOutputMessage),
+    HookStarted(HookStartedMessage),
+    HookProgress(HookProgressMessage),
+    HookResponse(HookResponseMessage),
+    PluginInstall(PluginInstallMessage),
+    BackgroundTasksChanged(BackgroundTasksChangedMessage),
+    SessionStateChanged(SessionStateChangedMessage),
+    WorkerShuttingDown(WorkerShuttingDownMessage),
+    CommandsChanged(CommandsChangedMessage),
+    Notification(NotificationMessage),
+    FilesPersisted(FilesPersistedMessage),
+    MemoryRecall(MemoryRecallMessage),
+    ElicitationComplete(ElicitationCompleteMessage),
+    PermissionDenied(PermissionDeniedMessage),
+    MirrorError(MirrorErrorMessage),
+    Informational(InformationalMessage),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiRetryMessage {
+    pub attempt: u64,
+    pub max_retries: u64,
+    pub retry_delay_ms: u64,
+    pub error_status: Option<u16>,
+    pub error: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ControlRequestProgressMessage {
+    pub request_id: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attempt: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_retries: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_delay_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_status: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelRefusalFallbackMessage {
+    pub trigger: String,
+    pub direction: String,
+    pub original_model: String,
+    pub fallback_model: String,
+    pub request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_refusal_category: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_refusal_explanation: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retracted_message_uuids: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refused_user_message_uuid: Option<String>,
+    pub content: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelRefusalNoFallbackMessage {
+    pub original_model: String,
+    pub request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_refusal_category: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_refusal_explanation: Option<String>,
+    pub content: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LocalCommandOutputMessage {
+    pub content: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookStartedMessage {
+    pub hook_id: String,
+    pub hook_name: String,
+    pub hook_event: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookProgressMessage {
+    pub hook_id: String,
+    pub hook_name: String,
+    pub hook_event: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stdout: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stderr: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookResponseMessage {
+    pub hook_id: String,
+    pub hook_name: String,
+    pub hook_event: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stdout: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stderr: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    pub outcome: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginInstallMessage {
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackgroundTasksChangedMessage {
+    pub tasks: Vec<BackgroundTaskInfo>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackgroundTaskInfo {
+    pub task_id: String,
+    pub task_type: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionStateChangedMessage {
+    pub state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkerShuttingDownMessage {
+    pub reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandsChangedMessage {
+    pub commands: Vec<CommandInfo>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandInfo {
+    pub name: String,
+    pub description: String,
+    #[serde(rename = "argumentHint")]
+    pub argument_hint: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aliases: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotificationMessage {
+    pub key: String,
+    pub text: String,
+    pub priority: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FilesPersistedMessage {
+    pub files: Vec<PersistedFile>,
+    pub failed: Vec<FailedPersistedFile>,
+    pub processed_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedFile {
+    pub filename: String,
+    pub file_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailedPersistedFile {
+    pub filename: String,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryRecallMessage {
+    pub mode: String,
+    pub memories: Vec<MemoryRecallItem>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryRecallItem {
+    pub path: String,
+    pub scope: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ElicitationCompleteMessage {
+    pub mcp_server_name: String,
+    pub elicitation_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermissionDeniedMessage {
+    pub tool_name: String,
+    pub tool_use_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decision_reason_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decision_reason: Option<String>,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MirrorErrorMessage {
+    pub error: String,
+    pub key: MirrorErrorKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MirrorErrorKey {
+    #[serde(rename = "projectKey")]
+    pub project_key: String,
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subpath: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InformationalMessage {
+    pub content: String,
+    pub level: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_use_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prevent_continuation: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
 }
 
 /// Plugin info from the init message
@@ -744,6 +1348,26 @@ pub struct PluginInfo {
     /// Plugin registry source (e.g., "rust-analyzer-lsp@claude-plugins-official")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
+}
+
+/// Plugin load diagnostic reported by system init.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PluginDiagnostic {
+    pub plugin: String,
+    #[serde(rename = "type")]
+    pub diagnostic_type: String,
+    pub message: String,
+}
+
+/// Memory paths reported by system init.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MemoryPaths {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team: Option<String>,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, Value>,
 }
 
 /// Init system message data - sent at session start
@@ -794,7 +1418,7 @@ pub struct InitMessage {
 
     /// Memory storage paths (e.g., {"auto": "/path/to/memory/"})
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub memory_paths: Option<Value>,
+    pub memory_paths: Option<MemoryPaths>,
 
     /// Fast mode toggle state (e.g., "off")
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -807,6 +1431,22 @@ pub struct InitMessage {
     /// Whether product-feedback prompts are disabled for this session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub product_feedback_disabled: Option<bool>,
+
+    /// API beta flags active for the session.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub betas: Vec<String>,
+
+    /// Open-set protocol capability names supported by this CLI.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
+
+    /// Plugin load errors.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub plugin_errors: Vec<PluginDiagnostic>,
+
+    /// Plugin load warnings.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub plugin_warnings: Vec<PluginDiagnostic>,
 }
 
 /// Status system message - sent during operations like context compaction
@@ -819,6 +1459,13 @@ pub struct StatusMessage {
     /// Unique identifier for this message
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uuid: Option<String>,
+    /// Current permission mode when changed mid-session.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "permissionMode")]
+    pub permission_mode: Option<InitPermissionMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compact_result: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compact_error: Option<String>,
 }
 
 /// Compact boundary message - marks where context compaction occurred
@@ -853,6 +1500,9 @@ pub struct CompactBoundaryMessage {
     /// Unique identifier for this message
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uuid: Option<String>,
+    /// Logical parent across the compaction boundary.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logical_parent_uuid: Option<Option<String>>,
 }
 
 /// Metadata about context compaction
@@ -862,6 +1512,39 @@ pub struct CompactMetadata {
     pub pre_tokens: u64,
     /// What triggered the compaction
     pub trigger: CompactionTrigger,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub post_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cumulative_dropped_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_context: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub messages_summarized: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub precomputed: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pre_compact_discovered_tools: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preserved_segment: Option<PreservedSegment>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preserved_messages: Option<PreservedMessages>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PreservedSegment {
+    pub head_uuid: String,
+    pub anchor_uuid: String,
+    pub tail_uuid: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PreservedMessages {
+    pub anchor_uuid: String,
+    pub uuids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub all_uuids: Option<Vec<String>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -880,21 +1563,119 @@ pub struct TaskUsage {
 }
 
 /// The kind of background task.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TaskType {
     /// A sub-agent task (e.g., Explore, Plan).
     LocalAgent,
     /// A background bash command.
     LocalBash,
+    /// A local workflow task.
+    LocalWorkflow,
+    /// A task type not yet known to this version of the crate.
+    Unknown(String),
+}
+
+impl TaskType {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::LocalAgent => "local_agent",
+            Self::LocalBash => "local_bash",
+            Self::LocalWorkflow => "local_workflow",
+            Self::Unknown(s) => s.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for TaskType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<&str> for TaskType {
+    fn from(s: &str) -> Self {
+        match s {
+            "local_agent" => Self::LocalAgent,
+            "local_bash" => Self::LocalBash,
+            "local_workflow" => Self::LocalWorkflow,
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+}
+
+impl Serialize for TaskType {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for TaskType {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self::from(s.as_str()))
+    }
 }
 
 /// Completion status of a background task.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TaskStatus {
+    Pending,
+    Running,
     Completed,
     Failed,
+    Killed,
+    Paused,
+    Stopped,
+    Unknown(String),
+}
+
+impl TaskStatus {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Killed => "killed",
+            Self::Paused => "paused",
+            Self::Stopped => "stopped",
+            Self::Unknown(s) => s.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for TaskStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<&str> for TaskStatus {
+    fn from(s: &str) -> Self {
+        match s {
+            "pending" => Self::Pending,
+            "running" => Self::Running,
+            "completed" => Self::Completed,
+            "failed" => Self::Failed,
+            "killed" => Self::Killed,
+            "paused" => Self::Paused,
+            "stopped" => Self::Stopped,
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+}
+
+impl Serialize for TaskStatus {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for TaskStatus {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self::from(s.as_str()))
+    }
 }
 
 /// `task_started` system message — emitted once when a background task begins.
@@ -902,8 +1683,10 @@ pub enum TaskStatus {
 pub struct TaskStartedMessage {
     pub session_id: String,
     pub task_id: String,
-    pub task_type: TaskType,
-    pub tool_use_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_type: Option<TaskType>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_use_id: Option<String>,
     pub description: String,
     /// The subagent type for `local_agent` tasks (e.g. `general-purpose`,
     /// `Explore`). Absent for `local_bash` tasks.
@@ -912,6 +1695,10 @@ pub struct TaskStartedMessage {
     /// The prompt handed to the subagent. Present for `local_agent` tasks.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_transcript: Option<bool>,
     pub uuid: String,
 }
 
@@ -936,6 +1723,14 @@ pub struct TaskPatch {
     /// reports completion.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub end_time: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_paused_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_backgrounded: Option<bool>,
 }
 
 /// `thinking_tokens` system message — emitted as the model streams extended
@@ -956,13 +1751,17 @@ pub struct ThinkingTokensMessage {
 pub struct TaskProgressMessage {
     pub session_id: String,
     pub task_id: String,
-    pub tool_use_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_use_id: Option<String>,
     pub description: String,
-    pub last_tool_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_tool_name: Option<String>,
     pub usage: TaskUsage,
     /// Subagent type for `local_agent` tasks (e.g. `Explore`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subagent_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
     pub uuid: String,
 }
 
@@ -979,8 +1778,92 @@ pub struct TaskNotificationMessage {
     pub tool_use_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage: Option<TaskUsage>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_transcript: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uuid: Option<String>,
+}
+
+/// API error category attached to assistant wrapper frames.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum AssistantErrorKind {
+    AuthenticationFailed,
+    OauthOrgNotAllowed,
+    BillingError,
+    RateLimit,
+    Overloaded,
+    InvalidRequest,
+    ModelNotFound,
+    ServerError,
+    UnknownError,
+    MaxOutputTokens,
+    Unknown(String),
+}
+
+impl AssistantErrorKind {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::AuthenticationFailed => "authentication_failed",
+            Self::OauthOrgNotAllowed => "oauth_org_not_allowed",
+            Self::BillingError => "billing_error",
+            Self::RateLimit => "rate_limit",
+            Self::Overloaded => "overloaded",
+            Self::InvalidRequest => "invalid_request",
+            Self::ModelNotFound => "model_not_found",
+            Self::ServerError => "server_error",
+            Self::UnknownError => "unknown",
+            Self::MaxOutputTokens => "max_output_tokens",
+            Self::Unknown(s) => s.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for AssistantErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<&str> for AssistantErrorKind {
+    fn from(s: &str) -> Self {
+        match s {
+            "authentication_failed" => Self::AuthenticationFailed,
+            "oauth_org_not_allowed" => Self::OauthOrgNotAllowed,
+            "billing_error" => Self::BillingError,
+            "rate_limit" => Self::RateLimit,
+            "overloaded" => Self::Overloaded,
+            "invalid_request" => Self::InvalidRequest,
+            "model_not_found" => Self::ModelNotFound,
+            "server_error" => Self::ServerError,
+            "unknown" => Self::UnknownError,
+            "max_output_tokens" => Self::MaxOutputTokens,
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+}
+
+impl Serialize for AssistantErrorKind {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for AssistantErrorKind {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self::from(s.as_str()))
+    }
+}
+
+/// Display metadata for a tool-use block carried on the assistant wrapper.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolUseMeta {
+    pub id: String,
+    pub display_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_display_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon_url: Option<String>,
 }
 
 /// Assistant message
@@ -1002,6 +1885,38 @@ pub struct AssistantMessage {
     /// Short description of the subagent task, present alongside `subagent_type`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<AssistantErrorKind>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub supersedes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_use_meta: Vec<ToolUseMeta>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_meta: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_virtual: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_api_error_message: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_error_status: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_details: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub advisor_model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attribution_agent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attribution_skill: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attribution_plugin: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attribution_mcp_server: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attribution_mcp_tool: Option<String>,
 }
 
 /// Nested message content for assistant messages
@@ -1211,8 +2126,11 @@ mod tests {
             let task = sys.as_task_started().expect("Should parse as task_started");
             assert_eq!(task.session_id, "9abbc466-dad0-4b8e-b6b0-cad5eb7a16b9");
             assert_eq!(task.task_id, "b6daf3f");
-            assert_eq!(task.task_type, super::TaskType::LocalBash);
-            assert_eq!(task.tool_use_id, "toolu_011rfSTFumpJZdCCfzeD7jaS");
+            assert_eq!(task.task_type, Some(super::TaskType::LocalBash));
+            assert_eq!(
+                task.tool_use_id.as_deref(),
+                Some("toolu_011rfSTFumpJZdCCfzeD7jaS")
+            );
             assert_eq!(task.description, "Wait for CI on PR #12");
         } else {
             panic!("Expected System message");
@@ -1235,7 +2153,7 @@ mod tests {
         let output: ClaudeOutput = serde_json::from_str(json).unwrap();
         if let ClaudeOutput::System(sys) = output {
             let task = sys.as_task_started().expect("Should parse as task_started");
-            assert_eq!(task.task_type, super::TaskType::LocalAgent);
+            assert_eq!(task.task_type, Some(super::TaskType::LocalAgent));
             assert_eq!(task.task_id, "a4a7e0906e5fc64cc");
         } else {
             panic!("Expected System message");
@@ -1270,7 +2188,7 @@ mod tests {
                 .expect("Should parse as task_progress");
             assert_eq!(progress.task_id, "a4a7e0906e5fc64cc");
             assert_eq!(progress.description, "Reading src/jplephem/chebyshev.rs");
-            assert_eq!(progress.last_tool_name, "Read");
+            assert_eq!(progress.last_tool_name.as_deref(), Some("Read"));
             assert_eq!(progress.usage.duration_ms, 13996);
             assert_eq!(progress.usage.tool_uses, 9);
             assert_eq!(progress.usage.total_tokens, 38779);

--- a/claude-codes/src/io/result.rs
+++ b/claude-codes/src/io/result.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
+use std::fmt;
 
 /// Result message for completed queries
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -20,6 +21,18 @@ pub struct ResultMessage {
     /// Time from session start until the first request was issued, in milliseconds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_to_request_ms: Option<u64>,
+
+    /// Time from spawning a worker/spare until the first request was issued, in milliseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_to_request_from_spawn_ms: Option<u64>,
+
+    /// Whether a warm spare process was claimed for this request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warm_spare_claimed: Option<bool>,
+
+    /// Epoch-ish timestamp origin used by CLI timing instrumentation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time_origin_ms: Option<u64>,
 
     pub num_turns: i32,
 
@@ -65,6 +78,18 @@ pub struct ResultMessage {
     /// Per-model cost breakdown, keyed by model name (e.g. `"claude-opus-4-8"`).
     #[serde(skip_serializing_if = "Option::is_none", rename = "modelUsage")]
     pub model_usage: Option<std::collections::BTreeMap<String, ModelUsageEntry>>,
+
+    /// Structured-output payload returned by the model, when enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub structured_output: Option<Value>,
+
+    /// Deferred tool-use termination payload.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deferred_tool_use: Option<DeferredToolUse>,
+
+    /// Provenance of the message/run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin: Option<super::message_types::MessageOrigin>,
 }
 
 /// Usage and cost for a single model within a session, as found in
@@ -87,8 +112,20 @@ pub struct ModelUsageEntry {
     pub cost_usd: f64,
     #[serde(default)]
     pub web_search_requests: u32,
+    #[serde(default)]
+    pub context_window: u64,
+    #[serde(default)]
+    pub max_output_tokens: u64,
     #[serde(flatten)]
     pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Tool use deferred by a terminal result.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DeferredToolUse {
+    pub id: String,
+    pub name: String,
+    pub input: Value,
 }
 
 /// A record of a tool permission that was denied during the session.
@@ -108,12 +145,59 @@ pub struct PermissionDenial {
 }
 
 /// Result subtypes
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ResultSubtype {
     Success,
     ErrorMaxTurns,
     ErrorDuringExecution,
+    ErrorMaxBudgetUsd,
+    ErrorMaxStructuredOutputRetries,
+    Unknown(String),
+}
+
+impl ResultSubtype {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Success => "success",
+            Self::ErrorMaxTurns => "error_max_turns",
+            Self::ErrorDuringExecution => "error_during_execution",
+            Self::ErrorMaxBudgetUsd => "error_max_budget_usd",
+            Self::ErrorMaxStructuredOutputRetries => "error_max_structured_output_retries",
+            Self::Unknown(s) => s.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for ResultSubtype {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<&str> for ResultSubtype {
+    fn from(s: &str) -> Self {
+        match s {
+            "success" => Self::Success,
+            "error_max_turns" => Self::ErrorMaxTurns,
+            "error_during_execution" => Self::ErrorDuringExecution,
+            "error_max_budget_usd" => Self::ErrorMaxBudgetUsd,
+            "error_max_structured_output_retries" => Self::ErrorMaxStructuredOutputRetries,
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+}
+
+impl Serialize for ResultSubtype {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ResultSubtype {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self::from(s.as_str()))
+    }
 }
 
 /// Usage information for the request
@@ -181,6 +265,46 @@ mod tests {
 
         let output: ClaudeOutput = serde_json::from_str(json).unwrap();
         assert!(!output.is_error());
+    }
+
+    #[test]
+    fn test_result_subtype_new_and_unknown_values_do_not_fail() {
+        let json = r#"{
+            "type": "result",
+            "subtype": "error_max_budget_usd",
+            "is_error": true,
+            "duration_ms": 100,
+            "duration_api_ms": 200,
+            "num_turns": 1,
+            "session_id": "123",
+            "total_cost_usd": 0.01
+        }"#;
+
+        let output: ClaudeOutput = serde_json::from_str(json).unwrap();
+        let ClaudeOutput::Result(result) = output else {
+            panic!("Expected Result");
+        };
+        assert_eq!(result.subtype, ResultSubtype::ErrorMaxBudgetUsd);
+
+        let json = r#"{
+            "type": "result",
+            "subtype": "future_result_subtype",
+            "is_error": true,
+            "duration_ms": 100,
+            "duration_api_ms": 200,
+            "num_turns": 1,
+            "session_id": "123",
+            "total_cost_usd": 0.01
+        }"#;
+
+        let output: ClaudeOutput = serde_json::from_str(json).unwrap();
+        let ClaudeOutput::Result(result) = output else {
+            panic!("Expected Result");
+        };
+        assert_eq!(
+            result.subtype,
+            ResultSubtype::Unknown("future_result_subtype".to_string())
+        );
     }
 
     #[test]

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -139,20 +139,35 @@ pub use io::{
 // Control protocol types for tool permission handling
 pub use io::{
     AskUserQuestionResponseError, ControlRequest, ControlRequestMessage, ControlRequestPayload,
-    ControlResponse, ControlResponseMessage, ControlResponsePayload, HookCallbackRequest,
-    InitializeRequest, McpMessageRequest, Permission, PermissionBehavior, PermissionDenial,
-    PermissionDestination, PermissionModeName, PermissionResult, PermissionRule,
-    PermissionSuggestion, PermissionType, SDKControlInterruptRequest, ToolCaller,
-    ToolPermissionRequest, ToolUseBlock,
+    ControlResponse, ControlResponseMessage, ControlResponsePayload, GetUsageResponse,
+    HookCallbackRequest, InitializeRequest, McpMessageRequest, ModelScopedRateLimit, Permission,
+    PermissionBehavior, PermissionDenial, PermissionDestination, PermissionModeName,
+    PermissionResult, PermissionRule, PermissionSuggestion, PermissionType,
+    SDKControlInterruptRequest, ToolCaller, ToolPermissionRequest, ToolUseBlock, UsageBehavior,
+    UsageBehaviors, UsageModelUsage, UsageRateLimitWindow, UsageRateLimits, UsageSession,
 };
 
 // System message and assistant message types
 pub use io::{
-    ApiKeySource, CompactBoundaryMessage, CompactMetadata, CompactionTrigger, InitMessage,
-    InitPermissionMode, MessageRole, OutputStyle, PluginInfo, StatusMessage, StatusMessageStatus,
-    StopReason, SystemMessage, SystemSubtype, TaskNotificationMessage, TaskPatch,
-    TaskProgressMessage, TaskStartedMessage, TaskStatus, TaskType, TaskUpdatedMessage, TaskUsage,
-    ThinkingTokensMessage,
+    ApiKeySource, ApiRetryMessage, AssistantErrorKind, BackgroundTaskInfo,
+    BackgroundTasksChangedMessage, CommandInfo, CommandsChangedMessage, CompactBoundaryMessage,
+    CompactMetadata, CompactionTrigger, ControlRequestProgressMessage, ElicitationCompleteMessage,
+    FailedPersistedFile, FilesPersistedMessage, HookProgressMessage, HookResponseMessage,
+    HookStartedMessage, InformationalMessage, InitMessage, InitPermissionMode, KnownSystemEvent,
+    LocalCommandOutputMessage, McpMeta, MemoryPaths, MemoryRecallItem, MemoryRecallMessage,
+    MessageOrigin, MessageRole, MirrorErrorKey, MirrorErrorMessage, ModelRefusalFallbackMessage,
+    ModelRefusalNoFallbackMessage, NotificationMessage, OutputStyle, PermissionDeniedMessage,
+    PersistedFile, PluginDiagnostic, PluginInfo, PluginInstallMessage, PreservedMessages,
+    PreservedSegment, StatusMessage, StatusMessageStatus, StopReason, SummarizeMetadata,
+    SystemMessage, SystemSubtype, TaskNotificationMessage, TaskPatch, TaskProgressMessage,
+    TaskStartedMessage, TaskStatus, TaskType, TaskUpdatedMessage, TaskUsage, ThinkingTokensMessage,
+    ToolUseMeta, WorkerShuttingDownMessage,
+};
+
+// Additional top-level output message wrappers
+pub use io::{
+    AuthStatusMessage, ConversationResetMessage, PromptSuggestionMessage, StreamEventMessage,
+    ToolProgressMessage, ToolUseSummaryMessage,
 };
 
 // Wire-fidelity audit for verifying frames are fully typed
@@ -166,8 +181,8 @@ pub use io::{
 
 // Usage types
 pub use io::{
-    AssistantUsage, CacheCreationDetails, ServerToolUse, SubagentResult, SubagentToolStats,
-    UsageInfo,
+    AssistantUsage, CacheCreationDetails, DeferredToolUse, ServerToolUse, SubagentResult,
+    SubagentToolStats, UsageInfo,
 };
 
 // Typed tool input types

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -529,6 +529,8 @@ pub enum AuthMode {
     Chatgpt,
     #[serde(rename = "chatgptAuthTokens")]
     ChatgptAuthTokens,
+    #[serde(rename = "headers")]
+    Headers,
     #[serde(rename = "agentIdentity")]
     AgentIdentity,
     #[serde(rename = "personalAccessToken")]
@@ -1384,6 +1386,8 @@ pub enum ConsumeAccountRateLimitResetCreditOutcome {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConsumeAccountRateLimitResetCreditParams {
+    #[serde(rename = "creditId", default, skip_serializing_if = "Option::is_none")]
+    pub credit_id: Option<String>,
     #[serde(rename = "idempotencyKey", default)]
     pub idempotency_key: String,
 }
@@ -2843,12 +2847,20 @@ pub enum LoginAccountParams {
         api_key: String,
     },
     Chatgpt {
+        #[serde(rename = "appBrand", default, skip_serializing_if = "Option::is_none")]
+        app_brand: Option<LoginAppBrand>,
         #[serde(
             rename = "codexStreamlinedLogin",
             default,
             skip_serializing_if = "Option::is_none"
         )]
         codex_streamlined_login: Option<bool>,
+        #[serde(
+            rename = "useHostedLoginSuccessPage",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        use_hosted_login_success_page: Option<bool>,
     },
     #[serde(rename = "chatgptDeviceCode")]
     ChatgptDeviceCode,
@@ -2889,6 +2901,14 @@ pub enum LoginAccountResponse {
     },
     #[serde(rename = "chatgptAuthTokens")]
     ChatgptAuthTokens,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum LoginAppBrand {
+    #[serde(rename = "codex")]
+    Codex,
+    #[serde(rename = "chatgpt")]
+    Chatgpt,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -4200,6 +4220,14 @@ pub enum PluginInstallPolicy {
     INSTALLED_BY_DEFAULT,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PluginInstallPolicySource {
+    #[serde(rename = "WORKSPACE_SETTING")]
+    WORKSPACE_SETTING,
+    #[serde(rename = "IMPLICIT_CANONICAL_APP")]
+    IMPLICIT_CANONICAL_APP,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PluginInstallResponse {
@@ -4693,6 +4721,12 @@ pub struct PluginSummary {
     pub id: String,
     #[serde(rename = "installPolicy")]
     pub install_policy: PluginInstallPolicy,
+    #[serde(
+        rename = "installPolicySource",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub install_policy_source: Option<PluginInstallPolicySource>,
     #[serde(default)]
     pub installed: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -4721,6 +4755,8 @@ pub struct PluginSummary {
     pub share_context: Option<PluginShareContext>,
     #[serde()]
     pub source: PluginSource,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -4800,9 +4836,50 @@ pub enum RateLimitReachedType {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct RateLimitResetCredit {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(rename = "expiresAt", default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<i64>,
+    #[serde(rename = "grantedAt", default)]
+    pub granted_at: i64,
+    #[serde(default)]
+    pub id: String,
+    #[serde(rename = "resetType")]
+    pub reset_type: RateLimitResetType,
+    #[serde()]
+    pub status: RateLimitResetCreditStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RateLimitResetCreditStatus {
+    #[serde(rename = "available")]
+    Available,
+    #[serde(rename = "redeeming")]
+    Redeeming,
+    #[serde(rename = "redeemed")]
+    Redeemed,
+    #[serde(rename = "unknown")]
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RateLimitResetCreditsSummary {
     #[serde(rename = "availableCount", default)]
     pub available_count: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credits: Option<Vec<RateLimitResetCredit>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RateLimitResetType {
+    #[serde(rename = "codexRateLimits")]
+    CodexRateLimits,
+    #[serde(rename = "unknown")]
+    Unknown,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -6728,6 +6728,7 @@
         "enum": [
           "auto",
           "prompt",
+          "writes",
           "approve"
         ],
         "type": "string"
@@ -6947,6 +6948,13 @@
             "description": "[UNSTABLE] FOR OPENAI INTERNAL USE ONLY - DO NOT USE.\n\nChatGPT auth tokens are supplied by an external host app and are only stored in memory. Token refresh must be handled by the external host app.",
             "enum": [
               "chatgptAuthTokens"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Backend auth supplied as request headers.",
+            "enum": [
+              "headers"
             ],
             "type": "string"
           },
@@ -8688,6 +8696,13 @@
       "ConsumeAccountRateLimitResetCreditParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
+          "creditId": {
+            "description": "Opaque reset-credit identifier to redeem. When omitted, the backend selects the next available credit.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "idempotencyKey": {
             "description": "Identifies one logical reset attempt. A UUID is recommended; reuse the same value when retrying that attempt.",
             "type": "string"
@@ -11496,6 +11511,17 @@
           },
           {
             "properties": {
+              "appBrand": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/v2/LoginAppBrand"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
               "codexStreamlinedLogin": {
                 "type": "boolean"
               },
@@ -11505,6 +11531,9 @@
                 ],
                 "title": "Chatgptv2::LoginAccountParamsType",
                 "type": "string"
+              },
+              "useHostedLoginSuccessPage": {
+                "type": "boolean"
               }
             },
             "required": [
@@ -11658,6 +11687,13 @@
           }
         ],
         "title": "LoginAccountResponse"
+      },
+      "LoginAppBrand": {
+        "enum": [
+          "codex",
+          "chatgpt"
+        ],
+        "type": "string"
       },
       "LogoutAccountResponse": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -12860,13 +12896,29 @@
         "type": "object"
       },
       "MultiAgentMode": {
-        "description": "Controls whether the model receives multi-agent delegation instructions and, when it does, whether it should only spawn sub-agents after an explicit user request or may delegate proactively when doing so would help. `none` leaves the multi-agent tools available without injecting delegation instructions.",
-        "enum": [
-          "none",
-          "explicitRequestOnly",
-          "proactive"
-        ],
-        "type": "string"
+        "description": "Controls the effective multi-agent delegation instructions for a turn. `custom` means the configured mode hint defines the policy instead of a built-in policy.",
+        "oneOf": [
+          {
+            "enum": [
+              "explicitRequestOnly",
+              "proactive"
+            ],
+            "type": "string"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "custom": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "custom"
+            ],
+            "title": "CustomMultiAgentMode",
+            "type": "object"
+          }
+        ]
       },
       "NetworkAccess": {
         "enum": [
@@ -13397,6 +13449,13 @@
           "NOT_AVAILABLE",
           "AVAILABLE",
           "INSTALLED_BY_DEFAULT"
+        ],
+        "type": "string"
+      },
+      "PluginInstallPolicySource": {
+        "enum": [
+          "WORKSPACE_SETTING",
+          "IMPLICIT_CANONICAL_APP"
         ],
         "type": "string"
       },
@@ -14283,6 +14342,16 @@
           "installPolicy": {
             "$ref": "#/definitions/v2/PluginInstallPolicy"
           },
+          "installPolicySource": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/PluginInstallPolicySource"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "installed": {
             "type": "boolean"
           },
@@ -14334,6 +14403,14 @@
           },
           "source": {
             "$ref": "#/definitions/v2/PluginSource"
+          },
+          "version": {
+            "default": null,
+            "description": "Version advertised by the remote marketplace backend when available.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
@@ -14509,17 +14586,91 @@
         ],
         "type": "string"
       },
+      "RateLimitResetCredit": {
+        "properties": {
+          "description": {
+            "description": "Backend-provided display description for this credit, or `null` when unavailable.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "expiresAt": {
+            "description": "Unix timestamp in seconds when the credit expires, or `null` if it does not expire.",
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "grantedAt": {
+            "description": "Unix timestamp in seconds when the credit was granted.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "id": {
+            "description": "Opaque backend identifier for this reset credit.",
+            "type": "string"
+          },
+          "resetType": {
+            "$ref": "#/definitions/v2/RateLimitResetType"
+          },
+          "status": {
+            "$ref": "#/definitions/v2/RateLimitResetCreditStatus"
+          },
+          "title": {
+            "description": "Backend-provided display title for this credit, or `null` when unavailable.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "grantedAt",
+          "id",
+          "resetType",
+          "status"
+        ],
+        "type": "object"
+      },
+      "RateLimitResetCreditStatus": {
+        "enum": [
+          "available",
+          "redeeming",
+          "redeemed",
+          "unknown"
+        ],
+        "type": "string"
+      },
       "RateLimitResetCreditsSummary": {
         "properties": {
           "availableCount": {
             "format": "int64",
             "type": "integer"
+          },
+          "credits": {
+            "description": "Detail rows for available reset credits, when the backend provides them.\n\n`null` means only `availableCount` is known, while an empty array means details were fetched and no available credits were returned. The backend may cap this list, so its length can be less than `availableCount`.",
+            "items": {
+              "$ref": "#/definitions/v2/RateLimitResetCredit"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           }
         },
         "required": [
           "availableCount"
         ],
         "type": "object"
+      },
+      "RateLimitResetType": {
+        "enum": [
+          "codexRateLimits",
+          "unknown"
+        ],
+        "type": "string"
       },
       "RateLimitSnapshot": {
         "properties": {
@@ -15509,6 +15660,12 @@
               },
               "name": {
                 "type": "string"
+              },
+              "namespace": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "status": {
                 "type": [
@@ -17279,6 +17436,13 @@
           "ephemeral": {
             "type": "boolean"
           },
+          "lastTurnId": {
+            "description": "Optional last turn id to fork through, inclusive.\n\nWhen specified, turns after `last_turn_id` are omitted from the fork. The referenced turn cannot be in progress.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "model": {
             "description": "Configuration overrides for the forked thread, if any.",
             "type": [
@@ -17321,13 +17485,6 @@
               }
             ],
             "description": "Optional client-supplied analytics source classification for this forked thread."
-          },
-        "lastTurnId": {
-          "description": "Optional last turn id to fork through, inclusive.\n\nWhen specified, turns after `last_turn_id` are omitted from the fork. The referenced turn cannot be in progress.",
-            "type": [
-              "string",
-              "null"
-            ]
           }
         },
         "required": [

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -854,6 +854,7 @@
       "enum": [
         "auto",
         "prompt",
+        "writes",
         "approve"
       ],
       "type": "string"
@@ -1073,6 +1074,13 @@
           "description": "[UNSTABLE] FOR OPENAI INTERNAL USE ONLY - DO NOT USE.\n\nChatGPT auth tokens are supplied by an external host app and are only stored in memory. Token refresh must be handled by the external host app.",
           "enum": [
             "chatgptAuthTokens"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Backend auth supplied as request headers.",
+          "enum": [
+            "headers"
           ],
           "type": "string"
         },
@@ -4928,6 +4936,13 @@
     "ConsumeAccountRateLimitResetCreditParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
+        "creditId": {
+          "description": "Opaque reset-credit identifier to redeem. When omitted, the backend selects the next available credit.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "idempotencyKey": {
           "description": "Identifies one logical reset attempt. A UUID is recommended; reuse the same value when retrying that attempt.",
           "type": "string"
@@ -7900,6 +7915,17 @@
         },
         {
           "properties": {
+            "appBrand": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/LoginAppBrand"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
             "codexStreamlinedLogin": {
               "type": "boolean"
             },
@@ -7909,6 +7935,9 @@
               ],
               "title": "Chatgptv2::LoginAccountParamsType",
               "type": "string"
+            },
+            "useHostedLoginSuccessPage": {
+              "type": "boolean"
             }
           },
           "required": [
@@ -8062,6 +8091,13 @@
         }
       ],
       "title": "LoginAccountResponse"
+    },
+    "LoginAppBrand": {
+      "enum": [
+        "codex",
+        "chatgpt"
+      ],
+      "type": "string"
     },
     "LogoutAccountResponse": {
       "$schema": "http://json-schema.org/draft-07/schema#",
@@ -9264,13 +9300,29 @@
       "type": "object"
     },
     "MultiAgentMode": {
-      "description": "Controls whether the model receives multi-agent delegation instructions and, when it does, whether it should only spawn sub-agents after an explicit user request or may delegate proactively when doing so would help. `none` leaves the multi-agent tools available without injecting delegation instructions.",
-      "enum": [
-        "none",
-        "explicitRequestOnly",
-        "proactive"
-      ],
-      "type": "string"
+      "description": "Controls the effective multi-agent delegation instructions for a turn. `custom` means the configured mode hint defines the policy instead of a built-in policy.",
+      "oneOf": [
+        {
+          "enum": [
+            "explicitRequestOnly",
+            "proactive"
+          ],
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "custom": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "custom"
+          ],
+          "title": "CustomMultiAgentMode",
+          "type": "object"
+        }
+      ]
     },
     "NetworkAccess": {
       "enum": [
@@ -9801,6 +9853,13 @@
         "NOT_AVAILABLE",
         "AVAILABLE",
         "INSTALLED_BY_DEFAULT"
+      ],
+      "type": "string"
+    },
+    "PluginInstallPolicySource": {
+      "enum": [
+        "WORKSPACE_SETTING",
+        "IMPLICIT_CANONICAL_APP"
       ],
       "type": "string"
     },
@@ -10687,6 +10746,16 @@
         "installPolicy": {
           "$ref": "#/definitions/PluginInstallPolicy"
         },
+        "installPolicySource": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PluginInstallPolicySource"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "installed": {
           "type": "boolean"
         },
@@ -10738,6 +10807,14 @@
         },
         "source": {
           "$ref": "#/definitions/PluginSource"
+        },
+        "version": {
+          "default": null,
+          "description": "Version advertised by the remote marketplace backend when available.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -10913,17 +10990,91 @@
       ],
       "type": "string"
     },
+    "RateLimitResetCredit": {
+      "properties": {
+        "description": {
+          "description": "Backend-provided display description for this credit, or `null` when unavailable.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expiresAt": {
+          "description": "Unix timestamp in seconds when the credit expires, or `null` if it does not expire.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "grantedAt": {
+          "description": "Unix timestamp in seconds when the credit was granted.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "id": {
+          "description": "Opaque backend identifier for this reset credit.",
+          "type": "string"
+        },
+        "resetType": {
+          "$ref": "#/definitions/RateLimitResetType"
+        },
+        "status": {
+          "$ref": "#/definitions/RateLimitResetCreditStatus"
+        },
+        "title": {
+          "description": "Backend-provided display title for this credit, or `null` when unavailable.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "grantedAt",
+        "id",
+        "resetType",
+        "status"
+      ],
+      "type": "object"
+    },
+    "RateLimitResetCreditStatus": {
+      "enum": [
+        "available",
+        "redeeming",
+        "redeemed",
+        "unknown"
+      ],
+      "type": "string"
+    },
     "RateLimitResetCreditsSummary": {
       "properties": {
         "availableCount": {
           "format": "int64",
           "type": "integer"
+        },
+        "credits": {
+          "description": "Detail rows for available reset credits, when the backend provides them.\n\n`null` means only `availableCount` is known, while an empty array means details were fetched and no available credits were returned. The backend may cap this list, so its length can be less than `availableCount`.",
+          "items": {
+            "$ref": "#/definitions/RateLimitResetCredit"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
       "required": [
         "availableCount"
       ],
       "type": "object"
+    },
+    "RateLimitResetType": {
+      "enum": [
+        "codexRateLimits",
+        "unknown"
+      ],
+      "type": "string"
     },
     "RateLimitSnapshot": {
       "properties": {
@@ -11913,6 +12064,12 @@
             },
             "name": {
               "type": "string"
+            },
+            "namespace": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "status": {
               "type": [
@@ -15058,6 +15215,13 @@
         "ephemeral": {
           "type": "boolean"
         },
+        "lastTurnId": {
+          "description": "Optional last turn id to fork through, inclusive.\n\nWhen specified, turns after `last_turn_id` are omitted from the fork. The referenced turn cannot be in progress.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "model": {
           "description": "Configuration overrides for the forked thread, if any.",
           "type": [
@@ -15100,13 +15264,6 @@
             }
           ],
           "description": "Optional client-supplied analytics source classification for this forked thread."
-        },
-        "lastTurnId": {
-          "description": "Optional last turn id to fork through, inclusive.\n\nWhen specified, turns after `last_turn_id` are omitted from the fork. The referenced turn cannot be in progress.",
-          "type": [
-            "string",
-            "null"
-          ]
         }
       },
       "required": [


### PR DESCRIPTION
## Summary
- fix hard parse failures for new Claude 2.1.205 result/task enum values and top-level output message types
- add typed/forward-compatible fields for result, init/status/compact/task/user/assistant wrappers and system subtype payloads
- add get_usage and model-scoped quota typing, plus Codex schema snapshot regeneration for #179

Covers #181, #182, #183, #184, #185, #186, #187, #188, #189, #190, #191, and #179.

## Review notes
- PR #180 is still open and overlaps some rate_limit_event schema work; this branch is based on current main, so rate-limit overlap should be reconciled before merge.

## Verification
- cargo test -p claude-codes
- cargo run -p codex-codes --example schema_coverage
- python3 scripts/check_codex_schema_drift.py
- cargo test