### PR TITLE
codex-codes 0.143.5: re-snapshot app-server schema, fix drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.143.4"
+version = "0.143.5"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.161`, tested against Claude CLI `2.1.205`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.143.4`, tested against Codex CLI `0.143.0`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.143.5`, tested against Codex CLI `0.143.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.
 

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.143.5] - 2026-07-22
+
+Re-snapshot of the app-server schema from `openai/codex@main`, resolving the
+nightly drift report (#199). Snapshots are byte-identical to upstream again
+and schema coverage is back to 100%.
+
+### Added
+
+- **`app/read` and `app/installed` client requests** — new method constants
+  (`methods::APP_READ`, `methods::APP_INSTALLED`) with generated
+  `AppsReadParams`/`AppsReadResponse` and
+  `AppsInstalledParams`/`AppsInstalledResponse` types, plus supporting
+  `ConnectorMetadata`, `InstalledApp`, and `AppToolSummary` definitions.
+- **New generated definitions**: `CodexResponseHandoffMode`,
+  `FeedbackRequirements`, `PathUri`, `ThreadRealtimeInitialItem`.
+- Additive fields across `Account`, `ConfigRequirements`,
+  `ConfiguredHookHandler`, `ContentItem`, `HookEventName`, `HookMetadata`,
+  `InputModality`, `ManagedHooksRequirements`, `PluginListParams`,
+  `PluginSummary`, `UserInput`, and the external-agent-config params.
+
+### Changed
+
+- **Breaking**: `ReviewDecision::Denied` is now a struct variant carrying a
+  required `rejection: String` (wire shape
+  `{"decision":{"denied":{"rejection":...}}}`). The
+  `ExecCommandApprovalResponse::denied()` and
+  `ApplyPatchApprovalResponse::denied()` constructors now take the rejection
+  message as an argument.
+
+### Removed
+
+- **Breaking**: `AmazonBedrockCredentialSource` — removed upstream.
+
 ## [0.143.4] - 2026-07-16
 
 Combines the `agent-portal` audit ergonomics (originally staged as an

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.143.4"
+version = "0.143.5"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/examples/schema_coverage.rs
+++ b/codex-codes/examples/schema_coverage.rs
@@ -512,6 +512,8 @@ mod samples {
             methods::PLUGIN_SHARE_CHECKOUT,
             methods::PLUGIN_SHARE_DELETE,
             methods::APP_LIST,
+            methods::APP_READ,
+            methods::APP_INSTALLED,
             methods::FS_READFILE,
             methods::FS_WRITEFILE,
             methods::FS_CREATEDIRECTORY,

--- a/codex-codes/src/protocol.rs
+++ b/codex-codes/src/protocol.rs
@@ -63,6 +63,8 @@ pub mod methods {
     pub const PLUGIN_SHARE_CHECKOUT: &str = "plugin/share/checkout";
     pub const PLUGIN_SHARE_DELETE: &str = "plugin/share/delete";
     pub const APP_LIST: &str = "app/list";
+    pub const APP_READ: &str = "app/read";
+    pub const APP_INSTALLED: &str = "app/installed";
     pub const FS_READFILE: &str = "fs/readFile";
     pub const FS_WRITEFILE: &str = "fs/writeFile";
     pub const FS_CREATEDIRECTORY: &str = "fs/createDirectory";
@@ -320,10 +322,12 @@ impl ExecCommandApprovalResponse {
         }
     }
 
-    /// Deny the exec command (`{"decision":"denied"}`).
-    pub fn denied() -> Self {
+    /// Deny the exec command (`{"decision":{"denied":{"rejection":...}}}`).
+    pub fn denied(rejection: impl Into<String>) -> Self {
         Self {
-            decision: ReviewDecision::Denied,
+            decision: ReviewDecision::Denied {
+                rejection: rejection.into(),
+            },
         }
     }
 
@@ -350,10 +354,12 @@ impl ApplyPatchApprovalResponse {
         }
     }
 
-    /// Deny the patch (`{"decision":"denied"}`).
-    pub fn denied() -> Self {
+    /// Deny the patch (`{"decision":{"denied":{"rejection":...}}}`).
+    pub fn denied(rejection: impl Into<String>) -> Self {
         Self {
-            decision: ReviewDecision::Denied,
+            decision: ReviewDecision::Denied {
+                rejection: rejection.into(),
+            },
         }
     }
 
@@ -421,8 +427,9 @@ mod tests {
             serde_json::json!({"decision": "approved"})
         );
         assert_eq!(
-            serde_json::to_value(ApplyPatchApprovalResponse::denied()).unwrap(),
-            serde_json::json!({"decision": "denied"})
+            serde_json::to_value(ApplyPatchApprovalResponse::denied("keep the original file"))
+                .unwrap(),
+            serde_json::json!({"decision": {"denied": {"rejection": "keep the original file"}}})
         );
     }
 }

--- a/codex-codes/src/protocol_generated/samples.rs
+++ b/codex-codes/src/protocol_generated/samples.rs
@@ -252,7 +252,9 @@ pub fn client_request_samples() -> Vec<(&'static str, Value)> {
         ),
         ("account/usage/read", json!({})),
         ("account/workspaceMessages/read", json!({})),
+        ("app/installed", json!({})),
         ("app/list", json!({})),
+        ("app/read", json!({"appIds": []})),
         ("command/exec", json!({"command": []})),
         (
             "command/exec/resize",

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -37,11 +37,11 @@ pub enum Account {
     #[serde(rename = "amazonBedrock")]
     AmazonBedrock {
         #[serde(
-            rename = "credentialSource",
+            rename = "usesCodexManagedCredentials",
             default,
             skip_serializing_if = "Option::is_none"
         )]
-        credential_source: Option<Value>,
+        uses_codex_managed_credentials: Option<bool>,
     },
 }
 
@@ -182,14 +182,6 @@ pub struct AgentMessageDeltaNotification {
 #[serde(transparent)]
 pub struct AgentPath(pub String);
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum AmazonBedrockCredentialSource {
-    #[serde(rename = "codexManaged")]
-    CodexManaged,
-    #[serde(rename = "awsManaged")]
-    AwsManaged,
-}
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AnalyticsConfig {
@@ -309,12 +301,6 @@ pub struct AppMetadata {
         skip_serializing_if = "Option::is_none"
     )]
     pub first_party_requires_install: Option<bool>,
-    #[serde(
-        rename = "firstPartyType",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub first_party_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub review: Option<AppReview>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -427,6 +413,17 @@ pub enum AppTemplateUnavailableReason {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct AppToolSummary {
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApplyPatchApprovalParams {
     #[serde(rename = "callId", default)]
     pub call_id: String,
@@ -459,6 +456,26 @@ pub enum ApprovalsReviewer {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct AppsInstalledParams {
+    #[serde(
+        rename = "forceRefresh",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub force_refresh: Option<bool>,
+    #[serde(rename = "threadId", default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppsInstalledResponse {
+    #[serde(default)]
+    pub apps: Vec<InstalledApp>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AppsListParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
@@ -485,6 +502,28 @@ pub struct AppsListResponse {
         skip_serializing_if = "Option::is_none"
     )]
     pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppsReadParams {
+    #[serde(rename = "appIds", default)]
+    pub app_ids: Vec<String>,
+    #[serde(
+        rename = "includeTools",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub include_tools: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppsReadResponse {
+    #[serde(default)]
+    pub apps: Vec<ConnectorMetadata>,
+    #[serde(rename = "missingAppIds", default)]
+    pub missing_app_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1246,6 +1285,12 @@ pub struct ConfigRequirements {
     )]
     pub allow_appshots: Option<bool>,
     #[serde(
+        rename = "allowLoginShell",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allow_login_shell: Option<bool>,
+    #[serde(
         rename = "allowManagedHooksOnly",
         default,
         skip_serializing_if = "Option::is_none"
@@ -1288,6 +1333,12 @@ pub struct ConfigRequirements {
     )]
     pub allowed_windows_sandbox_implementations: Option<Vec<WindowsSandboxSetupMode>>,
     #[serde(
+        rename = "checkForUpdateOnStartup",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub check_for_update_on_startup: Option<bool>,
+    #[serde(
         rename = "computerUse",
         default,
         skip_serializing_if = "Option::is_none"
@@ -1312,7 +1363,29 @@ pub struct ConfigRequirements {
     )]
     pub feature_requirements: Option<std::collections::BTreeMap<String, bool>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub feedback: Option<FeedbackRequirements>,
+    #[serde(rename = "logDir", default, skip_serializing_if = "Option::is_none")]
+    pub log_dir: Option<String>,
+    #[serde(
+        rename = "modelCatalogJson",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub model_catalog_json: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub models: Option<ModelsRequirements>,
+    #[serde(
+        rename = "sqliteHome",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sqlite_home: Option<String>,
+    #[serde(
+        rename = "windowsSandboxPrivateDesktop",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub windows_sandbox_private_desktop: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1369,6 +1442,49 @@ pub struct ConfigWriteResponse {
     pub status: WriteStatus,
     #[serde(default)]
     pub version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectorMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(
+        rename = "distributionChannel",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub distribution_channel: Option<String>,
+    #[serde(rename = "iconUrl", default, skip_serializing_if = "Option::is_none")]
+    pub icon_url: Option<String>,
+    #[serde(
+        rename = "iconUrlDark",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub icon_url_dark: Option<String>,
+    #[serde(default)]
+    pub id: String,
+    #[serde(
+        rename = "installUrl",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub install_url: Option<String>,
+    #[serde(default)]
+    pub name: String,
+    #[serde(
+        rename = "pluginDisplayNames",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub plugin_display_names: Option<Vec<String>>,
+    #[serde(
+        rename = "toolSummaries",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub tool_summaries: Option<Vec<AppToolSummary>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -1437,6 +1553,11 @@ pub enum DynamicToolCallOutputContentItem {
     InputImage {
         #[serde(rename = "imageUrl")]
         image_url: String,
+    },
+    #[serde(rename = "inputAudio")]
+    InputAudio {
+        #[serde(rename = "audioUrl")]
+        audio_url: String,
     },
 }
 
@@ -1615,6 +1736,18 @@ pub struct ExternalAgentConfigDetectParams {
     )]
     pub include_home: Option<bool>,
     #[serde(
+        rename = "maxSessionAgeDays",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub max_session_age_days: Option<i64>,
+    #[serde(
+        rename = "maxSessions",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub max_sessions: Option<i64>,
+    #[serde(
         rename = "migrationSource",
         default,
         skip_serializing_if = "Option::is_none"
@@ -1709,6 +1842,12 @@ pub struct ExternalAgentConfigImportParams {
         skip_serializing_if = "Option::is_none"
     )]
     pub migration_source: Option<String>,
+    #[serde(
+        rename = "providerId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub provider_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
 }
@@ -1792,6 +1931,13 @@ pub struct ExternalAgentImportedConnectorCandidate {
 pub enum ExternalAgentImportedConnectorSource {
     #[serde(rename = "remoteMcpServersConfig")]
     RemoteMcpServersConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeedbackRequirements {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -2453,6 +2599,8 @@ pub enum HookEventName {
     PostCompact,
     #[serde(rename = "sessionStart")]
     SessionStart,
+    #[serde(rename = "sessionEnd")]
+    SessionEnd,
     #[serde(rename = "userPromptSubmit")]
     UserPromptSubmit,
     #[serde(rename = "subagentStart")]
@@ -2484,6 +2632,12 @@ pub enum HookHandlerType {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HookMetadata {
+    #[serde(
+        rename = "additionalContextLimit",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub additional_context_limit: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
     #[serde(rename = "currentHash", default)]
@@ -2771,6 +2925,25 @@ pub enum InputModality {
     Text,
     #[serde(rename = "image")]
     Image,
+    #[serde(rename = "audio")]
+    Audio,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstalledApp {
+    #[serde(default)]
+    pub callable: bool,
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub id: String,
+    #[serde(
+        rename = "runtimeName",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub runtime_name: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -4434,6 +4607,12 @@ pub struct PluginListParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cwds: Option<Vec<AbsolutePathBuf>>,
     #[serde(
+        rename = "forceRefetch",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub force_refetch: Option<bool>,
+    #[serde(
         rename = "marketplaceKinds",
         default,
         skip_serializing_if = "Option::is_none"
@@ -4703,6 +4882,8 @@ pub enum PluginShareUpdateDiscoverability {
     UNLISTED,
     #[serde(rename = "PRIVATE")]
     PRIVATE,
+    #[serde(rename = "LISTED")]
+    LISTED,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -4799,6 +4980,12 @@ pub struct PluginSummary {
         skip_serializing_if = "Option::is_none"
     )]
     pub local_version: Option<String>,
+    #[serde(
+        rename = "mustShowInstallationInterstitial",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub must_show_installation_interstitial: Option<bool>,
     #[serde(default)]
     pub name: String,
     #[serde(
@@ -5188,7 +5375,7 @@ pub enum ReviewDecision {
         network_policy_amendment: NetworkPolicyAmendment,
     },
     #[serde(rename = "denied")]
-    Denied,
+    Denied { rejection: String },
     #[serde(rename = "timed_out")]
     TimedOut,
     #[serde(rename = "abort")]
@@ -5765,6 +5952,8 @@ pub struct Thread {
     pub git_info: Option<GitInfo>,
     #[serde(default)]
     pub id: String,
+    #[serde(rename = "isPinned", default, skip_serializing_if = "Option::is_none")]
+    pub is_pinned: Option<bool>,
     #[serde(rename = "modelProvider", default)]
     pub model_provider: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6342,6 +6531,8 @@ pub struct ThreadListParams {
     pub cursor: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cwd: Option<ThreadListCwdFilter>,
+    #[serde(rename = "isPinned", default, skip_serializing_if = "Option::is_none")]
+    pub is_pinned: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<i64>,
     #[serde(
@@ -6435,6 +6626,8 @@ pub struct ThreadMetadataGitInfoUpdateParams {
 pub struct ThreadMetadataUpdateParams {
     #[serde(rename = "gitInfo", default, skip_serializing_if = "Option::is_none")]
     pub git_info: Option<ThreadMetadataGitInfoUpdateParams>,
+    #[serde(rename = "isPinned", default, skip_serializing_if = "Option::is_none")]
+    pub is_pinned: Option<bool>,
     #[serde(rename = "threadId", default)]
     pub thread_id: String,
 }
@@ -7392,6 +7585,13 @@ pub enum UserInput {
     LocalImage {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         detail: Option<ImageDetail>,
+        path: String,
+    },
+    Audio {
+        url: String,
+    },
+    #[serde(rename = "localAudio")]
+    LocalAudio {
         path: String,
     },
     Skill {

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -1076,6 +1076,30 @@
             },
             "method": {
               "enum": [
+                "app/read"
+              ],
+              "title": "App/readRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/AppsReadParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "App/readRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
                 "app/list"
               ],
               "title": "App/listRequestMethod",
@@ -1091,6 +1115,30 @@
             "params"
           ],
           "title": "App/listRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
+                "app/installed"
+              ],
+              "title": "App/installedRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/AppsInstalledParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "App/installedRequest",
           "type": "object"
         },
         {
@@ -4081,11 +4129,26 @@
           "type": "object"
         },
         {
+          "additionalProperties": false,
           "description": "User has denied this command and the agent should not execute it, but it should continue the session and try something else.",
-          "enum": [
+          "properties": {
+            "denied": {
+              "properties": {
+                "rejection": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "rejection"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
             "denied"
           ],
-          "type": "string"
+          "title": "DeniedReviewDecision",
+          "type": "object"
         },
         {
           "description": "Automatic approval review timed out before reaching a decision.",
@@ -5973,20 +6036,16 @@
           },
           {
             "properties": {
-              "credentialSource": {
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/v2/AmazonBedrockCredentialSource"
-                  }
-                ],
-                "default": "awsManaged"
-              },
               "type": {
                 "enum": [
                   "amazonBedrock"
                 ],
                 "title": "AmazonBedrockAccountType",
                 "type": "string"
+              },
+              "usesCodexManagedCredentials": {
+                "default": false,
+                "type": "boolean"
               }
             },
             "required": [
@@ -6300,13 +6359,6 @@
       "AgentPath": {
         "type": "string"
       },
-      "AmazonBedrockCredentialSource": {
-        "enum": [
-          "codexManaged",
-          "awsManaged"
-        ],
-        "type": "string"
-      },
       "AnalyticsConfig": {
         "additionalProperties": true,
         "properties": {
@@ -6567,12 +6619,6 @@
               "null"
             ]
           },
-          "firstPartyType": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "review": {
             "anyOf": [
               {
@@ -6801,6 +6847,28 @@
         },
         "type": "object"
       },
+      "AppToolSummary": {
+        "description": "EXPERIMENTAL - metadata returned by app/read.",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "description",
+          "name"
+        ],
+        "type": "object"
+      },
       "AppToolsConfig": {
         "type": "object"
       },
@@ -6866,6 +6934,42 @@
         },
         "type": "object"
       },
+      "AppsInstalledParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "Read the committed installed connector runtime snapshot.",
+        "properties": {
+          "forceRefresh": {
+            "description": "When true and Apps are permitted, refresh and publish the hosted connector runtime tool snapshot first.",
+            "type": "boolean"
+          },
+          "threadId": {
+            "description": "Optional loaded thread id used to evaluate effective app configuration.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "AppsInstalledParams",
+        "type": "object"
+      },
+      "AppsInstalledResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "The installed connectors in one committed runtime snapshot.",
+        "properties": {
+          "apps": {
+            "items": {
+              "$ref": "#/definitions/v2/InstalledApp"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "apps"
+        ],
+        "title": "AppsInstalledResponse",
+        "type": "object"
+      },
       "AppsListParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "description": "EXPERIMENTAL - list available apps/connectors.",
@@ -6923,6 +7027,52 @@
           "data"
         ],
         "title": "AppsListResponse",
+        "type": "object"
+      },
+      "AppsReadParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "EXPERIMENTAL - read metadata for specific apps/connectors.",
+        "properties": {
+          "appIds": {
+            "description": "App ids to read. The server accepts at most 100 ids and deduplicates repeated ids while preserving their first-request order.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "includeTools": {
+            "description": "When true, include display-only public tool summaries in the returned metadata.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "appIds"
+        ],
+        "title": "AppsReadParams",
+        "type": "object"
+      },
+      "AppsReadResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "EXPERIMENTAL - app/read response.",
+        "properties": {
+          "apps": {
+            "items": {
+              "$ref": "#/definitions/v2/ConnectorMetadata"
+            },
+            "type": "array"
+          },
+          "missingAppIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "apps",
+          "missingAppIds"
+        ],
+        "title": "AppsReadResponse",
         "type": "object"
       },
       "AskForApproval": {
@@ -7274,6 +7424,14 @@
             "type": "object"
           }
         ]
+      },
+      "CodexResponseHandoffMode": {
+        "enum": [
+          "thinking",
+          "commentary",
+          "bemTags"
+        ],
+        "type": "string"
       },
       "CollabAgentState": {
         "properties": {
@@ -8378,6 +8536,12 @@
               "null"
             ]
           },
+          "allowLoginShell": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "allowManagedHooksOnly": {
             "type": [
               "boolean",
@@ -8435,6 +8599,12 @@
               "null"
             ]
           },
+          "checkForUpdateOnStartup": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "computerUse": {
             "anyOf": [
               {
@@ -8470,6 +8640,28 @@
               "null"
             ]
           },
+          "feedback": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/FeedbackRequirements"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "logDir": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "modelCatalogJson": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "models": {
             "anyOf": [
               {
@@ -8478,6 +8670,18 @@
               {
                 "type": "null"
               }
+            ]
+          },
+          "sqliteHome": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "windowsSandboxPrivateDesktop": {
+            "type": [
+              "boolean",
+              "null"
             ]
           }
         },
@@ -8612,6 +8816,15 @@
         "oneOf": [
           {
             "properties": {
+              "additionalContextLimit": {
+                "description": "Approximate token threshold for spilling this hook's `additionalContext` to disk. `null` uses 2,500 tokens; `0` disables spilling for this hook. The threshold is evaluated against the original context; a spilled preview also includes recovery metadata.",
+                "format": "uint",
+                "minimum": 0.0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
               "async": {
                 "type": "boolean"
               },
@@ -8705,6 +8918,68 @@
         },
         "required": [
           "hooks"
+        ],
+        "type": "object"
+      },
+      "ConnectorMetadata": {
+        "description": "EXPERIMENTAL - metadata returned by app/read.",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "distributionChannel": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "iconUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "iconUrlDark": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "installUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "pluginDisplayNames": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "toolSummaries": {
+            "items": {
+              "$ref": "#/definitions/v2/AppToolSummary"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "name"
         ],
         "type": "object"
       },
@@ -8824,6 +9099,26 @@
               "type"
             ],
             "title": "InputImageContentItem",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "audio_url": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "input_audio"
+                ],
+                "title": "InputAudioContentItemType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "audio_url",
+              "type"
+            ],
+            "title": "InputAudioContentItem",
             "type": "object"
           },
           {
@@ -8956,6 +9251,26 @@
               "type"
             ],
             "title": "InputImageDynamicToolCallOutputContentItem",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "audioUrl": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "inputAudio"
+                ],
+                "title": "InputAudioDynamicToolCallOutputContentItemType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "audioUrl",
+              "type"
+            ],
+            "title": "InputAudioDynamicToolCallOutputContentItem",
             "type": "object"
           }
         ]
@@ -9302,6 +9617,24 @@
             "description": "If true, include detection under the user's home directory.",
             "type": "boolean"
           },
+          "maxSessionAgeDays": {
+            "description": "Maximum age in days for detected sessions. Missing values use the default limit.",
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "maxSessions": {
+            "description": "Maximum number of sessions to detect. Missing values use the default limit.",
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "migrationSource": {
             "description": "Optional migration-source selector. Missing or unrecognized values use the default source.",
             "type": [
@@ -9497,6 +9830,13 @@
               "null"
             ]
           },
+          "providerId": {
+            "description": "Opaque provider identifier supplied by the caller for analytics attribution. This does not select the migration source.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "source": {
             "description": "Optional identifier for the product that initiated the import.",
             "type": [
@@ -9642,6 +9982,17 @@
           "remoteMcpServersConfig"
         ],
         "type": "string"
+      },
+      "FeedbackRequirements": {
+        "properties": {
+          "enabled": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
       },
       "FeedbackUploadParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -10444,6 +10795,26 @@
           },
           {
             "properties": {
+              "audio_url": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "input_audio"
+                ],
+                "title": "InputAudioFunctionCallOutputContentItemType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "audio_url",
+              "type"
+            ],
+            "title": "InputAudioFunctionCallOutputContentItem",
+            "type": "object"
+          },
+          {
+            "properties": {
               "encrypted_content": {
                 "type": "string"
               },
@@ -10940,6 +11311,7 @@
           "preCompact",
           "postCompact",
           "sessionStart",
+          "sessionEnd",
           "userPromptSubmit",
           "subagentStart",
           "subagentStop",
@@ -10964,6 +11336,15 @@
       },
       "HookMetadata": {
         "properties": {
+          "additionalContextLimit": {
+            "description": "Configured `additionalContext` spill threshold. `null` uses 2,500 tokens; `0` disables spilling.",
+            "format": "uint",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "command": {
             "type": [
               "string",
@@ -11323,8 +11704,44 @@
               "image"
             ],
             "type": "string"
+          },
+          {
+            "description": "Audio attachments included in user turns.",
+            "enum": [
+              "audio"
+            ],
+            "type": "string"
           }
         ]
+      },
+      "InstalledApp": {
+        "description": "Installed connector runtime state.",
+        "properties": {
+          "callable": {
+            "description": "Whether the connector is enabled and has a non-synthetic, model-visible tool allowed by effective MCP and app/tool policy in the committed runtime snapshot.",
+            "type": "boolean"
+          },
+          "enabled": {
+            "description": "Effective enabled state after applying global, workspace, local, and managed configuration at read time.",
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "runtimeName": {
+            "description": "Best-effort name carried by the runtime tool catalog. Canonical app metadata remains owned by `app/read`.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "callable",
+          "enabled",
+          "id"
+        ],
+        "type": "object"
       },
       "InternalChatMessageMetadataPassthrough": {
         "description": "Internal Responses API passthrough metadata copied into underlying chat messages.\n\nResponses API strongly types this payload. Do not modify it without first getting API approval and making the corresponding Responses API change.",
@@ -11902,6 +12319,13 @@
             "type": "array"
           },
           "PreToolUse": {
+            "items": {
+              "$ref": "#/definitions/v2/ConfiguredHookMatcherGroup"
+            },
+            "type": "array"
+          },
+          "SessionEnd": {
+            "default": [],
             "items": {
               "$ref": "#/definitions/v2/ConfiguredHookMatcherGroup"
             },
@@ -13351,6 +13775,9 @@
           }
         ]
       },
+      "PathUri": {
+        "type": "string"
+      },
       "PermissionProfileListParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
@@ -13884,6 +14311,10 @@
               "null"
             ]
           },
+          "forceRefetch": {
+            "description": "Whether the client requests a fresh remote plugin catalog fetch.",
+            "type": "boolean"
+          },
           "marketplaceKinds": {
             "description": "Optional marketplace kind filter. When omitted, only local marketplaces are queried, plus the default remote catalog when enabled by feature flag.",
             "items": {
@@ -14308,7 +14739,8 @@
       "PluginShareUpdateDiscoverability": {
         "enum": [
           "UNLISTED",
-          "PRIVATE"
+          "PRIVATE",
+          "LISTED"
         ],
         "type": "string"
       },
@@ -14561,6 +14993,13 @@
             "description": "Version of the locally materialized plugin package when available.",
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "mustShowInstallationInterstitial": {
+            "default": null,
+            "type": [
+              "boolean",
               "null"
             ]
           },
@@ -17521,6 +17960,11 @@
             "description": "Identifier for this thread. Codex-generated thread IDs are UUIDv7.",
             "type": "string"
           },
+          "isPinned": {
+            "default": false,
+            "description": "Whether the thread has been pinned by the user.",
+            "type": "boolean"
+          },
           "modelProvider": {
             "description": "Model provider used for this thread (for example, 'openai').",
             "type": "string"
@@ -18965,6 +19409,13 @@
             ],
             "description": "Optional cwd filter or filters; when set, only threads whose session cwd exactly matches one of these paths are returned."
           },
+          "isPinned": {
+            "description": "Optional pinned filter; when set, only threads matching this value are returned.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "limit": {
             "description": "Optional page size; defaults to a reasonable server-side value.",
             "format": "uint32",
@@ -19155,6 +19606,13 @@
             ],
             "description": "Patch the stored Git metadata for this thread. Omit a field to leave it unchanged, set it to `null` to clear it, or provide a string to replace the stored value."
           },
+          "isPinned": {
+            "description": "Patch whether this thread is pinned. Omit to leave the stored value unchanged.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "threadId": {
             "type": "string"
           }
@@ -19301,6 +19759,22 @@
           "threadId"
         ],
         "title": "ThreadRealtimeErrorNotification",
+        "type": "object"
+      },
+      "ThreadRealtimeInitialItem": {
+        "description": "EXPERIMENTAL - role-bearing text item included when a realtime V3 session starts.",
+        "properties": {
+          "role": {
+            "$ref": "#/definitions/v2/ConversationTextRole"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "role",
+          "text"
+        ],
         "type": "object"
       },
       "ThreadRealtimeItemAddedNotification": {
@@ -21001,6 +21475,46 @@
               "type"
             ],
             "title": "LocalImageUserInput",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "audio"
+                ],
+                "title": "AudioUserInputType",
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "url"
+            ],
+            "title": "AudioUserInput",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "path": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "localAudio"
+                ],
+                "title": "LocalAudioUserInputType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "path",
+              "type"
+            ],
+            "title": "LocalAudioUserInput",
             "type": "object"
           },
           {

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -52,20 +52,16 @@
         },
         {
           "properties": {
-            "credentialSource": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/AmazonBedrockCredentialSource"
-                }
-              ],
-              "default": "awsManaged"
-            },
             "type": {
               "enum": [
                 "amazonBedrock"
               ],
               "title": "AmazonBedrockAccountType",
               "type": "string"
+            },
+            "usesCodexManagedCredentials": {
+              "default": false,
+              "type": "boolean"
             }
           },
           "required": [
@@ -379,13 +375,6 @@
     "AgentPath": {
       "type": "string"
     },
-    "AmazonBedrockCredentialSource": {
-      "enum": [
-        "codexManaged",
-        "awsManaged"
-      ],
-      "type": "string"
-    },
     "AnalyticsConfig": {
       "additionalProperties": true,
       "properties": {
@@ -646,12 +635,6 @@
             "null"
           ]
         },
-        "firstPartyType": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "review": {
           "anyOf": [
             {
@@ -880,6 +863,28 @@
       },
       "type": "object"
     },
+    "AppToolSummary": {
+      "description": "EXPERIMENTAL - metadata returned by app/read.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "description",
+        "name"
+      ],
+      "type": "object"
+    },
     "AppToolsConfig": {
       "type": "object"
     },
@@ -945,6 +950,42 @@
       },
       "type": "object"
     },
