### PR TITLE
add ClaudeModel and CodexModel convenience enums

### DIFF
--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`ClaudeModel`** — convenience enum for every model selector the Claude CLI
+  accepts, keyed by human-friendly names. Floating aliases (`Sonnet`, `Opus`,
+  `Haiku`, `Fable`, `Best`, `OpusPlan`, and the `[1m]` context variants) plus
+  the pinned registry models (`Fable5`, `Mythos5`, `Opus48` … `Haiku35`),
+  extracted from the CLI 2.1.205 binary's model registry. `cli_arg()` returns
+  the exact `--model` string, `display_name()` the human-readable name, and
+  `Custom(String)` passes unknown models through verbatim.
+  `ClaudeCliBuilder::model(ClaudeModel::Sonnet5)` works directly via
+  `Into<String>`. Re-exported at the crate root.
+
 ## [2.1.160] - 2026-07-10
 
 ### Added

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -102,6 +102,7 @@
 pub mod error;
 pub mod io;
 pub mod messages;
+pub mod models;
 pub mod protocol;
 pub mod tool_inputs;
 pub mod types;
@@ -125,6 +126,7 @@ pub use io::{
     ClaudeOutput, ParseError, TranscriptMessage,
 };
 pub use messages::*;
+pub use models::ClaudeModel;
 pub use protocol::{MessageEnvelope, Protocol};
 pub use types::*;
 

