### PR TITLE
claude-codes: automated stream-json schema drift check + nightly CI

### DIFF
--- a/.github/workflows/claude-schema-drift.yml
+++ b/.github/workflows/claude-schema-drift.yml
@@ -1,0 +1,128 @@
+name: Claude Schema Drift
+
+# Nightly check: does the installed Claude Code CLI's stream-json wire schema
+# still match our snapshot at
+# `claude-codes/tests/schemas/claude_stream_json_snapshot.txt`?
+#
+# Claude Code ships no published schema — the wire types live as minified zod
+# definitions inside the Bun-compiled CLI ELF. We install the CLI, extract the
+# schemas (scripts/extract_claude_sdk_schemas.py), reduce them to a
+# minification-invariant fingerprint (scripts/check_claude_schema_drift.py),
+# and diff against the snapshot. On drift we open (or update) an issue.
+#
+# Sibling of codex-schema-drift.yml; kept separate because the source of truth
+# is a locally-installed binary, not an upstream URL.
+
+on:
+  schedule:
+    # 06:47 UTC — offset from the codex drift check (06:17) and off the hour.
+    - cron: "47 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: diff installed CLI schema vs snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install the Claude Code CLI
+        # Best-effort: the native installer drops the Bun ELF at
+        # ~/.local/share/claude/versions/<version>. If this fails, the drift
+        # check exits 2 (soft skip) rather than failing the job.
+        run: |
+          set +e
+          curl -fsSL https://claude.ai/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          # Trigger the download if the installer only placed a launcher shim.
+          "$HOME/.local/bin/claude" --version >/dev/null 2>&1 || true
+          exit 0
+
+      - name: Locate the CLI binary
+        id: bin
+        run: |
+          BIN="$(ls -d "$HOME"/.local/share/claude/versions/* 2>/dev/null | sort -V | tail -1)"
+          if [ -z "$BIN" ] && command -v claude >/dev/null 2>&1; then
+            BIN="$(readlink -f "$(command -v claude)")"
+          fi
+          echo "binary=$BIN" >> "$GITHUB_OUTPUT"
+          echo "Resolved CLI binary: ${BIN:-<none>}"
+
+      - name: Run drift check
+        id: check
+        run: |
+          set +e
+          ARGS=""
+          if [ -n "${{ steps.bin.outputs.binary }}" ]; then
+            ARGS="--binary ${{ steps.bin.outputs.binary }}"
+          fi
+          python3 scripts/check_claude_schema_drift.py $ARGS | tee /tmp/claude_drift_report.md
+          STATUS=${PIPESTATUS[0]}
+          echo "exit_code=$STATUS" >> "$GITHUB_OUTPUT"
+          case "$STATUS" in
+            0) echo "result=no-drift"      >> "$GITHUB_OUTPUT" ;;
+            1) echo "result=drift"         >> "$GITHUB_OUTPUT" ;;
+            *) echo "result=extract-skip"  >> "$GITHUB_OUTPUT" ;;
+          esac
+          exit 0  # don't fail the job on drift; we open an issue instead
+
+      - name: Open or update drift issue
+        if: steps.check.outputs.result == 'drift'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Single-thread by label: at most one open drift issue at a time.
+          LABEL="claude-schema-drift"
+          TITLE="claude-codes: Claude Code stream-json schema has drifted from our snapshot"
+          BODY_FILE=/tmp/claude_drift_report.md
+          gh label create "$LABEL" \
+            --color "5319E7" \
+            --description "Nightly check found drift between the installed Claude CLI schema and our snapshot" \
+            --force \
+            || true
+          EXISTING=$(gh issue list --state open --label "$LABEL" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing drift issue #$EXISTING"
+            {
+              echo "_Nightly drift re-check (run #${{ github.run_number }}, $(date -u +%Y-%m-%dT%H:%MZ)):_"
+              echo
+              cat "$BODY_FILE"
+            } | gh issue comment "$EXISTING" --body-file -
+          else
+            echo "Opening new drift issue"
+            gh issue create \
+              --title "$TITLE" \
+              --label "$LABEL" \
+              --body-file "$BODY_FILE"
+          fi
+
+      - name: Report extract skip (job summary only — don't open issue)
+        if: steps.check.outputs.result == 'extract-skip'
+        run: |
+          {
+            echo "## Claude schema drift check skipped"
+            echo
+            echo "Could not install the Claude CLI or extract its schemas (the"
+            echo "bundle layout may have changed, or the install failed on the"
+            echo "runner). Will retry on the next nightly run; see"
+            echo "\`claude-codes/RESNAPSHOTTING.md\` if the extractor needs updating."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: All clear (job summary only)
+        if: steps.check.outputs.result == 'no-drift'
+        run: |
+          {
+            echo "## ✅ No Claude schema drift"
+            echo
+            echo "The installed CLI's wire labels and top-level fields match"
+            echo "\`claude-codes/tests/schemas/claude_stream_json_snapshot.txt\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ reference/
 
 # Local Claude Code settings and agent worktrees
 .claude/
+
+# Python bytecode
+__pycache__/
+*.pyc

--- a/claude-codes/RESNAPSHOTTING.md
+++ b/claude-codes/RESNAPSHOTTING.md
@@ -1,0 +1,134 @@
+# Re-snapshotting claude-codes against a new Claude Code CLI
+
+The Claude Code stream-json protocol evolves with every CLI release. This doc
+describes how to extract the CLI's actual wire schemas from the shipped binary
+and diff them against this crate, so any agent or contributor can repeat the
+process. It was first run against CLI 2.1.205 (PR #180, issues #181–#191).
+
+## Where the code lives
+
+The npm package `@anthropic-ai/claude-code` is only a downloader shim — there
+is no `cli.js` in it anymore. The real bundle is a **Bun-compiled ELF** with
+the JavaScript embedded as plain bytes:
+
+```bash
+claude update                      # get the newest version first
+readlink -f "$(which claude)"      # → ~/.local/share/claude/versions/<version>
+```
+
+Because the JS is embedded uncompressed, everything below is byte-level
+`grep -a` / Python `re` over the ELF. No unpacking required.
+
+## Quick check: has anything drifted?
+
+Before the full walk-through, run the automated drift check. It extracts the
+current CLI's schemas, reduces them to a minification-invariant fingerprint
+(the set of wire `type`/`subtype` labels and each schema's top-level field
+keys), and diffs against the committed snapshot at
+`claude-codes/tests/schemas/claude_stream_json_snapshot.txt`:
+
+```bash
+python3 scripts/check_claude_schema_drift.py     # exit 0 = clean, 1 = drift, 2 = couldn't extract
+```
+
+The nightly `.github/workflows/claude-schema-drift.yml` runs exactly this and
+opens a `claude-schema-drift`-labelled issue on drift. When it fires (or after
+a `claude update`), follow the steps below to model the change, then accept the
+new snapshot with `python3 scripts/check_claude_schema_drift.py --update`.
+
+The check is deliberately coarse — it flags new/removed message types and
+added/removed top-level fields (the changes that break `ClaudeOutput` decode),
+but not deep field-type or required/optional changes. Those still need the
+field-by-field walk below.
+
+## Step 1 — extract the SDK output schemas
+
+```bash
+python3 scripts/extract_claude_sdk_schemas.py -o /tmp/claude_sdk_schemas.txt
+```
+
+The CLI defines its wire types as lazy zod schemas,
+`NAME=Se(()=>E.object({type:E.literal("..."),...}))`, and the SDK output
+union is an `E.union([NAME(), ...])` over ~40 of them. Minified names change
+every release; the structure does not. The script anchors on the
+`rate_limit_event` literal, finds the union that references it, and dumps
+every member schema plus transitive references, each labeled with its
+resolved `type`/`subtype`.
+
+If the script fails to find the anchor or union, the bundle layout changed;
+fall back to manual spelunking (below) and update the script.
+
+## Step 2 — diff against the crate
+
+Map each extracted schema to its crate type and compare field-by-field:
+
+| Wire type | Crate type (in `claude-codes/src/io/`) |
+|---|---|
+| `assistant` / `user` | `AssistantMessage`, `UserMessage` (`message_types.rs`) |
+| `result` (success + error subtypes) | `ResultMessage` (`result.rs`) |
+| `system/<subtype>` | `SystemSubtype` + per-subtype structs (`message_types.rs`) |
+| `rate_limit_event` | `RateLimitEvent` (`rate_limit.rs`) |
+| `control_request` / `control_response` | `control.rs` |
+| everything else | `ClaudeOutput` variants (`claude_output.rs`) |
+
+Things to check, in priority order:
+
+1. **New top-level `type` literals.** `ClaudeOutput` is `#[serde(tag = "type")]`
+   with no catch-all — an unmodeled type fails typed decode outright.
+2. **Closed enums.** Any derive-serde enum without an `Unknown(String)`
+   fallback hard-fails the whole frame when the CLI adds a value. Prefer the
+   manual `as_str` / `From<&str>` / serde pattern used throughout the crate.
+3. **Required → optional flips.** A crate field that is required while the
+   wire schema says `.optional()` fails to parse frames that omit it.
+4. **New fields.** Dropped on round-trip; the `assert_fully_wrapped` audit
+   catches these for `system` frames.
+
+Two caveats that save confusion:
+
+- The `message` payloads of `assistant`/`user`, the `stream_event` `event`,
+  and the result `usage` are `E.unknown()` in the CLI's own schema — raw
+  Anthropic API passthrough. The crate types those against the API shape,
+  not the CLI schema, so "the zod says unknown" is not drift.
+- Minified names collide across bundle modules. When extracting by hand,
+  prefer the definition nearest the union's byte offset.
+
+## Manual spelunking recipes
+
+Enumerate every wire `type`/`subtype` literal (broader than the SDK union —
+includes internal orchestrator frames):
+
+```bash
+grep -aoE 'type:E\.literal\("[a-z_]+"\)' <binary> | sort | uniq -c
+grep -aoE 'subtype:E\.literal\("[a-z_0-9]+"\)' <binary> | sort | uniq -c
+```
+
+Pull context around any anchor string (Python is much faster than grep's
+regex context on a ~250 MB binary):
+
+```python
+data = open(BINARY, 'rb').read()
+i = data.find(b'some_anchor_string')
+print(data[i-500:i+1500].decode('utf-8', 'replace'))
+```
+
+Definitions end where the next `NAME=Se(` begins — split on that boundary
+rather than balanced-paren parsing (regex literals in the minified JS break
+paren counting).
+
+Non-protocol provenance worth knowing (for fixtures and header-derived
+state): live quota values in `rate_limit_event` come from
+`anthropic-ratelimit-unified-*` response headers (including per-window
+`-{5h|7d|7d_oi|overage}-utilization` / `-reset` pairs), the `/usage` panel
+comes from `GET /api/oauth/usage`, and the CLI fires a 1-max-token probe
+request (body `"quota"`, `source: "quota_check"`) at startup purely to
+harvest those headers.
+
+## Step 3 — land the changes
+
+- File one issue per drifted type/area with the extracted schema excerpt
+  (see #181–#191 for the shape), or fix directly.
+- Follow the crate conventions: `skip_serializing_if = "Option::is_none"`,
+  `Unknown(String)` fallbacks, round-trip tests against a full-fat JSON
+  frame, `CHANGELOG.md` entry under `[Unreleased]`.
+- Update the tested CLI version pin when the integration suite passes
+  against the new binary.

--- a/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
+++ b/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
@@ -1,0 +1,45 @@
+# Claude Code stream-json wire schema snapshot.
+# Regenerate: python3 scripts/check_claude_schema_drift.py --update
+# One line per wire label: `<type[/subtype]>: comma-separated top-level field keys`.
+# Minified schema names and nested/describe() detail are intentionally omitted;
+# see the header of check_claude_schema_drift.py for the comparison contract.
+# union_members: 39
+
+assistant: advisor_model, api_error, api_error_status, attribution_agent, attribution_mcp_server, attribution_mcp_tool, attribution_plugin, attribution_skill, error, error_details, is_api_error_message, is_meta, is_virtual, message, parent_tool_use_id, request_id, session_id, subagent_type, supersedes, task_description, timestamp, tool_use_meta, type, uuid
+auth_status: error, isAuthenticating, output, session_id, type, uuid
+conversation_reset: new_conversation_id, session_id, type, uuid
+prompt_suggestion: session_id, suggestion, type, uuid
+rate_limit_event: rate_limit_info, session_id, type, uuid
+result: duration_api_ms, duration_ms, errors, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, session_id, stop_reason, subtype, terminal_reason, total_cost_usd, type, usage, uuid
+result/success: api_error_status, deferred_tool_use, duration_api_ms, duration_ms, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, result, session_id, stop_reason, structured_output, subtype, terminal_reason, time_origin_ms, time_to_request_from_spawn_ms, time_to_request_ms, total_cost_usd, ttft_ms, ttft_stream_ms, type, usage, uuid, warm_spare_claimed
+stream_event: event, parent_tool_use_id, session_id, ttft_ms, type, uuid
+system/api_retry: attempt, error, error_status, max_retries, retry_delay_ms, session_id, subtype, type, uuid
+system/background_tasks_changed: session_id, subtype, tasks, type, uuid
+system/commands_changed: commands, session_id, subtype, type, uuid
+system/compact_boundary: compact_metadata, logical_parent_uuid, session_id, subtype, type, uuid
+system/control_request_progress: attempt, error_status, max_retries, request_id, retry_delay_ms, session_id, status, subtype, type, uuid
+system/elicitation_complete: elicitation_id, mcp_server_name, session_id, subtype, type, uuid
+system/files_persisted: failed, files, processed_at, session_id, subtype, type, uuid
+system/hook_progress: hook_event, hook_id, hook_name, output, session_id, stderr, stdout, subtype, type, uuid
+system/hook_response: exit_code, hook_event, hook_id, hook_name, outcome, output, session_id, stderr, stdout, subtype, type, uuid
+system/hook_started: hook_event, hook_id, hook_name, session_id, subtype, type, uuid
+system/informational: content, level, prevent_continuation, session_id, subtype, tool_use_id, type, uuid
+system/init: agents, analytics_disabled, apiKeySource, betas, capabilities, claude_code_version, cwd, fast_mode_state, mcp_servers, memory_paths, model, output_style, permissionMode, plugin_errors, plugin_warnings, plugins, product_feedback_disabled, session_id, skills, slash_commands, subtype, tools, type, uuid
+system/local_command_output: content, session_id, subtype, type, uuid
+system/memory_recall: memories, mode, session_id, subtype, type, uuid
+system/mirror_error: error, key, session_id, subtype, type, uuid
+system/model_refusal_fallback: api_refusal_category, api_refusal_explanation, content, direction, fallback_model, original_model, refused_user_message_uuid, request_id, retracted_message_uuids, session_id, subtype, trigger, type, uuid
+system/model_refusal_no_fallback: api_refusal_category, api_refusal_explanation, content, original_model, refused_user_message_uuid, request_id, session_id, subtype, type, uuid
+system/notification: color, key, priority, session_id, subtype, text, timeout_ms, type, uuid
+system/permission_denied: agent_id, decision_reason, decision_reason_type, message, session_id, subtype, tool_name, tool_use_id, type, uuid
+system/plugin_install: error, name, session_id, status, subtype, type, uuid
+system/session_state_changed: session_id, state, subtype, type, uuid
+system/status: compact_error, compact_result, permissionMode, session_id, status, subtype, type, uuid
+system/task_notification: output_file, session_id, skip_transcript, status, subtype, summary, task_id, tool_use_id, type, usage, uuid
+system/task_progress: description, last_tool_name, session_id, subagent_type, subtype, summary, task_id, tool_use_id, type, usage, uuid
+system/task_updated: patch, session_id, subtype, task_id, type, uuid
+system/thinking_tokens: estimated_tokens, estimated_tokens_delta, session_id, subtype, type, uuid
+system/worker_shutting_down: reason, session_id, subtype, type, uuid
+tool_progress: elapsed_time_seconds, parent_tool_use_id, session_id, task_id, tool_name, tool_use_id, type, uuid
+tool_use_summary: preceding_tool_use_ids, session_id, summary, timestamp, type, uuid
+user: client_platform, image_paste_ids, inbound_origin, interrupted_message_id, isSynthetic, is_compact_summary, is_meta, is_virtual, is_visible_in_transcript_only, mcp_meta, message, origin, parent_tool_use_id, permission_mode, plan_content, priority, shouldQuery, source_tool_assistant_uuid, source_tool_use_id, summarize_metadata, timestamp, tool_use_result, type

--- a/claude.md
+++ b/claude.md
@@ -13,6 +13,28 @@ This project follows a test-driven development approach for implementing the Cla
 5. **Verify Implementation**: Run `cargo test deserialization` to ensure the new types deserialize correctly
 6. **Lock in Progress**: Successful test cases prove our protocol implementation is correct
 
+### Re-snapshotting against a new Claude CLI
+
+Claude Code ships no published schema — the wire types live as minified zod
+definitions inside the Bun-compiled CLI ELF. Two scripts turn that into a
+drift signal:
+
+```bash
+# Full extraction (one block per schema, for the crate-side field-by-field diff):
+python3 scripts/extract_claude_sdk_schemas.py -o /tmp/claude_sdk_schemas.txt
+
+# Automated drift check against the committed snapshot (wire labels + top-level fields):
+python3 scripts/check_claude_schema_drift.py           # exit 0 clean / 1 drift / 2 skip
+python3 scripts/check_claude_schema_drift.py --update   # accept a new snapshot
+```
+
+The snapshot lives at `claude-codes/tests/schemas/claude_stream_json_snapshot.txt`
+and the nightly `.github/workflows/claude-schema-drift.yml` opens a
+`claude-schema-drift`-labelled issue when the installed CLI drifts from it.
+Full procedure — where the bundle lives, how to map schemas to crate types,
+what counts as drift, manual spelunking recipes — is in
+**`claude-codes/RESNAPSHOTTING.md`**.
+
 ## Git Workflow Requirements
 
 **CRITICAL: This repository enforces a strict PR-based workflow**

--- a/scripts/check_claude_schema_drift.py
+++ b/scripts/check_claude_schema_drift.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""
+Detect drift between the Claude Code CLI's stream-json wire schemas and the
+snapshot committed at `claude-codes/tests/schemas/claude_stream_json_snapshot.txt`.
+
+Unlike the Codex app-server (which publishes JSON Schemas we fetch directly),
+Claude Code ships no schema — the wire types live as minified zod definitions
+inside the Bun-compiled CLI ELF. `scripts/extract_claude_sdk_schemas.py` pulls
+them out; this script reduces them to a **minification-invariant fingerprint**
+and diffs it against the committed snapshot.
+
+## What is (and isn't) compared
+
+The minified schema *variable* names churn every CLI release, so we key on the
+stable parts only:
+
+  - the set of wire **labels** — a message's `type` literal, or `type/subtype`
+    for `system` frames, and
+  - each labeled schema's **top-level field keys** (the object keys are real
+    wire names; nested objects and `.describe()` prose are ignored).
+
+This catches the highest-severity drift — a new/removed message `type`
+(which fails `ClaudeOutput`'s tagged-enum decode outright) and added/removed
+top-level fields — with no false positives from minification. It intentionally
+does **not** diff deep field types or required/optional flips; for those, run
+the full extractor and follow `claude-codes/RESNAPSHOTTING.md`.
+
+## Usage
+
+    python3 scripts/check_claude_schema_drift.py [--binary PATH]   # check
+    python3 scripts/check_claude_schema_drift.py --update [--binary PATH]  # re-snapshot
+
+## Exit codes
+
+  0 — no drift (or --update wrote the snapshot)
+  1 — drift detected; the Markdown report on stdout says what changed
+  2 — could not extract (no `claude` binary, or the bundle layout changed so
+      the anchor/union moved — treated as a soft skip by CI, like a fetch blip)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from extract_claude_sdk_schemas import (  # noqa: E402
+    REF_CALL,
+    SchemaExtractionError,
+    extract_schemas,
+    resolve_binary,
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+SNAPSHOT = ROOT / "claude-codes" / "tests" / "schemas" / "claude_stream_json_snapshot.txt"
+
+_KEY = re.compile(r"[A-Za-z_$][\w$]*")
+
+
+def top_level_keys(body: str) -> list[str]:
+    """The direct object keys of a schema's outermost `E.object({...})`.
+
+    String-literal aware (so colons/braces inside `.describe("...")` prose are
+    skipped) and bracket-depth aware (so nested `E.object(...)` keys aren't
+    counted). Only bare-identifier keys are recognized — all Claude wire
+    schemas use them.
+    """
+    start = body.find("E.object({")
+    if start < 0:
+        return []
+    i = start + len("E.object({")
+    depth = 0
+    n = len(body)
+    keys: list[str] = []
+    while i < n:
+        c = body[i]
+        if c in "\"'":
+            quote = c
+            i += 1
+            while i < n:
+                if body[i] == "\\":
+                    i += 2
+                    continue
+                if body[i] == quote:
+                    i += 1
+                    break
+                i += 1
+            continue
+        if c in "{[(":
+            depth += 1
+            i += 1
+            continue
+        if c in "}])":
+            if depth == 0:
+                break  # closed the outermost object
+            depth -= 1
+            i += 1
+            continue
+        if depth == 0 and (c.isalpha() or c in "_$"):
+            m = _KEY.match(body, i)
+            j = m.end()
+            while j < n and body[j] in " \t\n":
+                j += 1
+            if j < n and body[j] == ":":
+                keys.append(m.group(0))
+                i = j + 1
+                continue
+            i = m.end()
+            continue
+        i += 1
+    return keys
+
+
+def build_fingerprint(data: bytes) -> tuple[int, dict[str, list[str]]]:
+    """`(union_member_count, {label: sorted top-level keys})` for labeled schemas."""
+    union_text, results = extract_schemas(data)
+    members = len(REF_CALL.findall(union_text))
+    labeled: dict[str, list[str]] = {}
+    for _name, label, body in results:
+        if label in ("(nested)", "NOT FOUND"):
+            continue
+        keys = sorted(set(top_level_keys(body)))
+        # First definition wins on the rare label collision; keep it deterministic.
+        labeled.setdefault(label, keys)
+    return members, labeled
+
+
+def render_snapshot(members: int, labeled: dict[str, list[str]]) -> str:
+    lines = [
+        "# Claude Code stream-json wire schema snapshot.",
+        "# Regenerate: python3 scripts/check_claude_schema_drift.py --update",
+        "# One line per wire label: `<type[/subtype]>: comma-separated top-level field keys`.",
+        "# Minified schema names and nested/describe() detail are intentionally omitted;",
+        "# see the header of check_claude_schema_drift.py for the comparison contract.",
+        f"# union_members: {members}",
+        "",
+    ]
+    for label in sorted(labeled):
+        lines.append(f"{label}: {', '.join(labeled[label])}")
+    return "\n".join(lines) + "\n"
+
+
+def parse_snapshot(text: str) -> tuple[int | None, dict[str, list[str]]]:
+    members: int | None = None
+    labeled: dict[str, list[str]] = {}
+    for line in text.splitlines():
+        line = line.rstrip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            m = re.match(r"#\s*union_members:\s*(\d+)", line)
+            if m:
+                members = int(m.group(1))
+            continue
+        label, _, keys = line.partition(":")
+        labeled[label.strip()] = [k.strip() for k in keys.split(",") if k.strip()]
+    return members, labeled
+
+
+def diff_report(
+    old_members: int | None,
+    old: dict[str, list[str]],
+    new_members: int,
+    new: dict[str, list[str]],
+) -> tuple[bool, str]:
+    """`(drift, markdown_report)`."""
+    lines = ["# Claude Code stream-json schema drift report", ""]
+    lines.append("Comparing the installed `claude` CLI against")
+    lines.append("`claude-codes/tests/schemas/claude_stream_json_snapshot.txt`.")
+    lines.append("")
+
+    drift = False
+    added = sorted(set(new) - set(old))
+    removed = sorted(set(old) - set(new))
+    common = sorted(set(old) & set(new))
+
+    if old_members is not None and old_members != new_members:
+        drift = True
+        lines.append(
+            f"- ⚠️ **SDK output union member count changed**: {old_members} → {new_members}"
+        )
+        lines.append("")
+
+    if added:
+        drift = True
+        lines.append(f"### New wire labels ({len(added)})")
+        lines.append("")
+        for label in added:
+            keys = ", ".join(new[label]) or "(no top-level keys)"
+            lines.append(f"- `{label}` — fields: {keys}")
+        lines.append("")
+
+    if removed:
+        drift = True
+        lines.append(f"### Removed wire labels ({len(removed)})")
+        lines.append("")
+        for label in removed:
+            lines.append(f"- `{label}`")
+        lines.append("")
+
+    field_changes = []
+    for label in common:
+        a, b = set(old[label]), set(new[label])
+        if a != b:
+            field_changes.append((label, sorted(b - a), sorted(a - b)))
+    if field_changes:
+        drift = True
+        lines.append(f"### Changed top-level fields ({len(field_changes)})")
+        lines.append("")
+        for label, gained, lost in field_changes:
+            parts = []
+            if gained:
+                parts.append("added " + ", ".join(f"`{k}`" for k in gained))
+            if lost:
+                parts.append("removed " + ", ".join(f"`{k}`" for k in lost))
+            lines.append(f"- `{label}` — {'; '.join(parts)}")
+        lines.append("")
+
+    if not drift:
+        lines.append("- ✅ No drift: wire labels and top-level fields match the snapshot.")
+        lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append("Regenerate the snapshot + investigate deeper changes with:")
+    lines.append("")
+    lines.append("```bash")
+    lines.append("python3 scripts/extract_claude_sdk_schemas.py -o /tmp/claude_schemas.txt")
+    lines.append("python3 scripts/check_claude_schema_drift.py --update  # accept new snapshot")
+    lines.append("# then follow claude-codes/RESNAPSHOTTING.md for the crate-side diff")
+    lines.append("```")
+    return drift, "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--binary", help="path to the claude CLI ELF (default: `claude` on PATH)")
+    ap.add_argument("--update", action="store_true", help="(re)write the committed snapshot")
+    args = ap.parse_args()
+
+    try:
+        binary = resolve_binary(args.binary)
+        data = binary.read_bytes()
+        new_members, new = build_fingerprint(data)
+    except SchemaExtractionError as e:
+        print(f"# Claude schema drift check skipped\n\nCould not extract schemas: {e}")
+        return 2
+    except (FileNotFoundError, SystemExit) as e:
+        print(f"# Claude schema drift check skipped\n\nCould not read the CLI binary: {e}")
+        return 2
+
+    if args.update:
+        SNAPSHOT.parent.mkdir(parents=True, exist_ok=True)
+        SNAPSHOT.write_text(render_snapshot(new_members, new))
+        print(f"# wrote {len(new)} labels ({new_members} union members) to {SNAPSHOT}")
+        return 0
+
+    if not SNAPSHOT.exists():
+        print(f"error: snapshot missing at {SNAPSHOT}; run with --update to create it")
+        return 2
+
+    old_members, old = parse_snapshot(SNAPSHOT.read_text())
+    drift, report = diff_report(old_members, old, new_members, new)
+    print(report)
+    return 1 if drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/extract_claude_sdk_schemas.py
+++ b/scripts/extract_claude_sdk_schemas.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+Extract the Claude Code CLI's SDK stream-json output schemas from the
+compiled CLI binary, for diffing against the claude-codes crate.
+
+The CLI ships as a Bun-compiled ELF with the bundled JavaScript embedded as
+plain bytes, so the zod schema definitions are recoverable with byte-level
+regex work — no unpacking needed. The wire schemas are lazy zod definitions
+of the form `NAME=Se(()=>E.object({type:E.literal("..."),...}))`, and the
+SDK output union is an `E.union([NAME(), ...])` over ~40 of them.
+
+Minified names change every release; the *structure* does not. This script
+anchors on the `rate_limit_event` literal (a stable, unique member), finds
+the union that references it, then extracts every member schema plus
+transitive references.
+
+Usage:
+  python3 scripts/extract_claude_sdk_schemas.py [BINARY] [-o OUT.txt]
+
+BINARY defaults to the resolved `claude` on PATH (follow the symlink to
+~/.local/share/claude/versions/<version>). Output is one block per schema,
+labeled with its resolved type/subtype, written to stdout or -o.
+
+The extraction logic is also importable — `extract_schemas(data)` powers
+`scripts/check_claude_schema_drift.py`.
+
+Exits 0 on success, 1 if the anchor or union cannot be located (usually
+means the bundle layout changed — see claude-codes/RESNAPSHOTTING.md).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+from pathlib import Path
+
+# A schema definition starts at `NAME=Se(` and ends where the next one begins.
+DEF_START = re.compile(rb"[^\w$]([A-Za-z_$][\w$]{1,6})=Se\(")
+BOUNDARY = re.compile(rb"[,;({\[]\s*[A-Za-z_$][\w$]{1,6}=Se\(")
+# Calls to other lazy schemas inside a definition body: `ref()`.
+REF_CALL = re.compile(r"\b([A-Za-z_$][\w$]{1,6})\(\)")
+# The anchor schema: the one whose body opens with the rate_limit_event literal.
+ANCHOR = re.compile(
+    rb'([A-Za-z_$][\w$]{1,6})=Se\(\(\)=>E\.object\(\{type:E\.literal\("rate_limit_event"\)'
+)
+UNION = re.compile(rb"[A-Za-z_$][\w$]{1,6}=Se\(\(\)=>E\.union\(\[[^\]]*\]\)\)")
+
+
+class SchemaExtractionError(RuntimeError):
+    """The bundle layout changed and an anchor/union could not be located."""
+
+
+def resolve_binary(arg: str | None) -> Path:
+    if arg:
+        return Path(arg)
+    on_path = shutil.which("claude")
+    if not on_path:
+        sys.exit("error: no `claude` on PATH; pass the binary path explicitly")
+    return Path(on_path).resolve()
+
+
+def index_definitions(data: bytes) -> dict[str, list[tuple[int, bytes]]]:
+    """One pass over the binary → {name: [(offset, body-bytes), ...]}.
+
+    Minified names collide across bundle modules, so each name maps to every
+    candidate definition; callers pick the one nearest the union with
+    [`pick_definition`]. Indexing once turns per-name full-binary scans into
+    O(1) lookups — the difference between minutes and seconds on a ~250 MB ELF.
+    """
+    idx: dict[str, list[tuple[int, bytes]]] = {}
+    for m in DEF_START.finditer(data):
+        name = m.group(1).decode()
+        start = m.start() + 1
+        nxt = BOUNDARY.search(data, m.end())
+        end = nxt.start() + 1 if nxt else m.end() + 20_000
+        idx.setdefault(name, []).append((start, data[start:end]))
+    return idx
+
+
+def pick_definition(cands: list[tuple[int, bytes]], anchor: int) -> bytes | None:
+    if not cands:
+        return None
+    return min(cands, key=lambda c: abs(c[0] - anchor))[1]
+
+
+def label_of(body: str) -> str:
+    t = re.search(r'type:E\.literal\("([a-z_]+)"\)', body)
+    s = re.search(r'subtype:E\.literal\("([a-z_0-9]+)"\)', body)
+    if t and s:
+        return f"{t.group(1)}/{s.group(1)}"
+    if t:
+        return t.group(1)
+    return "(nested)"
+
+
+def extract_schemas(data: bytes) -> tuple[str, list[tuple[str, str, str]]]:
+    """Extract the SDK output union and every reachable schema.
+
+    Returns `(union_text, [(minified_name, label, body_text), ...])` in
+    breadth-first order from the union members. Raises
+    [`SchemaExtractionError`] if the anchor or union can't be found.
+    """
+    m = ANCHOR.search(data)
+    if not m:
+        raise SchemaExtractionError(
+            "rate_limit_event anchor schema not found — bundle layout changed?"
+        )
+    anchor_name, anchor_off = m.group(1).decode(), m.start()
+
+    union = None
+    for um in UNION.finditer(data):
+        if (anchor_name + "()").encode() in um.group(0):
+            union = um
+            break
+    if union is None:
+        raise SchemaExtractionError("SDK output union referencing the anchor not found")
+    union_text = union.group(0).decode()
+    members = REF_CALL.findall(union_text)
+
+    idx = index_definitions(data)
+    results: list[tuple[str, str, str]] = []
+    seen: set[str] = set()
+    queue = list(dict.fromkeys(members))
+    while queue:
+        name = queue.pop(0)
+        if name in seen:
+            continue
+        seen.add(name)
+        body = pick_definition(idx.get(name, []), union.start())
+        if body is None:
+            results.append((name, "NOT FOUND", ""))
+            continue
+        text = body.decode("utf-8", "replace")
+        results.append((name, label_of(text), text))
+        for ref in REF_CALL.findall(text):
+            if ref not in seen and ref not in queue:
+                queue.append(ref)
+    return union_text, results
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("binary", nargs="?", help="path to the claude CLI ELF")
+    ap.add_argument("-o", "--out", help="write schemas here instead of stdout")
+    args = ap.parse_args()
+
+    binary = resolve_binary(args.binary)
+    data = binary.read_bytes()
+    print(f"# read {binary} ({len(data):,} bytes)", file=sys.stderr)
+
+    try:
+        union_text, results = extract_schemas(data)
+    except SchemaExtractionError as e:
+        sys.exit(f"error: {e}")
+
+    print(f"# union: {len(REF_CALL.findall(union_text))} members", file=sys.stderr)
+    blocks = [f"// SDK output union\n{union_text}"]
+    for name, label, text in results:
+        blocks.append(f"// {name}: {label}\n{text}" if text else f"// {name}: {label}")
+
+    out = "\n\n".join(blocks) + "\n"
+    if args.out:
+        Path(args.out).write_text(out)
+        print(f"# wrote {len(blocks)} schemas to {args.out}", file=sys.stderr)
+    else:
+        sys.stdout.write(out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds an automated schema-drift check for Claude Code, mirroring the codex drift workflow. **Supersedes #192** (which added the extractor + guide but never merged and had no automated check).

## Why it's different from the codex check

Codex publishes JSON Schemas, so `check_codex_schema_drift.py` just fetches them. **Claude Code ships no schema** — the wire types live as minified zod definitions inside the Bun-compiled CLI ELF (`~/.local/share/claude/versions/<ver>`). So this check extracts them from the binary and diffs a **minification-invariant fingerprint**.

## What's here

- **`scripts/extract_claude_sdk_schemas.py`** — pulls the SDK stream-json schemas out of the ELF (anchors on the `rate_limit_event` literal, resolves the 39-member output union + transitive refs, labels each by `type`/`subtype`). Brought over from #192 and **refactored to a single-pass definition index → 2 min to 14 s** on the 257 MB binary, plus an importable `extract_schemas()` API.
- **`scripts/check_claude_schema_drift.py`** — reduces the extraction to `{wire label → sorted top-level field keys}` (+ union member count) and diffs against the committed snapshot. String/bracket-aware key parser so `.describe()` prose and nested objects don't pollute the signal. `--update` re-snapshots. Exit `0` clean / `1` drift / `2` couldn't-extract (soft skip).
- **`claude-codes/tests/schemas/claude_stream_json_snapshot.txt`** — the baseline (38 wire labels) for CLI **2.1.205**, matching the crate's current tested pin.
- **`.github/workflows/claude-schema-drift.yml`** — separate nightly workflow (06:47 UTC, offset from codex's 06:17). Installs the CLI, runs the check, opens/updates a single `claude-schema-drift`-labelled issue on drift. If the CLI can't be installed/extracted on the runner, the check exits 2 and the job reports a soft skip (no false issue, no red build).
- Docs: `claude-codes/RESNAPSHOTTING.md` (from #192) gains a \"quick check\" section; `claude.md` points at both scripts + the workflow.

## Scope of the signal (intentional)

Catches the highest-severity, zero-false-positive drift: **new/removed message `type`s** (which break `ClaudeOutput`'s tagged-enum decode outright) and **added/removed top-level fields**. It does *not* diff deep field types or required/optional flips — minified-name churn would make those noisy — so those still go through the manual `RESNAPSHOTTING.md` walk. Documented in both script headers.

## Validation
- Extractor + checker: `python3 -m py_compile` clean; extractor runs in ~14 s, 39 union members / 69 schemas.
- `check_claude_schema_drift.py` exits 0 against the committed snapshot; a simulated change (dropped field / removed label / union-count change) correctly reports drift and exits 1.
- Workflow YAML parses.

Note: the CI install step (`curl claude.ai/install.sh`) is best-effort; the exit-2 soft-skip is the safety net if a runner can't fetch the binary. Easy to iterate via `workflow_dispatch` once we see a live run.