### PR TITLE
claude-codes 2.1.162: wrap interrupt in control_request envelope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.161"
+version = "2.1.162"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.161`, tested against Claude CLI `2.1.205`.
+- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.162`, tested against Claude CLI `2.1.205`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.143.4`, tested against Codex CLI `0.143.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.162] - 2026-07-22
+
+### Fixed
+
+- **`ClaudeInput::interrupt()` now actually interrupts** (#218). It previously
+  serialized to a bare `{"subtype":"interrupt"}`, which the CLI silently
+  ignores (verified against 2.1.205 and 2.1.211) — the in-flight turn ran to
+  completion. It now emits the required `control_request` envelope
+  `{"type":"control_request","request_id":...,"request":{"subtype":"interrupt"}}`,
+  which the CLI acknowledges with a `control_response` and cancels the turn
+  immediately (verified live: ack in ~10ms, turn ends with
+  `result subtype=error_during_execution`).
+
+### Changed
+
+- **Breaking**: `ClaudeInput::interrupt(request_id)` now takes the unique
+  request id for the control envelope. `AsyncClient::interrupt()` /
+  `SyncClient::interrupt()` generate an `interrupt-<uuid>` id and now return
+  `Result<String>` (the id) so callers can correlate the CLI's
+  `control_response` ack.
+- **Breaking**: removed `SDKControlInterruptRequest` — its bare wire shape is
+  a no-op against the CLI. Use `ClaudeInput::interrupt(request_id)` or the new
+  `ControlRequestMessage::interrupt(request_id)` constructor instead.
+
+### Added
+
+- **`ControlRequestPayload::Interrupt`** variant and
+  **`ControlRequestMessage::interrupt(request_id)`** constructor (mirroring
+  `::initialize`), so the correctly-enveloped interrupt can be built typed.
+
 ## [2.1.161] - 2026-07-11
 
 ### Added

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.161"
+version = "2.1.162"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/src/client_async.rs
+++ b/claude-codes/src/client_async.rs
@@ -187,10 +187,15 @@ impl AsyncClient {
 
     /// Send an interrupt to gracefully stop the current response.
     ///
-    /// This writes `{ "subtype": "interrupt" }` to stdin, telling Claude
-    /// to stop without killing the session.
-    pub async fn interrupt(&mut self) -> Result<()> {
-        self.send(&ClaudeInput::interrupt()).await
+    /// This writes a `control_request` with subtype `interrupt` to stdin,
+    /// telling Claude to stop without killing the session. Returns the
+    /// generated `request_id`; the CLI acknowledges with a
+    /// `control_response` carrying the same id and ends the turn with a
+    /// `result` message.
+    pub async fn interrupt(&mut self) -> Result<String> {
+        let request_id = format!("interrupt-{}", Uuid::new_v4());
+        self.send(&ClaudeInput::interrupt(&request_id)).await?;
+        Ok(request_id)
     }
 
     /// Receive a single response from Claude.

--- a/claude-codes/src/client_sync.rs
+++ b/claude-codes/src/client_sync.rs
@@ -348,12 +348,16 @@ impl SyncClient {
 
     /// Send an interrupt to gracefully stop the current response.
     ///
-    /// This writes `{ "subtype": "interrupt" }` to stdin, telling Claude
-    /// to stop without killing the session.
-    pub fn interrupt(&mut self) -> Result<()> {
-        let input = ClaudeInput::interrupt();
+    /// This writes a `control_request` with subtype `interrupt` to stdin,
+    /// telling Claude to stop without killing the session. Returns the
+    /// generated `request_id`; the CLI acknowledges with a
+    /// `control_response` carrying the same id and ends the turn with a
+    /// `result` message.
+    pub fn interrupt(&mut self) -> Result<String> {
+        let request_id = format!("interrupt-{}", Uuid::new_v4());
+        let input = ClaudeInput::interrupt(&request_id);
         Protocol::write_sync(&mut self.stdin, &input)?;
-        Ok(())
+        Ok(request_id)
     }
 
     /// Check if tool approval protocol is enabled

--- a/claude-codes/src/io/claude_input.rs
+++ b/claude-codes/src/io/claude_input.rs
@@ -99,13 +99,21 @@ impl ClaudeInput {
         })
     }
 
-    /// Create an interrupt control message.
+    /// Create an interrupt control request.
     ///
-    /// Sends `{ "subtype": "interrupt" }` to the CLI subprocess's stdin,
+    /// Serializes to the `control_request` envelope the CLI requires:
+    /// `{"type":"control_request","request_id":...,"request":{"subtype":"interrupt"}}`,
     /// telling Claude to stop its current response and return control
-    /// without killing the session.
-    pub fn interrupt() -> Self {
-        ClaudeInput::Raw(serde_json::to_value(super::SDKControlInterruptRequest::new()).unwrap())
+    /// without killing the session. The CLI acknowledges with a
+    /// `control_response` carrying the same `request_id`.
+    ///
+    /// `request_id` must be unique per request; the clients generate
+    /// `interrupt-<uuid>` ids.
+    pub fn interrupt(request_id: impl Into<String>) -> Self {
+        ClaudeInput::ControlRequest(ControlRequest {
+            request_id: request_id.into(),
+            request: super::ControlRequestPayload::Interrupt,
+        })
     }
 
     /// Create a user message with an image and optional text
@@ -152,6 +160,19 @@ impl ClaudeInput {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_interrupt_serializes_to_control_request_envelope() {
+        let input = ClaudeInput::interrupt("interrupt-abc");
+        assert_eq!(
+            serde_json::to_value(&input).unwrap(),
+            serde_json::json!({
+                "type": "control_request",
+                "request_id": "interrupt-abc",
+                "request": {"subtype": "interrupt"}
+            })
+        );
+    }
 
     #[test]
     fn test_serialize_user_message() {

--- a/claude-codes/src/io/control.rs
+++ b/claude-codes/src/io/control.rs
@@ -241,6 +241,8 @@ pub enum ControlRequestPayload {
     McpMessage(McpMessageRequest),
     /// Initialize request (sent by SDK to CLI)
     Initialize(InitializeRequest),
+    /// Interrupt request (sent by SDK to CLI to stop the in-flight turn)
+    Interrupt,
 }
 
 /// A permission to grant for "remember this decision" functionality.
@@ -1068,49 +1070,6 @@ impl From<ControlResponse> for ControlResponseMessage {
     }
 }
 
-/// SDK control message to gracefully interrupt a running Claude session.
-///
-/// When written to the CLI subprocess's stdin, this tells Claude to stop its
-/// current response and return control to the caller without killing the session.
-///
-/// This corresponds to the TypeScript SDK's `SDKControlInterruptRequest` type
-/// and is distinct from closing or aborting the subprocess.
-///
-/// # Example
-///
-/// ```
-/// use claude_codes::SDKControlInterruptRequest;
-///
-/// let interrupt = SDKControlInterruptRequest::new();
-/// let json = serde_json::to_string(&interrupt).unwrap();
-/// assert_eq!(json, r#"{"subtype":"interrupt"}"#);
-/// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SDKControlInterruptRequest {
-    subtype: SDKControlInterruptSubtype,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-enum SDKControlInterruptSubtype {
-    #[serde(rename = "interrupt")]
-    Interrupt,
-}
-
-impl SDKControlInterruptRequest {
-    /// Create a new interrupt request.
-    pub fn new() -> Self {
-        SDKControlInterruptRequest {
-            subtype: SDKControlInterruptSubtype::Interrupt,
-        }
-    }
-}
-
-impl Default for SDKControlInterruptRequest {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Wrapper for outgoing control requests (includes type tag)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ControlRequestMessage {
@@ -1136,6 +1095,20 @@ impl ControlRequestMessage {
             message_type: "control_request".to_string(),
             request_id: request_id.into(),
             request: ControlRequestPayload::Initialize(InitializeRequest { hooks: Some(hooks) }),
+        }
+    }
+
+    /// Create an interrupt request to stop the in-flight turn.
+    ///
+    /// Serializes to the `control_request` envelope the CLI requires:
+    /// `{"type":"control_request","request_id":...,"request":{"subtype":"interrupt"}}`.
+    /// The CLI acknowledges with a `control_response` carrying the same
+    /// `request_id` and ends the turn with a `result` message.
+    pub fn interrupt(request_id: impl Into<String>) -> Self {
+        ControlRequestMessage {
+            message_type: "control_request".to_string(),
+            request_id: request_id.into(),
+            request: ControlRequestPayload::Interrupt,
         }
     }
 }
@@ -1327,6 +1300,29 @@ mod tests {
         assert!(json.contains("\"type\":\"control_request\""));
         assert!(json.contains("\"request_id\":\"init-1\""));
         assert!(json.contains("\"subtype\":\"initialize\""));
+    }
+
+    #[test]
+    fn test_control_request_message_interrupt_wire_shape() {
+        // The CLI silently ignores a bare {"subtype":"interrupt"}; it only
+        // acts on the full control_request envelope (verified against 2.1.211).
+        let msg = ControlRequestMessage::interrupt("interrupt-1");
+        assert_eq!(
+            serde_json::to_value(&msg).unwrap(),
+            serde_json::json!({
+                "type": "control_request",
+                "request_id": "interrupt-1",
+                "request": {"subtype": "interrupt"}
+            })
+        );
+    }
+
+    #[test]
+    fn test_interrupt_payload_roundtrip() {
+        let json = r#"{"subtype":"interrupt"}"#;
+        let payload: ControlRequestPayload = serde_json::from_str(json).unwrap();
+        assert!(matches!(payload, ControlRequestPayload::Interrupt));
+        assert_eq!(serde_json::to_string(&payload).unwrap(), json);
     }
 
     #[test]

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -144,9 +144,9 @@ pub use io::{
     ControlResponse, ControlResponseMessage, ControlResponsePayload, GetUsageResponse,
     HookCallbackRequest, InitializeRequest, McpMessageRequest, ModelScopedRateLimit, Permission,
     PermissionBehavior, PermissionDenial, PermissionDestination, PermissionModeName,
-    PermissionResult, PermissionRule, PermissionSuggestion, PermissionType,
-    SDKControlInterruptRequest, ToolCaller, ToolPermissionRequest, ToolUseBlock, UsageBehavior,
-    UsageBehaviors, UsageModelUsage, UsageRateLimitWindow, UsageRateLimits, UsageSession,
+    PermissionResult, PermissionRule, PermissionSuggestion, PermissionType, ToolCaller,
+    ToolPermissionRequest, ToolUseBlock, UsageBehavior, UsageBehaviors, UsageModelUsage,
+    UsageRateLimitWindow, UsageRateLimits, UsageSession,
 };
 
 // System message and assistant message types


### PR DESCRIPTION
Fixes #218.

`ClaudeInput::interrupt()` emitted a bare `{"subtype":"interrupt"}`, which the CLI silently ignores — interrupting was a no-op. The CLI requires the `control_request` envelope with a unique `request_id` (same as `initialize`/`can_use_tool`).

## Changes

- **`ControlRequestPayload::Interrupt`** variant — serializes to `{"subtype":"interrupt"}` under the envelope.
- **`ControlRequestMessage::interrupt(request_id)`** constructor, mirroring `::initialize`.
- **Breaking**: `ClaudeInput::interrupt(request_id)` now takes the request id and builds the typed `control_request` envelope.
- **Breaking**: `AsyncClient::interrupt()` / `SyncClient::interrupt()` generate an `interrupt-<uuid>` id and return `Result<String>` so callers can correlate the CLI's `control_response` ack.
- **Breaking**: removed `SDKControlInterruptRequest` — its wire shape is a no-op against the CLI.
- Version bump to 2.1.162 with changelog; README version string updated.

## Verification (live, CLI 2.1.205)

Drove the real CLI with `--print --verbose --input-format stream-json --output-format stream-json`, started a long counting turn, then:

| Sent mid-turn | Result |
|---|---|
| bare `{"subtype":"interrupt"}` (old encoding) | ignored — no ack, turn kept streaming |
| wrapped `control_request` (new encoding) | `control_response success` in ~10ms, turn cancelled with `result subtype=error_during_execution` |

Matches the reporter's findings against 2.1.211. Unit tests assert the exact wire shape; `cargo test -p claude-codes` and workspace clippy are clean.