--- a/claude-codes/src/models.rs
+++ b/claude-codes/src/models.rs
@@ -1,0 +1,295 @@
+//! Convenience enum for the models the Claude CLI exposes.
+//!
+//! Variants are keyed by human-friendly model names; [`ClaudeModel::cli_arg`]
+//! returns the exact string to pass to `claude --model` (and therefore to
+//! `ClaudeCliBuilder::model`, which accepts the enum directly via
+//! `Into<String>`).
+//!
+//! The model table was extracted from the Claude CLI 2.1.205 binary's model
+//! registry. Aliases (`sonnet`, `opus`, …) float to the newest model of that
+//! family on the CLI side; pinned variants name one concrete model. Unknown
+//! or future model strings round-trip through [`ClaudeModel::Custom`].
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+
+/// A model selector accepted by `claude --model`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ClaudeModel {
+    /// Newest Sonnet-family model (floating alias `sonnet`).
+    Sonnet,
+    /// Newest Opus-family model (floating alias `opus`).
+    Opus,
+    /// Newest Haiku-family model (floating alias `haiku`).
+    Haiku,
+    /// Newest Fable-family model (floating alias `fable`).
+    Fable,
+    /// The most capable model available to the account (alias `best`).
+    Best,
+    /// Opus for plan mode, Sonnet otherwise (alias `opusplan`).
+    OpusPlan,
+    /// Newest Sonnet with the 1M-token context beta (alias `sonnet[1m]`).
+    Sonnet1m,
+    /// Newest Opus with the 1M-token context beta (alias `opus[1m]`).
+    Opus1m,
+    /// Newest Fable with the 1M-token context beta (alias `fable[1m]`).
+    Fable1m,
+    /// Fable 5 (`claude-fable-5`).
+    Fable5,
+    /// Mythos 5 (`claude-mythos-5`).
+    Mythos5,
+    /// Opus 4.8 (`claude-opus-4-8`).
+    Opus48,
+    /// Opus 4.7 (`claude-opus-4-7`).
+    Opus47,
+    /// Opus 4.6 (`claude-opus-4-6`).
+    Opus46,
+    /// Opus 4.5 (`claude-opus-4-5`).
+    Opus45,
+    /// Opus 4.1 (`claude-opus-4-1`).
+    Opus41,
+    /// Opus 4 (`claude-opus-4-0`).
+    Opus40,
+    /// Sonnet 5 (`claude-sonnet-5`).
+    Sonnet5,
+    /// Sonnet 4.6 (`claude-sonnet-4-6`).
+    Sonnet46,
+    /// Sonnet 4.5 (`claude-sonnet-4-5`).
+    Sonnet45,
+    /// Sonnet 4 (`claude-sonnet-4-0`).
+    Sonnet40,
+    /// Sonnet 3.7 (`claude-3-7-sonnet`).
+    Sonnet37,
+    /// Sonnet 3.5 (`claude-3-5-sonnet`).
+    Sonnet35,
+    /// Haiku 4.5 (`claude-haiku-4-5`).
+    Haiku45,
+    /// Haiku 3.5 (`claude-3-5-haiku`).
+    Haiku35,
+    /// A model string not yet known to this version of the crate. Passed to
+    /// the CLI verbatim.
+    Custom(String),
+}
+
+impl ClaudeModel {
+    /// The string to pass to `claude --model` for this model.
+    pub fn cli_arg(&self) -> &str {
+        match self {
+            Self::Sonnet => "sonnet",
+            Self::Opus => "opus",
+            Self::Haiku => "haiku",
+            Self::Fable => "fable",
+            Self::Best => "best",
+            Self::OpusPlan => "opusplan",
+            Self::Sonnet1m => "sonnet[1m]",
+            Self::Opus1m => "opus[1m]",
+            Self::Fable1m => "fable[1m]",
+            Self::Fable5 => "claude-fable-5",
+            Self::Mythos5 => "claude-mythos-5",
+            Self::Opus48 => "claude-opus-4-8",
+            Self::Opus47 => "claude-opus-4-7",
+            Self::Opus46 => "claude-opus-4-6",
+            Self::Opus45 => "claude-opus-4-5",
+            Self::Opus41 => "claude-opus-4-1",
+            Self::Opus40 => "claude-opus-4-0",
+            Self::Sonnet5 => "claude-sonnet-5",
+            Self::Sonnet46 => "claude-sonnet-4-6",
+            Self::Sonnet45 => "claude-sonnet-4-5",
+            Self::Sonnet40 => "claude-sonnet-4-0",
+            Self::Sonnet37 => "claude-3-7-sonnet",
+            Self::Sonnet35 => "claude-3-5-sonnet",
+            Self::Haiku45 => "claude-haiku-4-5",
+            Self::Haiku35 => "claude-3-5-haiku",
+            Self::Custom(s) => s.as_str(),
+        }
+    }
+
+    /// Alias for [`cli_arg`](Self::cli_arg), matching the crate's string-enum
+    /// convention.
+    pub fn as_str(&self) -> &str {
+        self.cli_arg()
+    }
+
+    /// Human-friendly display name, matching what the CLI's own UI renders.
+    pub fn display_name(&self) -> &str {
+        match self {
+            Self::Sonnet => "Sonnet (latest)",
+            Self::Opus => "Opus (latest)",
+            Self::Haiku => "Haiku (latest)",
+            Self::Fable => "Fable (latest)",
+            Self::Best => "Best available",
+            Self::OpusPlan => "Opus (plan mode) / Sonnet",
+            Self::Sonnet1m => "Sonnet (latest, 1M context)",
+            Self::Opus1m => "Opus (latest, 1M context)",
+            Self::Fable1m => "Fable (latest, 1M context)",
+            Self::Fable5 => "Fable 5",
+            Self::Mythos5 => "Mythos 5",
+            Self::Opus48 => "Opus 4.8",
+            Self::Opus47 => "Opus 4.7",
+            Self::Opus46 => "Opus 4.6",
+            Self::Opus45 => "Opus 4.5",
+            Self::Opus41 => "Opus 4.1",
+            Self::Opus40 => "Opus 4",
+            Self::Sonnet5 => "Sonnet 5",
+            Self::Sonnet46 => "Sonnet 4.6",
+            Self::Sonnet45 => "Sonnet 4.5",
+            Self::Sonnet40 => "Sonnet 4",
+            Self::Sonnet37 => "Sonnet 3.7",
+            Self::Sonnet35 => "Sonnet 3.5",
+            Self::Haiku45 => "Haiku 4.5",
+            Self::Haiku35 => "Haiku 3.5",
+            Self::Custom(s) => s.as_str(),
+        }
+    }
+
+    /// True for the floating aliases (`sonnet`, `opus`, …) that the CLI
+    /// resolves to the newest model of the family at session start.
+    pub fn is_alias(&self) -> bool {
+        matches!(
+            self,
+            Self::Sonnet
+                | Self::Opus
+                | Self::Haiku
+                | Self::Fable
+                | Self::Best
+                | Self::OpusPlan
+                | Self::Sonnet1m
+                | Self::Opus1m
+                | Self::Fable1m
+        )
+    }
+
+    /// Every model known to this version of the crate, aliases first.
+    pub fn known() -> &'static [ClaudeModel] {
+        &[
+            Self::Sonnet,
+            Self::Opus,
+            Self::Haiku,
+            Self::Fable,
+            Self::Best,
+            Self::OpusPlan,
+            Self::Sonnet1m,
+            Self::Opus1m,
+            Self::Fable1m,
+            Self::Fable5,
+            Self::Mythos5,
+            Self::Opus48,
+            Self::Opus47,
+            Self::Opus46,
+            Self::Opus45,
+            Self::Opus41,
+            Self::Opus40,
+            Self::Sonnet5,
+            Self::Sonnet46,
+            Self::Sonnet45,
+            Self::Sonnet40,
+            Self::Sonnet37,
+            Self::Sonnet35,
+            Self::Haiku45,
+            Self::Haiku35,
+        ]
+    }
+}
+
+impl fmt::Display for ClaudeModel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.cli_arg())
+    }
+}
+
+impl From<&str> for ClaudeModel {
+    fn from(s: &str) -> Self {
+        match s {
+            "sonnet" => Self::Sonnet,
+            "opus" => Self::Opus,
+            "haiku" => Self::Haiku,
+            "fable" => Self::Fable,
+            "best" => Self::Best,
+            "opusplan" => Self::OpusPlan,
+            "sonnet[1m]" => Self::Sonnet1m,
+            "opus[1m]" => Self::Opus1m,
+            "fable[1m]" => Self::Fable1m,
+            "claude-fable-5" => Self::Fable5,
+            "claude-mythos-5" => Self::Mythos5,
+            "claude-opus-4-8" => Self::Opus48,
+            "claude-opus-4-7" => Self::Opus47,
+            "claude-opus-4-6" => Self::Opus46,
+            "claude-opus-4-5" => Self::Opus45,
+            "claude-opus-4-1" => Self::Opus41,
+            "claude-opus-4-0" => Self::Opus40,
+            "claude-sonnet-5" => Self::Sonnet5,
+            "claude-sonnet-4-6" => Self::Sonnet46,
+            "claude-sonnet-4-5" => Self::Sonnet45,
+            "claude-sonnet-4-0" => Self::Sonnet40,
+            "claude-3-7-sonnet" => Self::Sonnet37,
+            "claude-3-5-sonnet" => Self::Sonnet35,
+            "claude-haiku-4-5" => Self::Haiku45,
+            "claude-3-5-haiku" => Self::Haiku35,
+            other => Self::Custom(other.to_string()),
+        }
+    }
+}
+
+impl From<ClaudeModel> for String {
+    fn from(model: ClaudeModel) -> Self {
+        model.cli_arg().to_string()
+    }
+}
+
+impl Serialize for ClaudeModel {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.cli_arg())
+    }
+}
+
+impl<'de> Deserialize<'de> for ClaudeModel {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self::from(s.as_str()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ClaudeModel;
+
+    #[test]
+    fn test_cli_arg_round_trip() {
+        for model in ClaudeModel::known() {
+            assert_eq!(&ClaudeModel::from(model.cli_arg()), model);
+        }
+        assert_eq!(
+            ClaudeModel::from("claude-nova-7"),
+            ClaudeModel::Custom("claude-nova-7".to_string())
+        );
+        assert_eq!(
+            ClaudeModel::from("claude-nova-7").cli_arg(),
+            "claude-nova-7"
+        );
+    }
+
+    #[test]
+    fn test_into_string_matches_cli_arg() {
+        let s: String = ClaudeModel::Sonnet5.into();
+        assert_eq!(s, "claude-sonnet-5");
+        let s: String = ClaudeModel::Opus1m.into();
+        assert_eq!(s, "opus[1m]");
+    }
+
+    #[test]
+    fn test_display_names() {
+        assert_eq!(ClaudeModel::Fable5.display_name(), "Fable 5");
+        assert_eq!(ClaudeModel::Opus48.display_name(), "Opus 4.8");
+        assert_eq!(ClaudeModel::Sonnet.display_name(), "Sonnet (latest)");
+        assert!(ClaudeModel::Sonnet.is_alias());
+        assert!(!ClaudeModel::Sonnet5.is_alias());
+    }
+
+    #[test]
+    fn test_serde_round_trip() {
+        let json = serde_json::to_string(&ClaudeModel::Haiku45).unwrap();
+        assert_eq!(json, "\"claude-haiku-4-5\"");
+        let back: ClaudeModel = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, ClaudeModel::Haiku45);
+    }
+}

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`CodexModel`** — convenience enum for the Codex model catalog, keyed by
+  human-friendly names (`Gpt56Sol`, `Gpt56Terra`, `Gpt56Luna`, `Gpt55`,
+  `Gpt54`, `Gpt54Mini`, `Gpt52`, `CodexAutoReview`), taken from
+  `openai/codex@main`'s bundled `models-manager/models.json` (2026-07-11).
+  `cli_arg()` returns the slug for `codex -m` / `ThreadStartParams.model`,
+  `display_name()` the catalog's display name, and `Custom(String)` passes
+  unknown slugs through. Re-exported at the crate root.
+
 ## [0.143.1] - 2026-07-10
 
 ### Changed