+    "AppsInstalledParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "Read the committed installed connector runtime snapshot.",
+      "properties": {
+        "forceRefresh": {
+          "description": "When true and Apps are permitted, refresh and publish the hosted connector runtime tool snapshot first.",
+          "type": "boolean"
+        },
+        "threadId": {
+          "description": "Optional loaded thread id used to evaluate effective app configuration.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "title": "AppsInstalledParams",
+      "type": "object"
+    },
+    "AppsInstalledResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "The installed connectors in one committed runtime snapshot.",
+      "properties": {
+        "apps": {
+          "items": {
+            "$ref": "#/definitions/InstalledApp"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "apps"
+      ],
+      "title": "AppsInstalledResponse",
+      "type": "object"
+    },
     "AppsListParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "description": "EXPERIMENTAL - list available apps/connectors.",
@@ -1002,6 +1043,52 @@
         "data"
       ],
       "title": "AppsListResponse",
+      "type": "object"
+    },
+    "AppsReadParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "EXPERIMENTAL - read metadata for specific apps/connectors.",
+      "properties": {
+        "appIds": {
+          "description": "App ids to read. The server accepts at most 100 ids and deduplicates repeated ids while preserving their first-request order.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "includeTools": {
+          "description": "When true, include display-only public tool summaries in the returned metadata.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "appIds"
+      ],
+      "title": "AppsReadParams",
+      "type": "object"
+    },
+    "AppsReadResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "EXPERIMENTAL - app/read response.",
+      "properties": {
+        "apps": {
+          "items": {
+            "$ref": "#/definitions/ConnectorMetadata"
+          },
+          "type": "array"
+        },
+        "missingAppIds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "apps",
+        "missingAppIds"
+      ],
+      "title": "AppsReadResponse",
       "type": "object"
     },
     "AskForApproval": {
@@ -2114,6 +2201,30 @@
             },
             "method": {
               "enum": [
+                "app/read"
+              ],
+              "title": "App/readRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/AppsReadParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "App/readRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
                 "app/list"
               ],
               "title": "App/listRequestMethod",
