### PR TITLE
codex-codes 0.143.4: audit ergonomics + schema re-snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.143.3"
+version = "0.143.4"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.143.2"
+version = "0.143.3"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.161`, tested against Claude CLI `2.1.205`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `0.143.2`, tested against Codex CLI `0.143.0`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.143.4`, tested against Codex CLI `0.143.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.
 

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.143.4] - 2026-07-16
+
+### Changed
+
+- **Re-snapshotted the Codex app-server schemas** against `openai/codex@main`;
+  both `codex_app_server_protocol{,.v2}.schemas.json` are byte-identical to
+  upstream again and the typed structs/samples were regenerated. Pulls in 6 new
+  definitions (`EnvironmentConnectionNotification`, `ScheduledTaskSummary` /
+  `ScheduledTaskSchedule` / `ScheduledTaskWeekday`,
+  `ExternalAgentImportedConnectorCandidate` / `ExternalAgentImportedConnectorSource`),
+  additive token/memory fields (e.g. `cacheWriteInputTokens` on
+  `TokenUsageBreakdown`, `memory` / `scheduledTasks` / `spendControlReached`),
+  and drops the upstream-removed `templateId` from `McpToolCallAppContext`.
+
+### Added
+
+- **`Notification::ThreadEnvironmentConnected` / `ThreadEnvironmentDisconnected`**
+  — typed variants for the new `thread/environment/connected` and
+  `thread/environment/disconnected` server notifications (both carry
+  `EnvironmentConnectionNotification`). Schema coverage back to 100%.
+
 ## [0.143.3] - 2026-07-16
 
 ### Added

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.143.3] - 2026-07-16
+
+### Added
+
+- **`ServerMessage::from_json_str` / `from_value`** — parse a raw app-server
+  frame into a typed [`ServerMessage`] without a live client, reusing the same
+  dispatch the client runs. Server-initiated notifications and requests decode
+  to their typed variants (unknown methods route to `Unknown`); a JSON-RPC
+  response/error frame returns `Error::Protocol`. Unblocks replay, recovery,
+  and fixture-based tests downstream. (#209)
+- **`Notification::turn_id() -> Option<&str>`** — read the turn id a
+  notification is scoped to straight from its typed fields (`turn.id` for the
+  turn-lifecycle notifications, the flat `turnId` for the streaming ones),
+  instead of round-tripping through `into_envelope()` and poking
+  `serde_json::Value`. This is the id `turn/interrupt` needs. (#205)
+- **`Notification::thread_item() -> Option<&ThreadItem>`** — typed access to the
+  item carried by `item/started` / `item/completed`, so event adapters don't
+  reserialize items back into JSON. (#213)
+- **`Default` for `ThreadStartParams`, `TurnStartParams`, `ThreadResumeParams`,
+  and `ThreadForkParams`** — construct empty request params with
+  `Params::default()` instead of spelling out every `None` field. (#206)
+- **`accept()` / `decline()` / `cancel()` / `approved()` / `denied()` /
+  `abort()` constructors** on the approval-response payloads
+  (`FileChangeRequestApprovalResponse`,
+  `CommandExecutionRequestApprovalResponse`, `ExecCommandApprovalResponse`,
+  `ApplyPatchApprovalResponse`), so callers respond to approval requests
+  without hand-rolling `serde_json` `decision` objects. (#212)
+
 ## [0.143.2] - 2026-07-11
 
 ### Added

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -7,26 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.143.4] - 2026-07-16
 
-### Changed
-
-- **Re-snapshotted the Codex app-server schemas** against `openai/codex@main`;
-  both `codex_app_server_protocol{,.v2}.schemas.json` are byte-identical to
-  upstream again and the typed structs/samples were regenerated. Pulls in 6 new
-  definitions (`EnvironmentConnectionNotification`, `ScheduledTaskSummary` /
-  `ScheduledTaskSchedule` / `ScheduledTaskWeekday`,
-  `ExternalAgentImportedConnectorCandidate` / `ExternalAgentImportedConnectorSource`),
-  additive token/memory fields (e.g. `cacheWriteInputTokens` on
-  `TokenUsageBreakdown`, `memory` / `scheduledTasks` / `spendControlReached`),
-  and drops the upstream-removed `templateId` from `McpToolCallAppContext`.
-
-### Added
-
-- **`Notification::ThreadEnvironmentConnected` / `ThreadEnvironmentDisconnected`**
-  — typed variants for the new `thread/environment/connected` and
-  `thread/environment/disconnected` server notifications (both carry
-  `EnvironmentConnectionNotification`). Schema coverage back to 100%.
-
-## [0.143.3] - 2026-07-16
+Combines the `agent-portal` audit ergonomics (originally staged as an
+unreleased 0.143.3) with a fresh upstream schema re-snapshot.
 
 ### Added
 
@@ -53,6 +35,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CommandExecutionRequestApprovalResponse`, `ExecCommandApprovalResponse`,
   `ApplyPatchApprovalResponse`), so callers respond to approval requests
   without hand-rolling `serde_json` `decision` objects. (#212)
+- **`Notification::ThreadEnvironmentConnected` / `ThreadEnvironmentDisconnected`**
+  — typed variants for the new `thread/environment/connected` and
+  `thread/environment/disconnected` server notifications (both carry
+  `EnvironmentConnectionNotification`). Schema coverage back to 100%.
+
+### Changed
+
+- **Re-snapshotted the Codex app-server schemas** against `openai/codex@main`;
+  both `codex_app_server_protocol{,.v2}.schemas.json` are byte-identical to
+  upstream again and the typed structs/samples were regenerated. Pulls in 6 new
+  definitions (`EnvironmentConnectionNotification`, `ScheduledTaskSummary` /
+  `ScheduledTaskSchedule` / `ScheduledTaskWeekday`,
+  `ExternalAgentImportedConnectorCandidate` / `ExternalAgentImportedConnectorSource`),
+  additive token/memory fields (e.g. `cacheWriteInputTokens` on
+  `TokenUsageBreakdown`, `memory` / `scheduledTasks` / `spendControlReached`),
+  and drops the upstream-removed `templateId` from `McpToolCallAppContext`.
 
 ## [0.143.2] - 2026-07-11
 

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.143.3"
+version = "0.143.4"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.143.2"
+version = "0.143.3"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/examples/schema_coverage.rs
+++ b/codex-codes/examples/schema_coverage.rs
@@ -465,6 +465,8 @@ mod samples {
             methods::THREAD_DELETED,
             methods::EXTERNAL_AGENT_CONFIG_IMPORT_PROGRESS,
             methods::MODEL_SAFETY_BUFFERING_UPDATED,
+            methods::THREAD_ENVIRONMENT_CONNECTED,
+            methods::THREAD_ENVIRONMENT_DISCONNECTED,
         ]
         .into_iter()
         .collect()

--- a/codex-codes/src/messages.rs
+++ b/codex-codes/src/messages.rs
@@ -30,7 +30,7 @@ use crate::protocol::{
     AccountUpdatedNotification, AgentMessageDeltaNotification, AppListUpdatedNotification,
     CommandExecOutputDeltaNotification, CommandExecutionOutputDeltaNotification,
     CommandExecutionRequestApprovalParams, ConfigWarningNotification, ContextCompactedNotification,
-    DeprecationNoticeNotification, ErrorNotification,
+    DeprecationNoticeNotification, EnvironmentConnectionNotification, ErrorNotification,
     ExternalAgentConfigImportCompletedNotification, ExternalAgentConfigImportProgressNotification,
     FileChangeOutputDeltaNotification, FileChangePatchUpdatedNotification,
     FileChangeRequestApprovalParams, FsChangedNotification,
@@ -203,6 +203,10 @@ pub enum Notification {
     ExternalAgentConfigImportProgress(ExternalAgentConfigImportProgressNotification),
     /// `model/safetyBuffering/updated`
     ModelSafetyBufferingUpdated(ModelSafetyBufferingUpdatedNotification),
+    /// `thread/environment/connected`
+    ThreadEnvironmentConnected(EnvironmentConnectionNotification),
+    /// `thread/environment/disconnected`
+    ThreadEnvironmentDisconnected(EnvironmentConnectionNotification),
     /// A method this crate version does not yet model. The raw params are
     /// preserved for caller inspection. Encountering this typically means
     /// the installed codex CLI is newer than the bindings.
@@ -294,6 +298,8 @@ impl Notification {
                 methods::EXTERNAL_AGENT_CONFIG_IMPORT_PROGRESS
             }
             Self::ModelSafetyBufferingUpdated(_) => methods::MODEL_SAFETY_BUFFERING_UPDATED,
+            Self::ThreadEnvironmentConnected(_) => methods::THREAD_ENVIRONMENT_CONNECTED,
+            Self::ThreadEnvironmentDisconnected(_) => methods::THREAD_ENVIRONMENT_DISCONNECTED,
             Self::Unknown { method, .. } => method,
         }
     }
@@ -555,6 +561,12 @@ impl Notification {
             methods::MODEL_SAFETY_BUFFERING_UPDATED => {
                 serde_json::from_value(params_value).map(Self::ModelSafetyBufferingUpdated)
             }
+            methods::THREAD_ENVIRONMENT_CONNECTED => {
+                serde_json::from_value(params_value).map(Self::ThreadEnvironmentConnected)
+            }
+            methods::THREAD_ENVIRONMENT_DISCONNECTED => {
+                serde_json::from_value(params_value).map(Self::ThreadEnvironmentDisconnected)
+            }
             _ => Ok(Self::Unknown {
                 method: method.to_string(),
                 params,
@@ -668,6 +680,10 @@ impl Notification {
             }
             Self::ModelSafetyBufferingUpdated(v) => {
                 pack(methods::MODEL_SAFETY_BUFFERING_UPDATED, v)
+            }
+            Self::ThreadEnvironmentConnected(v) => pack(methods::THREAD_ENVIRONMENT_CONNECTED, v),
+            Self::ThreadEnvironmentDisconnected(v) => {
+                pack(methods::THREAD_ENVIRONMENT_DISCONNECTED, v)
             }
             Self::Unknown { method, params } => Ok((method.clone(), params.clone())),
         }

--- a/codex-codes/src/messages.rs
+++ b/codex-codes/src/messages.rs
@@ -23,7 +23,8 @@
 //!   If you see one, the typed binding in [`crate::protocol`] is out of
 //!   sync with the wire format and needs to be updated.
 
-use crate::jsonrpc::RequestId;
+use crate::error::{Error, ParseError};
+use crate::jsonrpc::{JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, RequestId};
 use crate::protocol::{
     methods, AccountLoginCompletedNotification, AccountRateLimitsUpdatedNotification,
     AccountUpdatedNotification, AgentMessageDeltaNotification, AppListUpdatedNotification,
@@ -300,6 +301,62 @@ impl Notification {
     /// `true` if this notification's method isn't modeled by the crate.
     pub fn is_unknown(&self) -> bool {
         matches!(self, Self::Unknown { .. })
+    }
+
+    /// Return the turn id this notification is scoped to, if it carries one.
+    ///
+    /// Reads the typed `turnId` field (or `turn.id` for the turn-lifecycle
+    /// notifications) directly, so callers don't have to round-trip through
+    /// [`into_envelope`](Self::into_envelope) and poke `serde_json::Value`
+    /// fields. Returns `None` for notifications that aren't turn-scoped, and
+    /// treats an empty id the server omitted as absent.
+    ///
+    /// The turn id from `turn/started` is what
+    /// [`turn/interrupt`](crate::AsyncClient::turn_interrupt) needs to cancel
+    /// the active turn.
+    pub fn turn_id(&self) -> Option<&str> {
+        let id = match self {
+            Self::TurnStarted(n) => n.turn.id.as_str(),
+            Self::TurnCompleted(n) => n.turn.id.as_str(),
+            Self::AgentMessageDelta(n) => n.turn_id.as_str(),
+            Self::CmdOutputDelta(n) => n.turn_id.as_str(),
+            Self::FileChangeOutputDelta(n) => n.turn_id.as_str(),
+            Self::ReasoningDelta(n) => n.turn_id.as_str(),
+            Self::Error(n) => n.turn_id.as_str(),
+            Self::FileChangePatchUpdated(n) => n.turn_id.as_str(),
+            Self::PlanDelta(n) => n.turn_id.as_str(),
+            Self::TurnPlanUpdated(n) => n.turn_id.as_str(),
+            Self::TurnDiffUpdated(n) => n.turn_id.as_str(),
+            Self::TurnModerationMetadata(n) => n.turn_id.as_str(),
+            Self::ReasoningSummaryPartAdded(n) => n.turn_id.as_str(),
+            Self::ReasoningTextDelta(n) => n.turn_id.as_str(),
+            Self::ItemStarted(n) => n.turn_id.as_str(),
+            Self::ItemCompleted(n) => n.turn_id.as_str(),
+            Self::ContextCompacted(n) => n.turn_id.as_str(),
+            Self::McpToolCallProgress(n) => n.turn_id.as_str(),
+            Self::ModelRerouted(n) => n.turn_id.as_str(),
+            Self::ModelVerification(n) => n.turn_id.as_str(),
+            Self::ModelSafetyBufferingUpdated(n) => n.turn_id.as_str(),
+            Self::TerminalInteraction(n) => n.turn_id.as_str(),
+            Self::ThreadTokenUsageUpdated(n) => n.turn_id.as_str(),
+            Self::ItemGuardianApprovalReviewStarted(n) => n.turn_id.as_str(),
+            Self::ItemGuardianApprovalReviewCompleted(n) => n.turn_id.as_str(),
+            _ => return None,
+        };
+        (!id.is_empty()).then_some(id)
+    }
+
+    /// Return the typed [`ThreadItem`](crate::protocol::ThreadItem) this
+    /// notification carries, for `item/started` and `item/completed`.
+    ///
+    /// Lets downstream event adapters read the item's typed fields instead of
+    /// reserializing it back into `serde_json::Value`.
+    pub fn thread_item(&self) -> Option<&crate::protocol::ThreadItem> {
+        match self {
+            Self::ItemStarted(n) => Some(&n.item),
+            Self::ItemCompleted(n) => Some(&n.item),
+            _ => None,
+        }
     }
 
     /// Construct a [`Notification`] from a `method` + `params` envelope.
@@ -768,6 +825,58 @@ impl ServerMessage {
             Self::Request { request, .. } => request.is_unknown(),
         }
     }
+
+    /// Parse a raw app-server frame (one JSON-RPC line) into a [`ServerMessage`].
+    ///
+    /// This is the same parse path the [`AsyncClient`](crate::AsyncClient) and
+    /// [`SyncClient`](crate::SyncClient) run on incoming lines, exposed for
+    /// replay, recovery, and test fixtures that need to decode a captured frame
+    /// without a live client.
+    ///
+    /// A frame is a [`ServerMessage`] only if it is a server-initiated
+    /// notification or request. A JSON-RPC *response* / *error* (a reply to a
+    /// client request) is not a server message and returns
+    /// [`Error::Protocol`](crate::Error::Protocol). Unknown methods decode to
+    /// the `Unknown` variants rather than erroring; a modeled method whose
+    /// `params` don't fit returns [`Error::Deserialization`](crate::Error::Deserialization)
+    /// carrying the raw frame.
+    pub fn from_json_str(s: &str) -> Result<Self, Error> {
+        let msg: JsonRpcMessage = serde_json::from_str(s)
+            .map_err(|e| Error::Deserialization(ParseError::from_line(s, e)))?;
+        Self::from_jsonrpc(msg)
+    }
+
+    /// Parse a [`serde_json::Value`] frame into a [`ServerMessage`].
+    ///
+    /// See [`from_json_str`](Self::from_json_str) for the parsing contract.
+    pub fn from_value(value: Value) -> Result<Self, Error> {
+        let msg: JsonRpcMessage = serde_json::from_value(value.clone())
+            .map_err(|e| Error::Deserialization(ParseError::from_line(value.to_string(), e)))?;
+        Self::from_jsonrpc(msg)
+    }
+
+    fn from_jsonrpc(msg: JsonRpcMessage) -> Result<Self, Error> {
+        match msg {
+            JsonRpcMessage::Notification(JsonRpcNotification { method, params }) => {
+                Notification::from_envelope(&method, params.clone())
+                    .map(ServerMessage::Notification)
+                    .map_err(|e| Error::Deserialization(ParseError::from_envelope(method, params, e)))
+            }
+            JsonRpcMessage::Request(JsonRpcRequest { id, method, params }) => {
+                ServerRequest::from_envelope(&method, params.clone())
+                    .map(|request| ServerMessage::Request { id, request })
+                    .map_err(|e| Error::Deserialization(ParseError::from_envelope(method, params, e)))
+            }
+            JsonRpcMessage::Response(resp) => Err(Error::Protocol(format!(
+                "frame is a JSON-RPC response (id={}), not a server-initiated message",
+                resp.id
+            ))),
+            JsonRpcMessage::Error(err) => Err(Error::Protocol(format!(
+                "frame is a JSON-RPC error response (id={}, code={}), not a server-initiated message",
+                err.id, err.error.code
+            ))),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -804,5 +913,108 @@ mod tests {
         assert!(matches!(n, Notification::AgentMessageDelta(_)));
         let back = serde_json::to_value(&n).unwrap();
         assert_eq!(back, wire);
+    }
+
+    #[test]
+    fn test_turn_id_from_turn_started() {
+        // turn/started carries the id under `turn.id`.
+        let wire = serde_json::json!({
+            "method": "turn/started",
+            "params": {"threadId": "t1", "turn": {"id": "turn_42", "status": "inProgress"}},
+        });
+        let n: Notification = serde_json::from_value(wire).unwrap();
+        assert!(matches!(n, Notification::TurnStarted(_)));
+        assert_eq!(n.turn_id(), Some("turn_42"));
+    }
+
+    #[test]
+    fn test_turn_id_from_delta_field() {
+        // Streaming notifications carry a flat `turnId`.
+        let wire = serde_json::json!({
+            "method": "item/agentMessage/delta",
+            "params": {"threadId": "t1", "turnId": "turn_7", "itemId": "i1", "delta": "hi"},
+        });
+        let n: Notification = serde_json::from_value(wire).unwrap();
+        assert_eq!(n.turn_id(), Some("turn_7"));
+    }
+
+    #[test]
+    fn test_turn_id_none_for_non_turn_notification() {
+        let n = Notification::from_envelope(
+            "thread/deleted",
+            Some(serde_json::json!({"threadId": "t1"})),
+        )
+        .unwrap();
+        assert_eq!(n.turn_id(), None);
+    }
+
+    #[test]
+    fn test_thread_item_accessor() {
+        let wire = serde_json::json!({
+            "method": "item/started",
+            "params": {
+                "threadId": "t1",
+                "turnId": "turn_1",
+                "startedAtMs": 0,
+                "item": {"type": "agentMessage", "id": "i1", "text": "hi"},
+            },
+        });
+        let n: Notification = serde_json::from_value(wire).unwrap();
+        assert!(n.thread_item().is_some());
+        // A non-item notification has no thread item.
+        let other = Notification::from_envelope(
+            "thread/deleted",
+            Some(serde_json::json!({"threadId": "t1"})),
+        )
+        .unwrap();
+        assert!(other.thread_item().is_none());
+    }
+
+    #[test]
+    fn test_server_message_from_json_str_notification() {
+        let line = r#"{"method":"turn/started","params":{"threadId":"t1","turn":{"id":"turn_9","status":"inProgress"}}}"#;
+        let msg = ServerMessage::from_json_str(line).expect("parses a notification frame");
+        match msg {
+            ServerMessage::Notification(n) => assert_eq!(n.turn_id(), Some("turn_9")),
+            other => panic!("expected Notification, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_server_message_from_value_request() {
+        let frame = serde_json::json!({
+            "id": 7,
+            "method": "execCommandApproval",
+            "params": {
+                "callId": "c1",
+                "command": ["ls"],
+                "conversationId": "th_1",
+                "cwd": "/tmp",
+                "parsedCmd": [],
+            },
+        });
+        let msg = ServerMessage::from_value(frame).expect("parses a request frame");
+        match msg {
+            ServerMessage::Request { id, request } => {
+                assert_eq!(id, RequestId::Integer(7));
+                assert!(matches!(request, ServerRequest::ExecCommandApproval(_)));
+            }
+            other => panic!("expected Request, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_server_message_from_json_str_rejects_response() {
+        // A response to a client request is not a server-initiated message.
+        let line = r#"{"id":1,"result":{"threadId":"th_abc"}}"#;
+        let err = ServerMessage::from_json_str(line).unwrap_err();
+        assert!(matches!(err, Error::Protocol(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn test_server_message_from_json_str_unknown_method_ok() {
+        let line = r#"{"method":"some/future/notification","params":{"x":1}}"#;
+        let msg = ServerMessage::from_json_str(line).unwrap();
+        assert!(msg.is_unknown());
     }
 }

--- a/codex-codes/src/protocol.rs
+++ b/codex-codes/src/protocol.rs
@@ -187,6 +187,8 @@ pub mod methods {
     pub const TURN_MODERATION_METADATA: &str = "turn/moderationMetadata";
     pub const EXTERNAL_AGENT_CONFIG_IMPORT_PROGRESS: &str = "externalAgentConfig/import/progress";
     pub const MODEL_SAFETY_BUFFERING_UPDATED: &str = "model/safetyBuffering/updated";
+    pub const THREAD_ENVIRONMENT_CONNECTED: &str = "thread/environment/connected";
+    pub const THREAD_ENVIRONMENT_DISCONNECTED: &str = "thread/environment/disconnected";
 
     // Server → client requests (approval flow, v2 envelope)
     pub const CMD_EXEC_APPROVAL: &str = "item/commandExecution/requestApproval";

--- a/codex-codes/src/protocol.rs
+++ b/codex-codes/src/protocol.rs
@@ -200,3 +200,227 @@ pub mod methods {
     pub const APPLY_PATCH_APPROVAL: &str = "applyPatchApproval";
     pub const EXEC_COMMAND_APPROVAL: &str = "execCommandApproval";
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// Ergonomic constructors over the generated wire types.
+//
+// The types themselves are code-generated from the upstream schema; these
+// hand-written impls live here so they survive regeneration. They cover two
+// pain points for downstream consumers:
+//
+//   * `Default` for the all-optional client request params, so callers don't
+//     have to spell out every `None` field or construct via `from_value`.
+//   * `accept` / `decline` / `approved` / `denied` constructors for the
+//     approval-response payloads, so callers don't hand-roll `serde_json`
+//     objects and can't typo the wire `decision` string.
+// ──────────────────────────────────────────────────────────────────────────
+
+macro_rules! default_from_empty_object {
+    ($($ty:ident),+ $(,)?) => {
+        $(
+            impl Default for $ty {
+                fn default() -> Self {
+                    // Every field is `#[serde(default)]`, so an empty object
+                    // yields the fully-unset params. Deserializing (rather than
+                    // listing fields) keeps this correct as the upstream schema
+                    // adds optional fields, and mirrors the construction idiom
+                    // shown in the crate docs.
+                    serde_json::from_value(serde_json::Value::Object(Default::default()))
+                        .expect(concat!(
+                            stringify!($ty),
+                            ": every field is serde-default, so `{}` must deserialize"
+                        ))
+                }
+            }
+        )+
+    };
+}
+
+default_from_empty_object!(
+    ThreadStartParams,
+    TurnStartParams,
+    ThreadResumeParams,
+    ThreadForkParams,
+);
+
+impl FileChangeRequestApprovalResponse {
+    /// Approve this file-change request (`{"decision":"accept"}`).
+    pub fn accept() -> Self {
+        Self {
+            decision: FileChangeApprovalDecision::Accept,
+        }
+    }
+
+    /// Approve this and future file changes for the session.
+    pub fn accept_for_session() -> Self {
+        Self {
+            decision: FileChangeApprovalDecision::AcceptForSession,
+        }
+    }
+
+    /// Decline this file-change request (`{"decision":"decline"}`).
+    pub fn decline() -> Self {
+        Self {
+            decision: FileChangeApprovalDecision::Decline,
+        }
+    }
+
+    /// Cancel the turn in response to this request.
+    pub fn cancel() -> Self {
+        Self {
+            decision: FileChangeApprovalDecision::Cancel,
+        }
+    }
+}
+
+impl CommandExecutionRequestApprovalResponse {
+    /// Approve this command execution (`{"decision":"accept"}`).
+    pub fn accept() -> Self {
+        Self {
+            decision: CommandExecutionApprovalDecision::Accept,
+        }
+    }
+
+    /// Approve this and future command executions for the session.
+    pub fn accept_for_session() -> Self {
+        Self {
+            decision: CommandExecutionApprovalDecision::AcceptForSession,
+        }
+    }
+
+    /// Decline this command execution (`{"decision":"decline"}`).
+    pub fn decline() -> Self {
+        Self {
+            decision: CommandExecutionApprovalDecision::Decline,
+        }
+    }
+
+    /// Cancel the turn in response to this request.
+    pub fn cancel() -> Self {
+        Self {
+            decision: CommandExecutionApprovalDecision::Cancel,
+        }
+    }
+}
+
+impl ExecCommandApprovalResponse {
+    /// Approve the exec command (`{"decision":"approved"}`).
+    pub fn approved() -> Self {
+        Self {
+            decision: ReviewDecision::Approved,
+        }
+    }
+
+    /// Approve the exec command for the rest of the session.
+    pub fn approved_for_session() -> Self {
+        Self {
+            decision: ReviewDecision::ApprovedForSession,
+        }
+    }
+
+    /// Deny the exec command (`{"decision":"denied"}`).
+    pub fn denied() -> Self {
+        Self {
+            decision: ReviewDecision::Denied,
+        }
+    }
+
+    /// Abort the turn in response to the request.
+    pub fn abort() -> Self {
+        Self {
+            decision: ReviewDecision::Abort,
+        }
+    }
+}
+
+impl ApplyPatchApprovalResponse {
+    /// Approve the patch (`{"decision":"approved"}`).
+    pub fn approved() -> Self {
+        Self {
+            decision: ReviewDecision::Approved,
+        }
+    }
+
+    /// Approve this and future patches for the session.
+    pub fn approved_for_session() -> Self {
+        Self {
+            decision: ReviewDecision::ApprovedForSession,
+        }
+    }
+
+    /// Deny the patch (`{"decision":"denied"}`).
+    pub fn denied() -> Self {
+        Self {
+            decision: ReviewDecision::Denied,
+        }
+    }
+
+    /// Abort the turn in response to the request.
+    pub fn abort() -> Self {
+        Self {
+            decision: ReviewDecision::Abort,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thread_start_params_default_is_empty_object() {
+        let p = ThreadStartParams::default();
+        assert_eq!(serde_json::to_value(&p).unwrap(), serde_json::json!({}));
+    }
+
+    #[test]
+    fn turn_start_params_default_round_trips() {
+        let p = TurnStartParams::default();
+        let v = serde_json::to_value(&p).unwrap();
+        // thread_id + input are required-but-defaulted; everything else omits.
+        assert_eq!(v["threadId"], "");
+        assert_eq!(v["input"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn thread_resume_and_fork_params_default() {
+        let _ = ThreadResumeParams::default();
+        let _ = ThreadForkParams::default();
+    }
+
+    #[test]
+    fn file_change_approval_response_wire_shape() {
+        assert_eq!(
+            serde_json::to_value(FileChangeRequestApprovalResponse::accept()).unwrap(),
+            serde_json::json!({"decision": "accept"})
+        );
+        assert_eq!(
+            serde_json::to_value(FileChangeRequestApprovalResponse::decline()).unwrap(),
+            serde_json::json!({"decision": "decline"})
+        );
+    }
+
+    #[test]
+    fn command_execution_approval_response_wire_shape() {
+        assert_eq!(
+            serde_json::to_value(CommandExecutionRequestApprovalResponse::accept()).unwrap(),
+            serde_json::json!({"decision": "accept"})
+        );
+        assert_eq!(
+            serde_json::to_value(CommandExecutionRequestApprovalResponse::cancel()).unwrap(),
+            serde_json::json!({"decision": "cancel"})
+        );
+    }
+
+    #[test]
+    fn exec_and_apply_patch_approval_response_wire_shape() {
+        assert_eq!(
+            serde_json::to_value(ExecCommandApprovalResponse::approved()).unwrap(),
+            serde_json::json!({"decision": "approved"})
+        );
+        assert_eq!(
+            serde_json::to_value(ApplyPatchApprovalResponse::denied()).unwrap(),
+            serde_json::json!({"decision": "denied"})
+        );
+    }
+}

--- a/codex-codes/src/protocol_generated/samples.rs
+++ b/codex-codes/src/protocol_generated/samples.rs
@@ -142,6 +142,14 @@ pub fn server_notification_samples() -> Vec<(&'static str, Value)> {
         ("thread/closed", json!({"threadId": "x"})),
         ("thread/compacted", json!({"threadId": "x", "turnId": "x"})),
         ("thread/deleted", json!({"threadId": "x"})),
+        (
+            "thread/environment/connected",
+            json!({"environmentId": "x", "threadId": "x"}),
+        ),
+        (
+            "thread/environment/disconnected",
+            json!({"environmentId": "x", "threadId": "x"}),
+        ),
         ("thread/goal/cleared", json!({"threadId": "x"})),
         (
             "thread/goal/updated",

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -1478,6 +1478,15 @@ pub enum DynamicToolCallStatus {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct EnvironmentConnectionNotification {
+    #[serde(rename = "environmentId", default)]
+    pub environment_id: String,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ErrorNotification {
     #[serde()]
     pub error: TurnError,
@@ -1605,6 +1614,14 @@ pub struct ExternalAgentConfigDetectParams {
         skip_serializing_if = "Option::is_none"
     )]
     pub include_home: Option<bool>,
+    #[serde(
+        rename = "migrationSource",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub migration_source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1626,6 +1643,8 @@ pub struct ExternalAgentConfigImportCompletedNotification {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExternalAgentConfigImportHistoriesReadResponse {
+    #[serde(default)]
+    pub connectors: Vec<ExternalAgentImportedConnectorCandidate>,
     #[serde(default)]
     pub data: Vec<ExternalAgentConfigImportHistory>,
 }
@@ -1658,6 +1677,12 @@ pub struct ExternalAgentConfigImportItemTypeFailure {
     pub message: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
+    #[serde(
+        rename = "subErrorType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sub_error_type: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1678,6 +1703,12 @@ pub struct ExternalAgentConfigImportItemTypeSuccess {
 pub struct ExternalAgentConfigImportParams {
     #[serde(rename = "migrationItems", default)]
     pub migration_items: Vec<ExternalAgentConfigMigrationItem>,
+    #[serde(
+        rename = "migrationSource",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub migration_source: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
 }
@@ -1740,8 +1771,27 @@ pub enum ExternalAgentConfigMigrationItemType {
     HOOKS,
     #[serde(rename = "COMMANDS")]
     COMMANDS,
+    #[serde(rename = "MEMORY")]
+    MEMORY,
     #[serde(rename = "SESSIONS")]
     SESSIONS,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalAgentImportedConnectorCandidate {
+    #[serde(default)]
+    pub name: String,
+    #[serde(rename = "sessionCount", default)]
+    pub session_count: i64,
+    #[serde()]
+    pub source: ExternalAgentImportedConnectorSource,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ExternalAgentImportedConnectorSource {
+    #[serde(rename = "remoteMcpServersConfig")]
+    RemoteMcpServersConfig,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1888,14 +1938,14 @@ pub enum FileSystemSpecialPath {
     Minimal,
     ProjectRoots {
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        subpath: Option<String>,
+        subpath: Option<LegacyAppPathString>,
     },
     Tmpdir,
     SlashTmp,
     Unknown {
         path: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        subpath: Option<String>,
+        subpath: Option<LegacyAppPathString>,
     },
 }
 
@@ -3540,12 +3590,6 @@ pub struct McpToolCallAppContext {
         skip_serializing_if = "Option::is_none"
     )]
     pub resource_uri: Option<String>,
-    #[serde(
-        rename = "templateId",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub template_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -3644,6 +3688,8 @@ pub struct MigrationDetails {
         skip_serializing_if = "Option::is_none"
     )]
     pub mcp_servers: Option<Vec<McpServerMigration>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plugins: Option<Vec<PluginsMigration>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -4182,6 +4228,12 @@ pub struct PluginDetail {
     pub marketplace_path: Option<AbsolutePathBuf>,
     #[serde(rename = "mcpServers", default)]
     pub mcp_servers: Vec<String>,
+    #[serde(
+        rename = "scheduledTasks",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub scheduled_tasks: Option<Vec<ScheduledTaskSummary>>,
     #[serde(rename = "shareUrl", default, skip_serializing_if = "Option::is_none")]
     pub share_url: Option<String>,
     #[serde(default)]
@@ -4917,6 +4969,12 @@ pub struct RateLimitSnapshot {
     pub rate_limit_reached_type: Option<RateLimitReachedType>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub secondary: Option<RateLimitWindow>,
+    #[serde(
+        rename = "spendControlReached",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub spend_control_reached: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -4940,6 +4998,8 @@ pub enum RealtimeConversationVersion {
     V1,
     #[serde(rename = "v2")]
     V2,
+    #[serde(rename = "v3")]
+    V3,
 }
 
 /// A non-empty reasoning effort value advertised by the model.
@@ -5255,6 +5315,58 @@ pub struct SandboxWorkspaceWrite {
     pub network_access: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub writable_roots: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ScheduledTaskSchedule {
+    Hourly {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        days: Option<Vec<ScheduledTaskWeekday>>,
+        #[serde(rename = "intervalHours")]
+        interval_hours: i64,
+    },
+    Daily {
+        time: String,
+    },
+    Weekdays {
+        time: String,
+    },
+    Weekly {
+        days: Vec<ScheduledTaskWeekday>,
+        time: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScheduledTaskSummary {
+    #[serde(default)]
+    pub key: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub prompt: String,
+    #[serde()]
+    pub schedule: ScheduledTaskSchedule,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ScheduledTaskWeekday {
+    #[serde(rename = "MO")]
+    MO,
+    #[serde(rename = "TU")]
+    TU,
+    #[serde(rename = "WE")]
+    WE,
+    #[serde(rename = "TH")]
+    TH,
+    #[serde(rename = "FR")]
+    FR,
+    #[serde(rename = "SA")]
+    SA,
+    #[serde(rename = "SU")]
+    SU,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -6171,6 +6283,8 @@ pub enum ThreadItem {
         action: Option<WebSearchAction>,
         id: String,
         query: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        results: Option<Vec<Value>>,
     },
     #[serde(rename = "imageView")]
     ImageView {
@@ -6908,6 +7022,12 @@ pub enum ThreadUnsubscribeStatus {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TokenUsageBreakdown {
+    #[serde(
+        rename = "cacheWriteInputTokens",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cache_write_input_tokens: Option<i64>,
     #[serde(rename = "cachedInputTokens", default)]
     pub cached_input_tokens: i64,
     #[serde(rename = "inputTokens", default)]

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -4332,6 +4332,46 @@
           "properties": {
             "method": {
               "enum": [
+                "thread/environment/connected"
+              ],
+              "title": "Thread/environment/connectedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/EnvironmentConnectionNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/environment/connectedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "thread/environment/disconnected"
+              ],
+              "title": "Thread/environment/disconnectedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/EnvironmentConnectionNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/environment/disconnectedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
                 "thread/settings/updated"
               ],
               "title": "Thread/settings/updatedNotificationMethod",
@@ -5476,6 +5516,13 @@
           "type": "object"
         }
       ],
+      "properties": {
+        "emittedAtMs": {
+          "description": "Unix timestamp (in milliseconds) when app-server emitted this notification.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
       "title": "ServerNotification"
     },
     "ServerRequest": {
@@ -9018,6 +9065,23 @@
           }
         ]
       },
+      "EnvironmentConnectionNotification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "environmentId": {
+            "type": "string"
+          },
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "environmentId",
+          "threadId"
+        ],
+        "title": "EnvironmentConnectionNotification",
+        "type": "object"
+      },
       "ErrorNotification": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
@@ -9237,6 +9301,20 @@
           "includeHome": {
             "description": "If true, include detection under the user's home directory.",
             "type": "boolean"
+          },
+          "migrationSource": {
+            "description": "Optional migration-source selector. Missing or unrecognized values use the default source.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "source": {
+            "description": "Deprecated field retained for compatibility. This field is ignored; use `migrationSource` to select the migration source.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "title": "ExternalAgentConfigDetectParams",
@@ -9281,6 +9359,12 @@
       "ExternalAgentConfigImportHistoriesReadResponse": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
+          "connectors": {
+            "items": {
+              "$ref": "#/definitions/v2/ExternalAgentImportedConnectorCandidate"
+            },
+            "type": "array"
+          },
           "data": {
             "items": {
               "$ref": "#/definitions/v2/ExternalAgentConfigImportHistory"
@@ -9289,6 +9373,7 @@
           }
         },
         "required": [
+          "connectors",
           "data"
         ],
         "title": "ExternalAgentConfigImportHistoriesReadResponse",
@@ -9352,6 +9437,12 @@
               "string",
               "null"
             ]
+          },
+          "subErrorType": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
@@ -9399,8 +9490,15 @@
             },
             "type": "array"
           },
+          "migrationSource": {
+            "description": "Migration-source selector used to produce the migration items. Pass the same value to detection and import; missing or unrecognized values use the default source.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "source": {
-            "description": "Source product that produced the migration items. Missing means unspecified.",
+            "description": "Optional identifier for the product that initiated the import.",
             "type": [
               "string",
               "null"
@@ -9513,7 +9611,35 @@
           "SUBAGENTS",
           "HOOKS",
           "COMMANDS",
+          "MEMORY",
           "SESSIONS"
+        ],
+        "type": "string"
+      },
+      "ExternalAgentImportedConnectorCandidate": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "sessionCount": {
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "source": {
+            "$ref": "#/definitions/v2/ExternalAgentImportedConnectorSource"
+          }
+        },
+        "required": [
+          "name",
+          "sessionCount",
+          "source"
+        ],
+        "type": "object"
+      },
+      "ExternalAgentImportedConnectorSource": {
+        "enum": [
+          "remoteMcpServersConfig"
         ],
         "type": "string"
       },
@@ -9758,9 +9884,13 @@
                 "type": "string"
               },
               "subpath": {
-                "type": [
-                  "string",
-                  "null"
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/v2/LegacyAppPathString"
+                  },
+                  {
+                    "type": "null"
+                  }
                 ]
               }
             },
@@ -9812,9 +9942,13 @@
                 "type": "string"
               },
               "subpath": {
-                "type": [
-                  "string",
-                  "null"
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/v2/LegacyAppPathString"
+                  },
+                  {
+                    "type": "null"
+                  }
                 ]
               }
             },
@@ -12361,12 +12495,6 @@
               "string",
               "null"
             ]
-          },
-          "templateId": {
-            "type": [
-              "string",
-              "null"
-            ]
           }
         },
         "required": [
@@ -12526,6 +12654,12 @@
             "default": [],
             "items": {
               "$ref": "#/definitions/v2/McpServerMigration"
+            },
+            "type": "array"
+          },
+          "memory": {
+            "items": {
+              "type": "string"
             },
             "type": "array"
           },
@@ -13413,6 +13547,15 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "scheduledTasks": {
+            "items": {
+              "$ref": "#/definitions/v2/ScheduledTaskSummary"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           },
           "shareUrl": {
             "type": [
@@ -14786,6 +14929,13 @@
                 "type": "null"
               }
             ]
+          },
+          "spendControlReached": {
+            "description": "Backend-reported spend-control state. `None` is unavailable, not a sparse-update recovery.",
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
         "type": "object"
@@ -14816,6 +14966,38 @@
         ],
         "type": "object"
       },
+      "RawResponseCompletedNotification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "Internal-only notification containing the exact usage from one upstream Responses API completion.",
+        "properties": {
+          "responseId": {
+            "type": "string"
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "turnId": {
+            "type": "string"
+          },
+          "usage": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/TokenUsageBreakdown"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "responseId",
+          "threadId",
+          "turnId"
+        ],
+        "title": "RawResponseCompletedNotification",
+        "type": "object"
+      },
       "RawResponseItemCompletedNotification": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
@@ -14840,7 +15022,8 @@
       "RealtimeConversationVersion": {
         "enum": [
           "v1",
-          "v2"
+          "v2",
+          "v3"
         ],
         "type": "string"
       },
@@ -16406,6 +16589,143 @@
           }
         },
         "type": "object"
+      },
+      "ScheduledTaskSchedule": {
+        "oneOf": [
+          {
+            "properties": {
+              "days": {
+                "items": {
+                  "$ref": "#/definitions/v2/ScheduledTaskWeekday"
+                },
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "intervalHours": {
+                "format": "uint32",
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              "type": {
+                "enum": [
+                  "hourly"
+                ],
+                "title": "HourlyScheduledTaskScheduleType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "intervalHours",
+              "type"
+            ],
+            "title": "HourlyScheduledTaskSchedule",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "time": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "daily"
+                ],
+                "title": "DailyScheduledTaskScheduleType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "time",
+              "type"
+            ],
+            "title": "DailyScheduledTaskSchedule",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "time": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "weekdays"
+                ],
+                "title": "WeekdaysScheduledTaskScheduleType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "time",
+              "type"
+            ],
+            "title": "WeekdaysScheduledTaskSchedule",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "days": {
+                "items": {
+                  "$ref": "#/definitions/v2/ScheduledTaskWeekday"
+                },
+                "type": "array"
+              },
+              "time": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "weekly"
+                ],
+                "title": "WeeklyScheduledTaskScheduleType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "days",
+              "time",
+              "type"
+            ],
+            "title": "WeeklyScheduledTaskSchedule",
+            "type": "object"
+          }
+        ]
+      },
+      "ScheduledTaskSummary": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "schedule": {
+            "$ref": "#/definitions/v2/ScheduledTaskSchedule"
+          }
+        },
+        "required": [
+          "key",
+          "name",
+          "prompt",
+          "schedule"
+        ],
+        "type": "object"
+      },
+      "ScheduledTaskWeekday": {
+        "enum": [
+          "MO",
+          "TU",
+          "WE",
+          "TH",
+          "FR",
+          "SA",
+          "SU"
+        ],
+        "type": "string"
       },
       "SelectedCapabilityRoot": {
         "description": "A user-selected root that can expose one or more runtime capabilities.",
@@ -18398,6 +18718,15 @@
               "query": {
                 "type": "string"
               },
+              "results": {
+                "default": null,
+                "description": "Structured search results returned out-of-band by standalone web search.\n\nThese stay as opaque JSON at the extension/app-server boundary so new result fields and result types can pass through without a Codex release.",
+                "items": true,
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
               "type": {
                 "enum": [
                   "webSearch"
@@ -18439,6 +18768,7 @@
             "type": "object"
           },
           {
+            "description": "Display item emitted by the interruptible `clock.sleep` tool.",
             "properties": {
               "durationMs": {
                 "format": "uint64",
@@ -18577,6 +18907,22 @@
             "type": "object"
           }
         ]
+      },
+      "ThreadItemEntry": {
+        "properties": {
+          "item": {
+            "$ref": "#/definitions/v2/ThreadItem"
+          },
+          "turnId": {
+            "description": "Turn containing this item.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "item",
+          "turnId"
+        ],
+        "type": "object"
       },
       "ThreadListCwdFilter": {
         "anyOf": [
@@ -19975,6 +20321,11 @@
       },
       "TokenUsageBreakdown": {
         "properties": {
+          "cacheWriteInputTokens": {
+            "default": 0,
+            "format": "int64",
+            "type": "integer"
+          },
           "cachedInputTokens": {
             "format": "int64",
             "type": "integer"
@@ -20170,6 +20521,16 @@
           },
           "environmentId": {
             "type": "string"
+          },
+          "runtimeWorkspaceRoots": {
+            "description": "Environment-native runtime workspace roots. Omitted defaults to `cwd`.",
+            "items": {
+              "$ref": "#/definitions/v2/LegacyAppPathString"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
           }
         },
         "required": [

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -5258,6 +5258,23 @@
         }
       ]
     },
+    "EnvironmentConnectionNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "environmentId": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "environmentId",
+        "threadId"
+      ],
+      "title": "EnvironmentConnectionNotification",
+      "type": "object"
+    },
     "ErrorNotification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
@@ -5477,6 +5494,20 @@
         "includeHome": {
           "description": "If true, include detection under the user's home directory.",
           "type": "boolean"
+        },
+        "migrationSource": {
+          "description": "Optional migration-source selector. Missing or unrecognized values use the default source.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source": {
+          "description": "Deprecated field retained for compatibility. This field is ignored; use `migrationSource` to select the migration source.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "title": "ExternalAgentConfigDetectParams",
@@ -5521,6 +5552,12 @@
     "ExternalAgentConfigImportHistoriesReadResponse": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
+        "connectors": {
+          "items": {
+            "$ref": "#/definitions/ExternalAgentImportedConnectorCandidate"
+          },
+          "type": "array"
+        },
         "data": {
           "items": {
             "$ref": "#/definitions/ExternalAgentConfigImportHistory"
@@ -5529,6 +5566,7 @@
         }
       },
       "required": [
+        "connectors",
         "data"
       ],
       "title": "ExternalAgentConfigImportHistoriesReadResponse",
@@ -5592,6 +5630,12 @@
             "string",
             "null"
           ]
+        },
+        "subErrorType": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -5639,8 +5683,15 @@
           },
           "type": "array"
         },
+        "migrationSource": {
+          "description": "Migration-source selector used to produce the migration items. Pass the same value to detection and import; missing or unrecognized values use the default source.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "source": {
-          "description": "Source product that produced the migration items. Missing means unspecified.",
+          "description": "Optional identifier for the product that initiated the import.",
           "type": [
             "string",
             "null"
@@ -5753,7 +5804,35 @@
         "SUBAGENTS",
         "HOOKS",
         "COMMANDS",
+        "MEMORY",
         "SESSIONS"
+      ],
+      "type": "string"
+    },
+    "ExternalAgentImportedConnectorCandidate": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "sessionCount": {
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "source": {
+          "$ref": "#/definitions/ExternalAgentImportedConnectorSource"
+        }
+      },
+      "required": [
+        "name",
+        "sessionCount",
+        "source"
+      ],
+      "type": "object"
+    },
+    "ExternalAgentImportedConnectorSource": {
+      "enum": [
+        "remoteMcpServersConfig"
       ],
       "type": "string"
     },
@@ -5998,9 +6077,13 @@
               "type": "string"
             },
             "subpath": {
-              "type": [
-                "string",
-                "null"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/LegacyAppPathString"
+                },
+                {
+                  "type": "null"
+                }
               ]
             }
           },
@@ -6052,9 +6135,13 @@
               "type": "string"
             },
             "subpath": {
-              "type": [
-                "string",
-                "null"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/LegacyAppPathString"
+                },
+                {
+                  "type": "null"
+                }
               ]
             }
           },
@@ -8765,12 +8852,6 @@
             "string",
             "null"
           ]
-        },
-        "templateId": {
-          "type": [
-            "string",
-            "null"
-          ]
         }
       },
       "required": [
@@ -8930,6 +9011,12 @@
           "default": [],
           "items": {
             "$ref": "#/definitions/McpServerMigration"
+          },
+          "type": "array"
+        },
+        "memory": {
+          "items": {
+            "type": "string"
           },
           "type": "array"
         },