--- a/codex-codes/src/lib.rs
+++ b/codex-codes/src/lib.rs
@@ -109,6 +109,7 @@ pub mod io;
 pub mod error;
 pub mod jsonrpc;
 pub mod messages;
+pub mod models;
 pub mod protocol;
 pub mod protocol_generated;
 
@@ -148,6 +149,9 @@ pub use protocol::*;
 
 // Typed message dispatch (notifications + server-to-client requests)
 pub use messages::{Notification, ServerMessage, ServerRequest};
+
+// Model catalog convenience enum
+pub use models::CodexModel;
 
 // CLI builder (feature-gated)
 #[cfg(any(feature = "sync-client", feature = "async-client"))]

--- a/codex-codes/src/models.rs
+++ b/codex-codes/src/models.rs
@@ -1,0 +1,169 @@
+//! Convenience enum for the models the Codex CLI exposes.
+//!
+//! Variants are keyed by human-friendly model names; [`CodexModel::cli_arg`]
+//! returns the model slug to pass to `codex -m` / `--model`, to
+//! `ThreadStartParams.model`, or to an `AppServerBuilder::config_override`
+//! of `model`.
+//!
+//! The catalog was taken from `openai/codex@main`'s bundled
+//! `models-manager/models.json` (2026-07-11). The server catalog evolves
+//! faster than this crate; unknown slugs round-trip through
+//! [`CodexModel::Custom`].
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+
+/// A model slug accepted by the Codex CLI and app-server.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum CodexModel {
+    /// GPT-5.6-Sol (`gpt-5.6-sol`).
+    Gpt56Sol,
+    /// GPT-5.6-Terra (`gpt-5.6-terra`).
+    Gpt56Terra,
+    /// GPT-5.6-Luna (`gpt-5.6-luna`).
+    Gpt56Luna,
+    /// GPT-5.5 (`gpt-5.5`).
+    Gpt55,
+    /// GPT-5.4 (`gpt-5.4`).
+    Gpt54,
+    /// GPT-5.4-Mini (`gpt-5.4-mini`).
+    Gpt54Mini,
+    /// GPT-5.2 (`gpt-5.2`).
+    Gpt52,
+    /// Codex Auto Review (`codex-auto-review`) — hidden from the picker but
+    /// accepted by the API.
+    CodexAutoReview,
+    /// A model slug not yet known to this version of the crate. Passed
+    /// through verbatim.
+    Custom(String),
+}
+
+impl CodexModel {
+    /// The slug to pass to `codex -m` / `ThreadStartParams.model`.
+    pub fn cli_arg(&self) -> &str {
+        match self {
+            Self::Gpt56Sol => "gpt-5.6-sol",
+            Self::Gpt56Terra => "gpt-5.6-terra",
+            Self::Gpt56Luna => "gpt-5.6-luna",
+            Self::Gpt55 => "gpt-5.5",
+            Self::Gpt54 => "gpt-5.4",
+            Self::Gpt54Mini => "gpt-5.4-mini",
+            Self::Gpt52 => "gpt-5.2",
+            Self::CodexAutoReview => "codex-auto-review",
+            Self::Custom(s) => s.as_str(),
+        }
+    }
+
+    /// Alias for [`cli_arg`](Self::cli_arg), matching the crate's string-enum
+    /// convention.
+    pub fn as_str(&self) -> &str {
+        self.cli_arg()
+    }
+
+    /// Human-friendly display name, matching the catalog's `display_name`.
+    pub fn display_name(&self) -> &str {
+        match self {
+            Self::Gpt56Sol => "GPT-5.6-Sol",
+            Self::Gpt56Terra => "GPT-5.6-Terra",
+            Self::Gpt56Luna => "GPT-5.6-Luna",
+            Self::Gpt55 => "GPT-5.5",
+            Self::Gpt54 => "GPT-5.4",
+            Self::Gpt54Mini => "GPT-5.4-Mini",
+            Self::Gpt52 => "GPT-5.2",
+            Self::CodexAutoReview => "Codex Auto Review",
+            Self::Custom(s) => s.as_str(),
+        }
+    }
+
+    /// Every model known to this version of the crate.
+    pub fn known() -> &'static [CodexModel] {
+        &[
+            Self::Gpt56Sol,
+            Self::Gpt56Terra,
+            Self::Gpt56Luna,
+            Self::Gpt55,
+            Self::Gpt54,
+            Self::Gpt54Mini,
+            Self::Gpt52,
+            Self::CodexAutoReview,
+        ]
+    }
+}
+
+impl fmt::Display for CodexModel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.cli_arg())
+    }
+}
+
+impl From<&str> for CodexModel {
+    fn from(s: &str) -> Self {
+        match s {
+            "gpt-5.6-sol" => Self::Gpt56Sol,
+            "gpt-5.6-terra" => Self::Gpt56Terra,
+            "gpt-5.6-luna" => Self::Gpt56Luna,
+            "gpt-5.5" => Self::Gpt55,
+            "gpt-5.4" => Self::Gpt54,
+            "gpt-5.4-mini" => Self::Gpt54Mini,
+            "gpt-5.2" => Self::Gpt52,
+            "codex-auto-review" => Self::CodexAutoReview,
+            other => Self::Custom(other.to_string()),
+        }
+    }
+}
+
+impl From<CodexModel> for String {
+    fn from(model: CodexModel) -> Self {
+        model.cli_arg().to_string()
+    }
+}
+
+impl Serialize for CodexModel {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.cli_arg())
+    }
+}
+
+impl<'de> Deserialize<'de> for CodexModel {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self::from(s.as_str()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CodexModel;
+
+    #[test]
+    fn test_cli_arg_round_trip() {
+        for model in CodexModel::known() {
+            assert_eq!(&CodexModel::from(model.cli_arg()), model);
+        }
+        assert_eq!(
+            CodexModel::from("gpt-9-experimental"),
+            CodexModel::Custom("gpt-9-experimental".to_string())
+        );
+    }
+
+    #[test]
+    fn test_into_string_matches_cli_arg() {
+        let s: String = CodexModel::Gpt56Sol.into();
+        assert_eq!(s, "gpt-5.6-sol");
+    }
+
+    #[test]
+    fn test_converts_into_thread_start_model_field() {
+        // ThreadStartParams.model is Option<String>; the enum feeds it via Into.
+        let model: Option<String> = Some(CodexModel::Gpt55.into());
+        assert_eq!(model.as_deref(), Some("gpt-5.5"));
+    }
+
+    #[test]
+    fn test_serde_round_trip() {
+        let json = serde_json::to_string(&CodexModel::Gpt54Mini).unwrap();
+        assert_eq!(json, "\"gpt-5.4-mini\"");
+        let back: CodexModel = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, CodexModel::Gpt54Mini);
+    }
+}


