### PR TITLE
codex-codes: re-snapshot schema drift (#195)

### DIFF
--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Re-snapshotted the Codex app-server schemas** against `openai/codex@main`
+  (resolves #195). `LoginAccountParams` and `LoginAccountResponse` gained an
+  `amazonBedrock` account variant (`apiKey` + `region` on params). Regenerated
+  `protocol_generated/{mod,types,samples}.rs`; schema coverage remains 165/165
+  (100%) and the drift check reports byte-identical.
+
 ## [0.143.0] - 2026-06-27
 
 ### Added

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -2877,6 +2877,12 @@ pub enum LoginAccountParams {
         )]
         chatgpt_plan_type: Option<String>,
     },
+    #[serde(rename = "amazonBedrock")]
+    AmazonBedrock {
+        #[serde(rename = "apiKey")]
+        api_key: String,
+        region: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -2901,6 +2907,8 @@ pub enum LoginAccountResponse {
     },
     #[serde(rename = "chatgptAuthTokens")]
     ChatgptAuthTokens,
+    #[serde(rename = "amazonBedrock")]
+    AmazonBedrock,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -11591,6 +11591,31 @@
             ],
             "title": "ChatgptAuthTokensv2::LoginAccountParams",
             "type": "object"
+          },
+          {
+            "description": "[UNSTABLE] Managed Amazon Bedrock login is experimental.",
+            "properties": {
+              "apiKey": {
+                "type": "string"
+              },
+              "region": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "amazonBedrock"
+                ],
+                "title": "AmazonBedrockv2::LoginAccountParamsType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "apiKey",
+              "region",
+              "type"
+            ],
+            "title": "AmazonBedrockv2::LoginAccountParams",
+            "type": "object"
           }
         ],
         "title": "LoginAccountParams"
@@ -11683,6 +11708,22 @@
               "type"
             ],
             "title": "ChatgptAuthTokensv2::LoginAccountResponse",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "amazonBedrock"
+                ],
+                "title": "AmazonBedrockv2::LoginAccountResponseType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "title": "AmazonBedrockv2::LoginAccountResponse",
             "type": "object"
           }
         ],

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -7995,6 +7995,31 @@
           ],
           "title": "ChatgptAuthTokensv2::LoginAccountParams",
           "type": "object"
+        },
+        {
+          "description": "[UNSTABLE] Managed Amazon Bedrock login is experimental.",
+          "properties": {
+            "apiKey": {
+              "type": "string"
+            },
+            "region": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "amazonBedrock"
+              ],
+              "title": "AmazonBedrockv2::LoginAccountParamsType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiKey",
+            "region",
+            "type"
+          ],
+          "title": "AmazonBedrockv2::LoginAccountParams",
+          "type": "object"
         }
       ],
       "title": "LoginAccountParams"
@@ -8087,6 +8112,22 @@
             "type"
           ],
           "title": "ChatgptAuthTokensv2::LoginAccountResponse",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "amazonBedrock"
+              ],
+              "title": "AmazonBedrockv2::LoginAccountResponseType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "AmazonBedrockv2::LoginAccountResponse",
           "type": "object"
         }
       ],


### PR DESCRIPTION
Re-snapshots the app-server schemas against openai/codex@main per the drift report in #195.

Upstream delta: `LoginAccountParams` / `LoginAccountResponse` gained an `amazonBedrock` account variant (`apiKey` + `region` on params).

Verification:
- `python3 scripts/check_codex_schema_drift.py` — clean (byte-identical)
- `cargo run -p codex-codes --example schema_coverage` — 165/165 modeled, 165/165 with sample
- `cargo test -p codex-codes` — all green

Closes #195.