@@ -9817,6 +9904,15 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "scheduledTasks": {
+          "items": {
+            "$ref": "#/definitions/ScheduledTaskSummary"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "shareUrl": {
           "type": [
@@ -11190,6 +11286,13 @@
               "type": "null"
             }
           ]
+        },
+        "spendControlReached": {
+          "description": "Backend-reported spend-control state. `None` is unavailable, not a sparse-update recovery.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "type": "object"
@@ -11220,6 +11323,38 @@
       ],
       "type": "object"
     },
+    "RawResponseCompletedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "Internal-only notification containing the exact usage from one upstream Responses API completion.",
+      "properties": {
+        "responseId": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "type": "string"
+        },
+        "usage": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TokenUsageBreakdown"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "responseId",
+        "threadId",
+        "turnId"
+      ],
+      "title": "RawResponseCompletedNotification",
+      "type": "object"
+    },
     "RawResponseItemCompletedNotification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
@@ -11244,7 +11379,8 @@
     "RealtimeConversationVersion": {
       "enum": [
         "v1",
-        "v2"
+        "v2",
+        "v3"
       ],
       "type": "string"
     },
@@ -12811,6 +12947,143 @@
       },
       "type": "object"
     },
+    "ScheduledTaskSchedule": {
+      "oneOf": [
+        {
+          "properties": {
+            "days": {
+              "items": {
+                "$ref": "#/definitions/ScheduledTaskWeekday"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "intervalHours": {
+              "format": "uint32",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "type": {
+              "enum": [
+                "hourly"
+              ],
+              "title": "HourlyScheduledTaskScheduleType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "intervalHours",
+            "type"
+          ],
+          "title": "HourlyScheduledTaskSchedule",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "time": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "daily"
+              ],
+              "title": "DailyScheduledTaskScheduleType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "time",
+            "type"
+          ],
+          "title": "DailyScheduledTaskSchedule",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "time": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "weekdays"
+              ],
+              "title": "WeekdaysScheduledTaskScheduleType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "time",
+            "type"
+          ],
+          "title": "WeekdaysScheduledTaskSchedule",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "days": {
+              "items": {
+                "$ref": "#/definitions/ScheduledTaskWeekday"
+              },
+              "type": "array"
+            },
+            "time": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "weekly"
+              ],
+              "title": "WeeklyScheduledTaskScheduleType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "days",
+            "time",
+            "type"
+          ],
+          "title": "WeeklyScheduledTaskSchedule",
+          "type": "object"
+        }
+      ]
+    },
+    "ScheduledTaskSummary": {
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "prompt": {
+          "type": "string"
+        },
+        "schedule": {
+          "$ref": "#/definitions/ScheduledTaskSchedule"
+        }
+      },
+      "required": [
+        "key",
+        "name",
+        "prompt",
+        "schedule"
+      ],
+      "type": "object"
+    },
+    "ScheduledTaskWeekday": {
+      "enum": [
+        "MO",
+        "TU",
+        "WE",
+        "TH",
+        "FR",
+        "SA",
+        "SU"
+      ],
+      "type": "string"
+    },
     "SelectedCapabilityRoot": {
       "description": "A user-selected root that can expose one or more runtime capabilities.",
       "properties": {
@@ -13082,6 +13355,46 @@
             "params"
           ],
           "title": "Thread/goal/clearedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "thread/environment/connected"
+              ],
+              "title": "Thread/environment/connectedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/EnvironmentConnectionNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/environment/connectedNotification",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "enum": [
+                "thread/environment/disconnected"
+              ],
+              "title": "Thread/environment/disconnectedNotificationMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/EnvironmentConnectionNotification"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "title": "Thread/environment/disconnectedNotification",
           "type": "object"
         },
         {
@@ -14232,6 +14545,13 @@
           "type": "object"
         }
       ],
