### PR TITLE
chore: bump claude-codes 2.1.160, codex-codes 0.143.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.159"
+version = "2.1.160"
 dependencies = [
  "anyhow",
  "base64",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.143.0"
+version = "0.143.1"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This workspace provides two independent crates for interacting with [Claude Code
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.159`, tested against Claude CLI `2.1.178`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.143.0`, tested against Codex CLI `0.143.0`.
+- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.160`, tested against Claude CLI `2.1.205`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.143.1`, tested against Codex CLI `0.143.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.
 

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.1.160] - 2026-07-10
 
 ### Added
 
@@ -52,6 +52,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deserialize.
 - `RateLimitWindow::Hourly` removed; the window no longer exists in the CLI
   schema. An `"hourly"` value now parses as `RateLimitWindow::Unknown`.
+
+### Changed
+
+- **Tested Claude CLI version** bumped to 2.1.205 — the full integration suite
+  passes against the installed binary. One suite fix was required: CLI 2.1.205
+  only enables `AskUserQuestion` in headless mode when a permission-prompt
+  tool is configured (`--permission-prompt-tool`), so the round-trip test now
+  spawns with one, matching the existing converge test.
 
 ## [2.1.159] - 2026-06-27
 

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.159"
+version = "2.1.160"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -138,7 +138,7 @@ let serialized = Protocol::serialize(&output)?;
 
 ## Compatibility
 
-**Tested against:** Claude CLI 2.1.178
+**Tested against:** Claude CLI 2.1.205
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -78,7 +78,7 @@
 //! ⚠️ **Important**: The Claude CLI protocol is unstable and evolving. This crate
 //! automatically checks your Claude CLI version and warns if it's newer than tested.
 //!
-//! Current tested version: **2.1.3**
+//! Current tested version: **2.1.205**
 //!
 //! Report compatibility issues at: <https://github.com/meawoppl/rust-claude-codes/pulls>
 //!

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.178";
+const TESTED_VERSION: &str = "2.1.205";
 
 /// Ensures version warning is only shown once per session
 static VERSION_CHECK: Once = Once::new();

--- a/claude-codes/tests/integration_tests.rs
+++ b/claude-codes/tests/integration_tests.rs
@@ -1925,10 +1925,13 @@ async fn test_ask_user_question_round_trip() {
 
     let _ = env_logger::builder().is_test(true).try_init();
 
+    // CLI 2.1.205+ only enables AskUserQuestion in headless mode when a
+    // permission-prompt tool is configured.
     let child = ClaudeCliBuilder::new()
         .model("sonnet")
         .allow_recursion()
         .allowed_tools(["AskUserQuestion"])
+        .permission_prompt_tool("stdio")
         .spawn()
         .await
         .expect("Failed to spawn Claude");

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.143.1] - 2026-07-10
 
 ### Changed
 

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.143.0"
+version = "0.143.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]


### PR DESCRIPTION
Release bump for publishing both crates.

**claude-codes 2.1.160**
- CLI 2.1.205 output coverage (#194), rate_limit_event schema (#180), transcript corpus parser (#193), `SubagentUsageRollup` (#197)
- `TESTED_VERSION` 2.1.178 → 2.1.205 — full live integration suite passes against the installed 2.1.205 binary
- Integration-suite fix: 2.1.205 only enables `AskUserQuestion` in headless mode when a permission-prompt tool is configured; the round-trip test now spawns with `.permission_prompt_tool("stdio")` like the converge test

**codex-codes 0.143.1**
- Schema re-snapshot from openai/codex@main (#196): `amazonBedrock` login account variant

READMEs, version.rs, changelogs, and Cargo.lock synced per the version-consistency CI job. Verified: fmt, clippy clean, 320 workspace tests + 26 live integration tests green.