@@ -2129,6 +2240,30 @@
             "params"
           ],
           "title": "App/listRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
+                "app/installed"
+              ],
+              "title": "App/installedRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/AppsInstalledParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "App/installedRequest",
           "type": "object"
         },
         {
@@ -3468,6 +3603,14 @@
         }
       ]
     },
+    "CodexResponseHandoffMode": {
+      "enum": [
+        "thinking",
+        "commentary",
+        "bemTags"
+      ],
+      "type": "string"
+    },
     "CollabAgentState": {
       "properties": {
         "message": {
@@ -4571,6 +4714,12 @@
             "null"
           ]
         },
+        "allowLoginShell": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "allowManagedHooksOnly": {
           "type": [
             "boolean",
@@ -4628,6 +4777,12 @@
             "null"
           ]
         },
+        "checkForUpdateOnStartup": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "computerUse": {
           "anyOf": [
             {
@@ -4663,6 +4818,28 @@
             "null"
           ]
         },
+        "feedback": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FeedbackRequirements"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "logDir": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "modelCatalogJson": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "models": {
           "anyOf": [
             {
@@ -4671,6 +4848,18 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "sqliteHome": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "windowsSandboxPrivateDesktop": {
+          "type": [
+            "boolean",
+            "null"
           ]
         }
       },
@@ -4805,6 +4994,15 @@
       "oneOf": [
         {
           "properties": {
+            "additionalContextLimit": {
+              "description": "Approximate token threshold for spilling this hook's `additionalContext` to disk. `null` uses 2,500 tokens; `0` disables spilling for this hook. The threshold is evaluated against the original context; a spilled preview also includes recovery metadata.",
+              "format": "uint",
+              "minimum": 0.0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
             "async": {
               "type": "boolean"
             },
@@ -4898,6 +5096,68 @@
       },
       "required": [
         "hooks"
+      ],
+      "type": "object"
+    },
+    "ConnectorMetadata": {
+      "description": "EXPERIMENTAL - metadata returned by app/read.",
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "distributionChannel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "iconUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "iconUrlDark": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "installUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "pluginDisplayNames": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "toolSummaries": {
+          "items": {
+            "$ref": "#/definitions/AppToolSummary"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "name"
       ],
       "type": "object"
     },
@@ -5017,6 +5277,26 @@
             "type"
           ],
           "title": "InputImageContentItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "audio_url": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "input_audio"
+              ],
+              "title": "InputAudioContentItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "audio_url",
+            "type"
+          ],
+          "title": "InputAudioContentItem",
           "type": "object"
         },
         {
@@ -5149,6 +5429,26 @@
             "type"
           ],
           "title": "InputImageDynamicToolCallOutputContentItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "audioUrl": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "inputAudio"
+              ],
+              "title": "InputAudioDynamicToolCallOutputContentItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "audioUrl",
+            "type"
+          ],
+          "title": "InputAudioDynamicToolCallOutputContentItem",
           "type": "object"
         }
       ]