+      "properties": {
+        "emittedAtMs": {
+          "description": "Unix timestamp (in milliseconds) when app-server emitted this notification.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
       "title": "ServerNotification"
     },
     "ServerRequestResolvedNotification": {
@@ -16177,6 +16497,15 @@
             "query": {
               "type": "string"
             },
+            "results": {
+              "default": null,
+              "description": "Structured search results returned out-of-band by standalone web search.\n\nThese stay as opaque JSON at the extension/app-server boundary so new result fields and result types can pass through without a Codex release.",
+              "items": true,
+              "type": [
+                "array",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "webSearch"
@@ -16218,6 +16547,7 @@
           "type": "object"
         },
         {
+          "description": "Display item emitted by the interruptible `clock.sleep` tool.",
           "properties": {
             "durationMs": {
               "format": "uint64",
@@ -16356,6 +16686,22 @@
           "type": "object"
         }
       ]
+    },
+    "ThreadItemEntry": {
+      "properties": {
+        "item": {
+          "$ref": "#/definitions/ThreadItem"
+        },
+        "turnId": {
+          "description": "Turn containing this item.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "item",
+        "turnId"
+      ],
+      "type": "object"
     },
     "ThreadListCwdFilter": {
       "anyOf": [
@@ -17754,6 +18100,11 @@
     },
     "TokenUsageBreakdown": {
       "properties": {
+        "cacheWriteInputTokens": {
+          "default": 0,
+          "format": "int64",
+          "type": "integer"
+        },
         "cachedInputTokens": {
           "format": "int64",
           "type": "integer"
@@ -17949,6 +18300,16 @@
         },
         "environmentId": {
           "type": "string"
+        },
+        "runtimeWorkspaceRoots": {
+          "description": "Environment-native runtime workspace roots. Omitted defaults to `cwd`.",
+          "items": {
+            "$ref": "#/definitions/LegacyAppPathString"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
       "required": [


### PR DESCRIPTION
Reconciles the schema drift the `check_codex_schema_drift.py` tooling reported against `openai/codex@main`. **Stacked on #214** (base branch = `meawoppl/codex-codes-ergonomics-204-213`); rebase onto main once #214 merges.

## Root-cause note (supersedes my earlier "codegen is destructive" warning)

The codegen is **healthy and deterministic**. My earlier alarm was a false positive: I'd regenerated against the *stale committed snapshot* and compared *pre-`cargo fmt`* output against the *rustfmt'd* committed file — the ~1600-line "deletion" was pure formatting. Regenerating against fresh upstream + `cargo fmt` yields a clean **+128/−8** diff. The committed snapshot in `tests/schemas/` was simply older than the committed generated types; refreshing it fixes both.

## What changed

- Refreshed `codex_app_server_protocol{,.v2}.schemas.json` from `openai/codex@main` → **byte-identical to upstream** (drift check exits 0).
- Regenerated `protocol_generated/{types,samples}.rs` (`python3 scripts/codegen_protocol.py` + `cargo fmt`). 6 new definitions, additive token/memory fields, `templateId` removed from `McpToolCallAppContext` (upstream removal).
- Modeled the 2 new notifications: `Notification::ThreadEnvironmentConnected` / `ThreadEnvironmentDisconnected` (both → `EnvironmentConnectionNotification`), with method constants and dispatch wiring.
- Updated `schema_coverage` modeled-methods registry → **coverage 70/70 notifications, 87/87 client requests, 10/10 server requests (100%)**.
- Bump 0.143.4.

## Gates
- `cargo test -p codex-codes --lib`: 75 pass
- `cargo clippy -p codex-codes --all-targets -- -D warnings`: clean
- `cargo run --example schema_coverage`: exit 0, 100%
- `python3 scripts/check_codex_schema_drift.py`: byte-identical to upstream, exit 0

---
This PR now carries the full codex-codes **0.143.4** release (ergonomics from #214 + this re-snapshot, folded into one published version). Supersedes #214.

Closes #205, #206, #209, #212. Partially addresses #213.