### PR DESCRIPTION
Convenience enums for the models each CLI exposes — variants keyed by human-friendly names, mapping to the exact argument that starts the CLI with that model.

**`claude_codes::ClaudeModel`**
- Floating aliases the CLI resolves at session start: `Sonnet`, `Opus`, `Haiku`, `Fable`, `Best`, `OpusPlan`, and the 1M-context forms `Sonnet1m`/`Opus1m`/`Fable1m`
- Pinned models from the 2.1.205 binary's model registry: `Fable5`, `Mythos5`, `Opus48`…`Opus40`, `Sonnet5`…`Sonnet35`, `Haiku45`, `Haiku35`
- `cli_arg()` → the `--model` string; `display_name()` → the CLI UI's own names ("Opus 4.8", "Sonnet 5", …); `is_alias()`, `known()`
- `ClaudeCliBuilder::model(ClaudeModel::Sonnet5)` works directly (`Into<String>`); verified live: `claude --model claude-sonnet-5` runs and reports `claude-sonnet-5` in `modelUsage`

**`codex_codes::CodexModel`**
- Catalog from `openai/codex@main` `models-manager/models.json` (refreshed today): `Gpt56Sol`, `Gpt56Terra`, `Gpt56Luna`, `Gpt55`, `Gpt54`, `Gpt54Mini`, `Gpt52`, `CodexAutoReview`
- `cli_arg()` → slug for `codex -m` / `ThreadStartParams.model` / `config_override("model", …)`

Both follow the crate string-enum conventions: `Custom(String)` passthrough for unknown models, `From<&str>` parsing, serde as plain strings, `Display` = CLI arg. Tests cover round-trips, conversions, and serde; changelogs updated under Unreleased. No version bump.