@@ -5495,6 +5795,24 @@
           "description": "If true, include detection under the user's home directory.",
           "type": "boolean"
         },
+        "maxSessionAgeDays": {
+          "description": "Maximum age in days for detected sessions. Missing values use the default limit.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "maxSessions": {
+          "description": "Maximum number of sessions to detect. Missing values use the default limit.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "migrationSource": {
           "description": "Optional migration-source selector. Missing or unrecognized values use the default source.",
           "type": [
@@ -5690,6 +6008,13 @@
             "null"
           ]
         },
+        "providerId": {
+          "description": "Opaque provider identifier supplied by the caller for analytics attribution. This does not select the migration source.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "source": {
           "description": "Optional identifier for the product that initiated the import.",
           "type": [
@@ -5835,6 +6160,17 @@
         "remoteMcpServersConfig"
       ],
       "type": "string"
+    },
+    "FeedbackRequirements": {
+      "properties": {
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
     },
     "FeedbackUploadParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
@@ -6637,6 +6973,26 @@
         },
         {
           "properties": {
+            "audio_url": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "input_audio"
+              ],
+              "title": "InputAudioFunctionCallOutputContentItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "audio_url",
+            "type"
+          ],
+          "title": "InputAudioFunctionCallOutputContentItem",
+          "type": "object"
+        },
+        {
+          "properties": {
             "encrypted_content": {
               "type": "string"
             },
@@ -7244,6 +7600,7 @@
         "preCompact",
         "postCompact",
         "sessionStart",
+        "sessionEnd",
         "userPromptSubmit",
         "subagentStart",
         "subagentStop",
@@ -7268,6 +7625,15 @@
     },
     "HookMetadata": {
       "properties": {
+        "additionalContextLimit": {
+          "description": "Configured `additionalContext` spill threshold. `null` uses 2,500 tokens; `0` disables spilling.",
+          "format": "uint",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "command": {
           "type": [
             "string",
@@ -7680,8 +8046,44 @@
             "image"
           ],
           "type": "string"
+        },
+        {
+          "description": "Audio attachments included in user turns.",
+          "enum": [
+            "audio"
+          ],
+          "type": "string"
         }
       ]
+    },
+    "InstalledApp": {
+      "description": "Installed connector runtime state.",
+      "properties": {
+        "callable": {
+          "description": "Whether the connector is enabled and has a non-synthetic, model-visible tool allowed by effective MCP and app/tool policy in the committed runtime snapshot.",
+          "type": "boolean"
+        },
+        "enabled": {
+          "description": "Effective enabled state after applying global, workspace, local, and managed configuration at read time.",
+          "type": "boolean"
+        },
+        "id": {
+          "type": "string"
+        },
+        "runtimeName": {
+          "description": "Best-effort name carried by the runtime tool catalog. Canonical app metadata remains owned by `app/read`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "callable",
+        "enabled",
+        "id"
+      ],
+      "type": "object"
     },
     "InternalChatMessageMetadataPassthrough": {
       "description": "Internal Responses API passthrough metadata copied into underlying chat messages.\n\nResponses API strongly types this payload. Do not modify it without first getting API approval and making the corresponding Responses API change.",
@@ -8259,6 +8661,13 @@
           "type": "array"
         },
         "PreToolUse": {
+          "items": {
+            "$ref": "#/definitions/ConfiguredHookMatcherGroup"
+          },
+          "type": "array"
+        },
+        "SessionEnd": {
+          "default": [],
           "items": {
             "$ref": "#/definitions/ConfiguredHookMatcherGroup"
           },
@@ -9708,6 +10117,9 @@
         }
       ]
     },
+    "PathUri": {
+      "type": "string"
+    },
     "PermissionProfileListParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
@@ -10241,6 +10653,10 @@
             "null"
           ]
         },
