### PR TITLE
codex-codes: ServerMessage/params/approval ergonomics (#205/#206/#209/#212/#213)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.143.2"
+version = "0.143.3"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.143.3] - 2026-07-16
+
+### Added
+
+- **`ServerMessage::from_json_str` / `from_value`** — parse a raw app-server
+  frame into a typed [`ServerMessage`] without a live client, reusing the same
+  dispatch the client runs. Server-initiated notifications and requests decode
+  to their typed variants (unknown methods route to `Unknown`); a JSON-RPC
+  response/error frame returns `Error::Protocol`. Unblocks replay, recovery,
+  and fixture-based tests downstream. (#209)
+- **`Notification::turn_id() -> Option<&str>`** — read the turn id a
+  notification is scoped to straight from its typed fields (`turn.id` for the
+  turn-lifecycle notifications, the flat `turnId` for the streaming ones),
+  instead of round-tripping through `into_envelope()` and poking
+  `serde_json::Value`. This is the id `turn/interrupt` needs. (#205)
+- **`Notification::thread_item() -> Option<&ThreadItem>`** — typed access to the
+  item carried by `item/started` / `item/completed`, so event adapters don't
+  reserialize items back into JSON. (#213)
+- **`Default` for `ThreadStartParams`, `TurnStartParams`, `ThreadResumeParams`,
+  and `ThreadForkParams`** — construct empty request params with
+  `Params::default()` instead of spelling out every `None` field. (#206)
+- **`accept()` / `decline()` / `cancel()` / `approved()` / `denied()` /
+  `abort()` constructors** on the approval-response payloads
+  (`FileChangeRequestApprovalResponse`,
+  `CommandExecutionRequestApprovalResponse`, `ExecCommandApprovalResponse`,
+  `ApplyPatchApprovalResponse`), so callers respond to approval requests
+  without hand-rolling `serde_json` `decision` objects. (#212)
+
 ## [0.143.2] - 2026-07-11
 
 ### Added

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.143.2"
+version = "0.143.3"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/src/messages.rs
+++ b/codex-codes/src/messages.rs
@@ -23,7 +23,8 @@
 //!   If you see one, the typed binding in [`crate::protocol`] is out of
 //!   sync with the wire format and needs to be updated.
 
-use crate::jsonrpc::RequestId;
+use crate::error::{Error, ParseError};
+use crate::jsonrpc::{JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, RequestId};
 use crate::protocol::{
     methods, AccountLoginCompletedNotification, AccountRateLimitsUpdatedNotification,
     AccountUpdatedNotification, AgentMessageDeltaNotification, AppListUpdatedNotification,
@@ -300,6 +301,62 @@ impl Notification {
     /// `true` if this notification's method isn't modeled by the crate.
     pub fn is_unknown(&self) -> bool {
         matches!(self, Self::Unknown { .. })
+    }
+
+    /// Return the turn id this notification is scoped to, if it carries one.
+    ///
+    /// Reads the typed `turnId` field (or `turn.id` for the turn-lifecycle
+    /// notifications) directly, so callers don't have to round-trip through
+    /// [`into_envelope`](Self::into_envelope) and poke `serde_json::Value`
+    /// fields. Returns `None` for notifications that aren't turn-scoped, and
+    /// treats an empty id the server omitted as absent.
+    ///
+    /// The turn id from `turn/started` is what
+    /// [`turn/interrupt`](crate::AsyncClient::turn_interrupt) needs to cancel
+    /// the active turn.
+    pub fn turn_id(&self) -> Option<&str> {
+        let id = match self {
+            Self::TurnStarted(n) => n.turn.id.as_str(),
+            Self::TurnCompleted(n) => n.turn.id.as_str(),
+            Self::AgentMessageDelta(n) => n.turn_id.as_str(),
+            Self::CmdOutputDelta(n) => n.turn_id.as_str(),
+            Self::FileChangeOutputDelta(n) => n.turn_id.as_str(),
+            Self::ReasoningDelta(n) => n.turn_id.as_str(),
+            Self::Error(n) => n.turn_id.as_str(),
+            Self::FileChangePatchUpdated(n) => n.turn_id.as_str(),
+            Self::PlanDelta(n) => n.turn_id.as_str(),
+            Self::TurnPlanUpdated(n) => n.turn_id.as_str(),
+            Self::TurnDiffUpdated(n) => n.turn_id.as_str(),
+            Self::TurnModerationMetadata(n) => n.turn_id.as_str(),
+            Self::ReasoningSummaryPartAdded(n) => n.turn_id.as_str(),
+            Self::ReasoningTextDelta(n) => n.turn_id.as_str(),
+            Self::ItemStarted(n) => n.turn_id.as_str(),
+            Self::ItemCompleted(n) => n.turn_id.as_str(),
+            Self::ContextCompacted(n) => n.turn_id.as_str(),
+            Self::McpToolCallProgress(n) => n.turn_id.as_str(),
+            Self::ModelRerouted(n) => n.turn_id.as_str(),
+            Self::ModelVerification(n) => n.turn_id.as_str(),
+            Self::ModelSafetyBufferingUpdated(n) => n.turn_id.as_str(),
+            Self::TerminalInteraction(n) => n.turn_id.as_str(),
+            Self::ThreadTokenUsageUpdated(n) => n.turn_id.as_str(),
+            Self::ItemGuardianApprovalReviewStarted(n) => n.turn_id.as_str(),
+            Self::ItemGuardianApprovalReviewCompleted(n) => n.turn_id.as_str(),
+            _ => return None,
+        };
+        (!id.is_empty()).then_some(id)
+    }
+
+    /// Return the typed [`ThreadItem`](crate::protocol::ThreadItem) this
+    /// notification carries, for `item/started` and `item/completed`.
+    ///
+    /// Lets downstream event adapters read the item's typed fields instead of
+    /// reserializing it back into `serde_json::Value`.
+    pub fn thread_item(&self) -> Option<&crate::protocol::ThreadItem> {
+        match self {
+            Self::ItemStarted(n) => Some(&n.item),
+            Self::ItemCompleted(n) => Some(&n.item),
+            _ => None,
+        }
     }
 
     /// Construct a [`Notification`] from a `method` + `params` envelope.
@@ -768,6 +825,58 @@ impl ServerMessage {
             Self::Request { request, .. } => request.is_unknown(),
         }
     }
+
+    /// Parse a raw app-server frame (one JSON-RPC line) into a [`ServerMessage`].
+    ///
+    /// This is the same parse path the [`AsyncClient`](crate::AsyncClient) and
+    /// [`SyncClient`](crate::SyncClient) run on incoming lines, exposed for
+    /// replay, recovery, and test fixtures that need to decode a captured frame
+    /// without a live client.
+    ///
+    /// A frame is a [`ServerMessage`] only if it is a server-initiated
+    /// notification or request. A JSON-RPC *response* / *error* (a reply to a
+    /// client request) is not a server message and returns
+    /// [`Error::Protocol`](crate::Error::Protocol). Unknown methods decode to
+    /// the `Unknown` variants rather than erroring; a modeled method whose
+    /// `params` don't fit returns [`Error::Deserialization`](crate::Error::Deserialization)
+    /// carrying the raw frame.
+    pub fn from_json_str(s: &str) -> Result<Self, Error> {
+        let msg: JsonRpcMessage = serde_json::from_str(s)
+            .map_err(|e| Error::Deserialization(ParseError::from_line(s, e)))?;
+        Self::from_jsonrpc(msg)
+    }
+
+    /// Parse a [`serde_json::Value`] frame into a [`ServerMessage`].
+    ///
+    /// See [`from_json_str`](Self::from_json_str) for the parsing contract.
+    pub fn from_value(value: Value) -> Result<Self, Error> {
+        let msg: JsonRpcMessage = serde_json::from_value(value.clone())
+            .map_err(|e| Error::Deserialization(ParseError::from_line(value.to_string(), e)))?;
+        Self::from_jsonrpc(msg)
+    }
+
+    fn from_jsonrpc(msg: JsonRpcMessage) -> Result<Self, Error> {
+        match msg {
+            JsonRpcMessage::Notification(JsonRpcNotification { method, params }) => {
+                Notification::from_envelope(&method, params.clone())
+                    .map(ServerMessage::Notification)
+                    .map_err(|e| Error::Deserialization(ParseError::from_envelope(method, params, e)))
+            }
+            JsonRpcMessage::Request(JsonRpcRequest { id, method, params }) => {
+                ServerRequest::from_envelope(&method, params.clone())
+                    .map(|request| ServerMessage::Request { id, request })
+                    .map_err(|e| Error::Deserialization(ParseError::from_envelope(method, params, e)))
+            }
+            JsonRpcMessage::Response(resp) => Err(Error::Protocol(format!(
+                "frame is a JSON-RPC response (id={}), not a server-initiated message",
+                resp.id
+            ))),
+            JsonRpcMessage::Error(err) => Err(Error::Protocol(format!(
+                "frame is a JSON-RPC error response (id={}, code={}), not a server-initiated message",
+                err.id, err.error.code
+            ))),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -804,5 +913,108 @@ mod tests {
         assert!(matches!(n, Notification::AgentMessageDelta(_)));
         let back = serde_json::to_value(&n).unwrap();
         assert_eq!(back, wire);
+    }
+
+    #[test]
+    fn test_turn_id_from_turn_started() {
+        // turn/started carries the id under `turn.id`.
+        let wire = serde_json::json!({
+            "method": "turn/started",
+            "params": {"threadId": "t1", "turn": {"id": "turn_42", "status": "inProgress"}},
+        });
+        let n: Notification = serde_json::from_value(wire).unwrap();
+        assert!(matches!(n, Notification::TurnStarted(_)));
+        assert_eq!(n.turn_id(), Some("turn_42"));
+    }
+
+    #[test]
+    fn test_turn_id_from_delta_field() {
+        // Streaming notifications carry a flat `turnId`.
+        let wire = serde_json::json!({
+            "method": "item/agentMessage/delta",
+            "params": {"threadId": "t1", "turnId": "turn_7", "itemId": "i1", "delta": "hi"},
+        });
+        let n: Notification = serde_json::from_value(wire).unwrap();
+        assert_eq!(n.turn_id(), Some("turn_7"));
+    }
+
+    #[test]
+    fn test_turn_id_none_for_non_turn_notification() {
+        let n = Notification::from_envelope(
+            "thread/deleted",
+            Some(serde_json::json!({"threadId": "t1"})),
+        )
+        .unwrap();
+        assert_eq!(n.turn_id(), None);
+    }
+
+    #[test]
+    fn test_thread_item_accessor() {
+        let wire = serde_json::json!({
+            "method": "item/started",
+            "params": {
+                "threadId": "t1",
+                "turnId": "turn_1",
+                "startedAtMs": 0,
+                "item": {"type": "agentMessage", "id": "i1", "text": "hi"},
+            },
+        });
+        let n: Notification = serde_json::from_value(wire).unwrap();
+        assert!(n.thread_item().is_some());
+        // A non-item notification has no thread item.
+        let other = Notification::from_envelope(
+            "thread/deleted",
+            Some(serde_json::json!({"threadId": "t1"})),
+        )
+        .unwrap();
+        assert!(other.thread_item().is_none());
+    }
+
+    #[test]
+    fn test_server_message_from_json_str_notification() {
+        let line = r#"{"method":"turn/started","params":{"threadId":"t1","turn":{"id":"turn_9","status":"inProgress"}}}"#;
+        let msg = ServerMessage::from_json_str(line).expect("parses a notification frame");
+        match msg {
+            ServerMessage::Notification(n) => assert_eq!(n.turn_id(), Some("turn_9")),
+            other => panic!("expected Notification, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_server_message_from_value_request() {
+        let frame = serde_json::json!({
+            "id": 7,
+            "method": "execCommandApproval",
+            "params": {
+                "callId": "c1",
+                "command": ["ls"],
+                "conversationId": "th_1",
+                "cwd": "/tmp",
+                "parsedCmd": [],
+            },
+        });
+        let msg = ServerMessage::from_value(frame).expect("parses a request frame");
+        match msg {
+            ServerMessage::Request { id, request } => {
+                assert_eq!(id, RequestId::Integer(7));
+                assert!(matches!(request, ServerRequest::ExecCommandApproval(_)));
+            }
+            other => panic!("expected Request, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_server_message_from_json_str_rejects_response() {
+        // A response to a client request is not a server-initiated message.
+        let line = r#"{"id":1,"result":{"threadId":"th_abc"}}"#;
+        let err = ServerMessage::from_json_str(line).unwrap_err();
+        assert!(matches!(err, Error::Protocol(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn test_server_message_from_json_str_unknown_method_ok() {
+        let line = r#"{"method":"some/future/notification","params":{"x":1}}"#;
+        let msg = ServerMessage::from_json_str(line).unwrap();
+        assert!(msg.is_unknown());
     }
 }

--- a/codex-codes/src/protocol.rs
+++ b/codex-codes/src/protocol.rs
@@ -200,3 +200,227 @@ pub mod methods {
     pub const APPLY_PATCH_APPROVAL: &str = "applyPatchApproval";
     pub const EXEC_COMMAND_APPROVAL: &str = "execCommandApproval";
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// Ergonomic constructors over the generated wire types.
+//
+// The types themselves are code-generated from the upstream schema; these
+// hand-written impls live here so they survive regeneration. They cover two
+// pain points for downstream consumers:
+//
+//   * `Default` for the all-optional client request params, so callers don't
+//     have to spell out every `None` field or construct via `from_value`.
+//   * `accept` / `decline` / `approved` / `denied` constructors for the
+//     approval-response payloads, so callers don't hand-roll `serde_json`
+//     objects and can't typo the wire `decision` string.
+// ──────────────────────────────────────────────────────────────────────────
+
+macro_rules! default_from_empty_object {
+    ($($ty:ident),+ $(,)?) => {
+        $(
+            impl Default for $ty {
+                fn default() -> Self {
+                    // Every field is `#[serde(default)]`, so an empty object
+                    // yields the fully-unset params. Deserializing (rather than
+                    // listing fields) keeps this correct as the upstream schema
+                    // adds optional fields, and mirrors the construction idiom
+                    // shown in the crate docs.
+                    serde_json::from_value(serde_json::Value::Object(Default::default()))
+                        .expect(concat!(
+                            stringify!($ty),
+                            ": every field is serde-default, so `{}` must deserialize"
+                        ))
+                }
+            }
+        )+
+    };
+}
+
+default_from_empty_object!(
+    ThreadStartParams,
+    TurnStartParams,
+    ThreadResumeParams,
+    ThreadForkParams,
+);
+
+impl FileChangeRequestApprovalResponse {
+    /// Approve this file-change request (`{"decision":"accept"}`).
+    pub fn accept() -> Self {
+        Self {
+            decision: FileChangeApprovalDecision::Accept,
+        }
+    }
+
+    /// Approve this and future file changes for the session.
+    pub fn accept_for_session() -> Self {
+        Self {
+            decision: FileChangeApprovalDecision::AcceptForSession,
+        }
+    }
+
+    /// Decline this file-change request (`{"decision":"decline"}`).
+    pub fn decline() -> Self {
+        Self {
+            decision: FileChangeApprovalDecision::Decline,
+        }
+    }
+
+    /// Cancel the turn in response to this request.
+    pub fn cancel() -> Self {
+        Self {
+            decision: FileChangeApprovalDecision::Cancel,
+        }
+    }
+}
+
+impl CommandExecutionRequestApprovalResponse {
+    /// Approve this command execution (`{"decision":"accept"}`).
+    pub fn accept() -> Self {
+        Self {
+            decision: CommandExecutionApprovalDecision::Accept,
+        }
+    }
+
+    /// Approve this and future command executions for the session.
+    pub fn accept_for_session() -> Self {
+        Self {
+            decision: CommandExecutionApprovalDecision::AcceptForSession,
+        }
+    }
+
+    /// Decline this command execution (`{"decision":"decline"}`).
+    pub fn decline() -> Self {
+        Self {
+            decision: CommandExecutionApprovalDecision::Decline,
+        }
+    }
+
+    /// Cancel the turn in response to this request.
+    pub fn cancel() -> Self {
+        Self {
+            decision: CommandExecutionApprovalDecision::Cancel,
+        }
+    }
+}
+
+impl ExecCommandApprovalResponse {
+    /// Approve the exec command (`{"decision":"approved"}`).
+    pub fn approved() -> Self {
+        Self {
+            decision: ReviewDecision::Approved,
+        }
+    }
+
+    /// Approve the exec command for the rest of the session.
+    pub fn approved_for_session() -> Self {
+        Self {
+            decision: ReviewDecision::ApprovedForSession,
+        }
+    }
+
+    /// Deny the exec command (`{"decision":"denied"}`).
+    pub fn denied() -> Self {
+        Self {
+            decision: ReviewDecision::Denied,
+        }
+    }
+
+    /// Abort the turn in response to the request.
+    pub fn abort() -> Self {
+        Self {
+            decision: ReviewDecision::Abort,
+        }
+    }
+}
+
+impl ApplyPatchApprovalResponse {
+    /// Approve the patch (`{"decision":"approved"}`).
+    pub fn approved() -> Self {
+        Self {
+            decision: ReviewDecision::Approved,
+        }
+    }
+
+    /// Approve this and future patches for the session.
+    pub fn approved_for_session() -> Self {
+        Self {
+            decision: ReviewDecision::ApprovedForSession,
+        }
+    }
+
+    /// Deny the patch (`{"decision":"denied"}`).
+    pub fn denied() -> Self {
+        Self {
+            decision: ReviewDecision::Denied,
+        }
+    }
+
+    /// Abort the turn in response to the request.
+    pub fn abort() -> Self {
+        Self {
+            decision: ReviewDecision::Abort,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thread_start_params_default_is_empty_object() {
+        let p = ThreadStartParams::default();
+        assert_eq!(serde_json::to_value(&p).unwrap(), serde_json::json!({}));
+    }
+
+    #[test]
+    fn turn_start_params_default_round_trips() {
+        let p = TurnStartParams::default();
+        let v = serde_json::to_value(&p).unwrap();
+        // thread_id + input are required-but-defaulted; everything else omits.
+        assert_eq!(v["threadId"], "");
+        assert_eq!(v["input"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn thread_resume_and_fork_params_default() {
+        let _ = ThreadResumeParams::default();
+        let _ = ThreadForkParams::default();
+    }
+
+    #[test]
+    fn file_change_approval_response_wire_shape() {
+        assert_eq!(
+            serde_json::to_value(FileChangeRequestApprovalResponse::accept()).unwrap(),
+            serde_json::json!({"decision": "accept"})
+        );
+        assert_eq!(
+            serde_json::to_value(FileChangeRequestApprovalResponse::decline()).unwrap(),
+            serde_json::json!({"decision": "decline"})
+        );
+    }
+
+    #[test]
+    fn command_execution_approval_response_wire_shape() {
+        assert_eq!(
+            serde_json::to_value(CommandExecutionRequestApprovalResponse::accept()).unwrap(),
+            serde_json::json!({"decision": "accept"})
+        );
+        assert_eq!(
+            serde_json::to_value(CommandExecutionRequestApprovalResponse::cancel()).unwrap(),
+            serde_json::json!({"decision": "cancel"})
+        );
+    }
+
+    #[test]
+    fn exec_and_apply_patch_approval_response_wire_shape() {
+        assert_eq!(
+            serde_json::to_value(ExecCommandApprovalResponse::approved()).unwrap(),
+            serde_json::json!({"decision": "approved"})
+        );
+        assert_eq!(
+            serde_json::to_value(ApplyPatchApprovalResponse::denied()).unwrap(),
+            serde_json::json!({"decision": "denied"})
+        );
+    }
+}


### PR DESCRIPTION
Implements the practical, non-schema-blocked half of the agent-portal audit batch for `codex-codes`. Everything here is additive on hand-written modules (`protocol.rs`, `messages.rs`) — no codegen regeneration (the in-repo codegen no longer reproduces the committed generated types against the snapshotted schemas, so regenerating would be destructive; see note below).

## Changes

- **#209** `ServerMessage::from_json_str` / `from_value` — public parse path for a raw app-server frame, reusing the client's dispatch. Notifications/requests decode to typed variants (unknown methods → `Unknown`); a JSON-RPC response/error frame returns `Error::Protocol`. Unblocks replay/recovery/fixture tests without a live client.
- **#205** `Notification::turn_id() -> Option<&str>` — reads the turn id from typed fields (`turn.id` for turn-lifecycle notifications, flat `turnId` for the 23 streaming/item ones) instead of `into_envelope()` + `Value` poking. This is the id `turn/interrupt` needs.
- **#206** `Default` for `ThreadStartParams`, `TurnStartParams`, `ThreadResumeParams`, `ThreadForkParams` — construct empty params with `::default()`.
- **#212** `accept()`/`decline()`/`cancel()`/`approved()`/`denied()`/`abort()` constructors on the four approval-response payloads, so callers don't hand-roll `serde_json` `decision` objects (and can't typo the wire string). Note the v2 command/file-change responses use `accept`/`decline`; the v1 exec/apply-patch responses use `approved`/`denied` — the helpers make the distinction explicit.
- **#213 (partial)** `Notification::thread_item() -> Option<&ThreadItem>` — typed access to the item in `item/started`/`item/completed`. The exec-JSONL-style event structs the issue asks for already exist as `ThreadEvent` in `io::events`; the remaining full `Notification → ThreadEvent` adapter is left as a follow-up because app-server `ItemStartedNotification.item` and the exec `ThreadEvent`'s item are two distinct `ThreadItem` types requiring conversion.

## Already satisfied by the current SDK (recommend closing)

- **#204** — `AsyncClient`/`SyncClient` already expose `thread_resume`, `thread_fork`, `thread_start`, `turn_start`, `turn_interrupt`, `thread_archive`, `thread_delete`. No `methods::*` needed downstream.
- **#207** — the raw-JSON fields the portal lists are already typed: `ApplyPatchApprovalParams.file_changes: BTreeMap<String, FileChange>`, `ExecCommandApprovalParams.parsed_cmd: Vec<ParsedCommand>`, `PermissionsRequestApprovalParams.permissions: RequestPermissionProfile`, `ToolRequestUserInputParams.questions: Vec<ToolRequestUserInputQuestion>`.
- **#140/#141/#142** — landed (typed `model_usage` map, `CompactBoundaryMessage.summary/leaf_message_count/duration_ms`, typed `Citation`).

## Upstream-blocked

- **#208** — `McpServerElicitationRequestParams` (`Form`/`OpenaiForm`/`Url`) carries no server name/id in the upstream v2 schema; only opaque `_meta`. Can't be typed at the SDK level without an upstream codex schema change.

## Codegen note

`scripts/codegen_protocol.py` against the snapshotted `tests/schemas/*.json` produces a much smaller file than the committed `protocol_generated/types.rs` (the committed types track a newer schema than the snapshot). I deliberately did **not** run codegen; all additions are in hand-written modules that survive regeneration.

Tests: 75 lib tests pass; `cargo clippy -p codex-codes --all-targets -- -D warnings` clean.

---
Closes #205, #206, #209, #212. Partially addresses #213 (adds `Notification::thread_item()`; the full `Notification -> ThreadEvent` adapter remains).