+        "forceRefetch": {
+          "description": "Whether the client requests a fresh remote plugin catalog fetch.",
+          "type": "boolean"
+        },
         "marketplaceKinds": {
           "description": "Optional marketplace kind filter. When omitted, only local marketplaces are queried, plus the default remote catalog when enabled by feature flag.",
           "items": {
@@ -10665,7 +11081,8 @@
     "PluginShareUpdateDiscoverability": {
       "enum": [
         "UNLISTED",
-        "PRIVATE"
+        "PRIVATE",
+        "LISTED"
       ],
       "type": "string"
     },
@@ -10918,6 +11335,13 @@
           "description": "Version of the locally materialized plugin package when available.",
           "type": [
             "string",
+            "null"
+          ]
+        },
+        "mustShowInstallationInterstitial": {
+          "default": null,
+          "type": [
+            "boolean",
             "null"
           ]
         },
@@ -15300,6 +15724,11 @@
           "description": "Identifier for this thread. Codex-generated thread IDs are UUIDv7.",
           "type": "string"
         },
+        "isPinned": {
+          "default": false,
+          "description": "Whether the thread has been pinned by the user.",
+          "type": "boolean"
+        },
         "modelProvider": {
           "description": "Model provider used for this thread (for example, 'openai').",
           "type": "string"
@@ -16744,6 +17173,13 @@
           ],
           "description": "Optional cwd filter or filters; when set, only threads whose session cwd exactly matches one of these paths are returned."
         },
+        "isPinned": {
+          "description": "Optional pinned filter; when set, only threads matching this value are returned.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "limit": {
           "description": "Optional page size; defaults to a reasonable server-side value.",
           "format": "uint32",
@@ -16934,6 +17370,13 @@
           ],
           "description": "Patch the stored Git metadata for this thread. Omit a field to leave it unchanged, set it to `null` to clear it, or provide a string to replace the stored value."
         },
+        "isPinned": {
+          "description": "Patch whether this thread is pinned. Omit to leave the stored value unchanged.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "threadId": {
           "type": "string"
         }
@@ -17080,6 +17523,22 @@
         "threadId"
       ],
       "title": "ThreadRealtimeErrorNotification",
+      "type": "object"
+    },
+    "ThreadRealtimeInitialItem": {
+      "description": "EXPERIMENTAL - role-bearing text item included when a realtime V3 session starts.",
+      "properties": {
+        "role": {
+          "$ref": "#/definitions/ConversationTextRole"
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "role",
+        "text"
+      ],
       "type": "object"
     },
     "ThreadRealtimeItemAddedNotification": {
@@ -18780,6 +19239,46 @@
             "type"
           ],
           "title": "LocalImageUserInput",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "audio"
+              ],
+              "title": "AudioUserInputType",
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "url"
+          ],
+          "title": "AudioUserInput",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "localAudio"
+              ],
+              "title": "LocalAudioUserInputType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "type"
+          ],
+          "title": "LocalAudioUserInput",
           "type": "object"
         },
         {


### PR DESCRIPTION
Fixes #199.

Refreshes both app-server schema snapshots from `openai/codex@main` (byte-identical to upstream again per `scripts/check_codex_schema_drift.py`) and regenerates typed structs/samples via `scripts/codegen_protocol.py`.

## Changes

- **New client requests modeled**: `app/read` and `app/installed` — method constants `APP_READ`/`APP_INSTALLED`, generated `AppsReadParams/Response`, `AppsInstalledParams/Response`, plus `ConnectorMetadata`, `InstalledApp`, `AppToolSummary`.
- **New generated definitions**: `CodexResponseHandoffMode`, `FeedbackRequirements`, `PathUri`, `ThreadRealtimeInitialItem`; additive fields across `Account`, `ConfigRequirements`, hooks/plugin/content-item types.
- **Breaking**: `ReviewDecision::Denied` is now a struct variant with a required `rejection: String` (wire shape `{"decision":{"denied":{"rejection":...}}}`); the `denied()` constructors on `ExecCommandApprovalResponse`/`ApplyPatchApprovalResponse` now take the rejection message.
- **Breaking**: `AmazonBedrockCredentialSource` removed (removed upstream).
- Version bump to 0.143.5 with changelog entry; root README version string updated.

## Verification

- `check_codex_schema_drift.py`: both snapshots byte-identical to upstream ✅
- `cargo run --example schema_coverage`: 169/169 modeled, 100% samples validate ✅
- `cargo test --workspace`: all passing ✅
- `cargo clippy --workspace --all-targets`: clean ✅