### PR TITLE
claude-codes: discover minified zod aliases in schema extractor

### DIFF
--- a/claude-codes/RESNAPSHOTTING.md
+++ b/claude-codes/RESNAPSHOTTING.md
@@ -48,15 +48,18 @@ python3 scripts/extract_claude_sdk_schemas.py -o /tmp/claude_sdk_schemas.txt
 ```
 
 The CLI defines its wire types as lazy zod schemas,
-`NAME=Se(()=>E.object({type:E.literal("..."),...}))`, and the SDK output
-union is an `E.union([NAME(), ...])` over ~40 of them. Minified names change
-every release; the structure does not. The script anchors on the
-`rate_limit_event` literal, finds the union that references it, and dumps
-every member schema plus transitive references, each labeled with its
-resolved `type`/`subtype`.
+`NAME=<lazy>(()=><zod>.object({type:<zod>.literal("..."),...}))`, and the SDK
+output union is a `<zod>.union([NAME(), ...])` over ~40 of them. Minified
+names change every release — including the `<lazy>`/`<zod>` aliases (`Se`/`E`
+on 2.1.205, `_e`/`b` on 2.1.218) — but the structure does not. The script
+anchors on the stable `rate_limit_event` literal, reads the alias pair from
+the bytes around it, rebuilds its patterns from the discovered aliases, finds
+the union that references the anchor, and dumps every member schema plus
+transitive references, each labeled with its resolved `type`/`subtype`.
 
-If the script fails to find the anchor or union, the bundle layout changed;
-fall back to manual spelunking (below) and update the script.
+If the script fails to find the anchor or union, the bundle layout changed
+more fundamentally than an alias rename; fall back to manual spelunking
+(below) and update the script.
 
 ## Step 2 — diff against the crate
 
@@ -86,7 +89,7 @@ Things to check, in priority order:
 Two caveats that save confusion:
 
 - The `message` payloads of `assistant`/`user`, the `stream_event` `event`,
-  and the result `usage` are `E.unknown()` in the CLI's own schema — raw
+  and the result `usage` are `.unknown()` in the CLI's own schema — raw
   Anthropic API passthrough. The crate types those against the API shape,
   not the CLI schema, so "the zod says unknown" is not drift.
 - Minified names collide across bundle modules. When extracting by hand,
@@ -98,8 +101,10 @@ Enumerate every wire `type`/`subtype` literal (broader than the SDK union —
 includes internal orchestrator frames):
 
 ```bash
-grep -aoE 'type:E\.literal\("[a-z_]+"\)' <binary> | sort | uniq -c
-grep -aoE 'subtype:E\.literal\("[a-z_0-9]+"\)' <binary> | sort | uniq -c
+# <zod> is the discovered zod alias — E on 2.1.205, b on 2.1.218; the
+# extractor prints it on stderr as `aliases: zod=...`.
+grep -aoE 'type:<zod>\.literal\("[a-z_]+"\)' <binary> | sort | uniq -c
+grep -aoE 'subtype:<zod>\.literal\("[a-z_0-9]+"\)' <binary> | sort | uniq -c
 ```
 
 Pull context around any anchor string (Python is much faster than grep's
@@ -111,7 +116,7 @@ i = data.find(b'some_anchor_string')
 print(data[i-500:i+1500].decode('utf-8', 'replace'))
 ```
 
-Definitions end where the next `NAME=Se(` begins — split on that boundary
+Definitions end where the next `NAME=<lazy>(` begins — split on that boundary
 rather than balanced-paren parsing (regex literals in the minified JS break
 paren counting).
 

--- a/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
+++ b/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
@@ -37,6 +37,7 @@ system/session_state_changed: session_id, state, subtype, type, uuid
 system/status: compact_error, compact_result, permissionMode, session_id, status, subtype, type, uuid
 system/task_notification: output_file, session_id, skip_transcript, status, subtype, summary, task_id, tool_use_id, type, usage, uuid
 system/task_progress: description, last_tool_name, session_id, subagent_type, subtype, summary, task_id, tool_use_id, type, usage, uuid
+system/task_started: description, prompt, session_id, skip_transcript, subagent_type, subtype, task_id, task_type, tool_use_id, type, uuid, workflow_name
 system/task_updated: patch, session_id, subtype, task_id, type, uuid
 system/thinking_tokens: estimated_tokens, estimated_tokens_delta, session_id, subtype, type, uuid
 system/worker_shutting_down: reason, session_id, subtype, type, uuid

--- a/scripts/check_claude_schema_drift.py
+++ b/scripts/check_claude_schema_drift.py
@@ -59,18 +59,21 @@ SNAPSHOT = ROOT / "claude-codes" / "tests" / "schemas" / "claude_stream_json_sna
 _KEY = re.compile(r"[A-Za-z_$][\w$]*")
 
 
-def top_level_keys(body: str) -> list[str]:
-    """The direct object keys of a schema's outermost `E.object({...})`.
+def top_level_keys(body: str, zod: str) -> list[str]:
+    """The direct object keys of a schema's outermost `<zod>.object({...})`.
 
+    `zod` is the minified zod-namespace alias the extractor discovered from
+    the binary (`E` on CLI 2.1.205) — it changes between releases.
     String-literal aware (so colons/braces inside `.describe("...")` prose are
-    skipped) and bracket-depth aware (so nested `E.object(...)` keys aren't
+    skipped) and bracket-depth aware (so nested `<zod>.object(...)` keys aren't
     counted). Only bare-identifier keys are recognized — all Claude wire
     schemas use them.
     """
-    start = body.find("E.object({")
+    opener = zod + ".object({"
+    start = body.find(opener)
     if start < 0:
         return []
-    i = start + len("E.object({")
+    i = start + len(opener)
     depth = 0
     n = len(body)
     keys: list[str] = []
@@ -115,13 +118,13 @@ def top_level_keys(body: str) -> list[str]:
 
 def build_fingerprint(data: bytes) -> tuple[int, dict[str, list[str]]]:
     """`(union_member_count, {label: sorted top-level keys})` for labeled schemas."""
-    union_text, results = extract_schemas(data)
-    members = len(REF_CALL.findall(union_text))
+    extraction = extract_schemas(data)
+    members = len(REF_CALL.findall(extraction.union_text))
     labeled: dict[str, list[str]] = {}
-    for _name, label, body in results:
+    for _name, label, body in extraction.results:
         if label in ("(nested)", "NOT FOUND"):
             continue
-        keys = sorted(set(top_level_keys(body)))
+        keys = sorted(set(top_level_keys(body, extraction.zod)))
         # First definition wins on the rare label collision; keep it deterministic.
         labeled.setdefault(label, keys)
     return members, labeled

--- a/scripts/extract_claude_sdk_schemas.py
+++ b/scripts/extract_claude_sdk_schemas.py
@@ -6,13 +6,17 @@ compiled CLI binary, for diffing against the claude-codes crate.
 The CLI ships as a Bun-compiled ELF with the bundled JavaScript embedded as
 plain bytes, so the zod schema definitions are recoverable with byte-level
 regex work — no unpacking needed. The wire schemas are lazy zod definitions
-of the form `NAME=Se(()=>E.object({type:E.literal("..."),...}))`, and the
-SDK output union is an `E.union([NAME(), ...])` over ~40 of them.
+of the form `NAME=<lazy>(()=><zod>.object({type:<zod>.literal("..."),...}))`,
+and the SDK output union is a `<zod>.union([NAME(), ...])` over ~40 of them.
 
-Minified names change every release; the *structure* does not. This script
-anchors on the `rate_limit_event` literal (a stable, unique member), finds
-the union that references it, then extracts every member schema plus
-transitive references.
+Minified names change every release — including the zod-namespace alias
+(`E` on CLI 2.1.205) and the lazy-schema wrapper alias (`Se` on 2.1.205) —
+but the *structure* does not. This script therefore discovers the aliases
+instead of assuming them: it anchors on the stable `"rate_limit_event"`
+literal, reads the lazy/zod alias tokens from the bytes around it, and
+rebuilds every pattern from the discovered pair. If several alias pairs
+match (multiple bundled zod copies), each is tried until one yields the
+union.
 
 Usage:
   python3 scripts/extract_claude_sdk_schemas.py [BINARY] [-o OUT.txt]
@@ -35,17 +39,64 @@ import re
 import shutil
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
-# A schema definition starts at `NAME=Se(` and ends where the next one begins.
-DEF_START = re.compile(rb"[^\w$]([A-Za-z_$][\w$]{1,6})=Se\(")
-BOUNDARY = re.compile(rb"[,;({\[]\s*[A-Za-z_$][\w$]{1,6}=Se\(")
-# Calls to other lazy schemas inside a definition body: `ref()`.
-REF_CALL = re.compile(r"\b([A-Za-z_$][\w$]{1,6})\(\)")
-# The anchor schema: the one whose body opens with the rate_limit_event literal.
-ANCHOR = re.compile(
-    rb'([A-Za-z_$][\w$]{1,6})=Se\(\(\)=>E\.object\(\{type:E\.literal\("rate_limit_event"\)'
+# A minified schema name (2-7 chars, like the pre-discovery extractor assumed).
+_IDENT = rb"[A-Za-z_$][\w$]{1,6}"
+# A minified alias can be a single character (`E` is the zod alias on 2.1.205).
+_ALIAS = rb"[A-Za-z_$][\w$]{0,6}"
+
+# Discovers the alias pair from the anchor schema. Captures:
+#   1. the anchor schema's minified name
+#   2. the lazy-schema wrapper alias (`Se` on CLI 2.1.205)
+#   3. the zod-namespace alias (`E` on CLI 2.1.205)
+ALIAS_DISCOVERY = re.compile(
+    rb"(" + _IDENT + rb")=(" + _ALIAS + rb")\(\(\)=>"
+    rb"(" + _ALIAS + rb')\.object\(\{type:\3\.literal\("rate_limit_event"\)'
 )
-UNION = re.compile(rb"[A-Za-z_$][\w$]{1,6}=Se\(\(\)=>E\.union\(\[[^\]]*\]\)\)")
+
+# Calls to other lazy schemas inside a definition body: `ref()`. A plain \b
+# does not work here: minified names can start with `$` (2.1.218 does this),
+# and there is no word boundary between a delimiter and `$` — it would match
+# the truncated `eE` out of `$eE()`. Guard with a lookbehind instead; `.` is
+# excluded too so zod method calls (`.string()`, `.optional()`) aren't taken
+# for schema refs.
+REF_CALL = re.compile(r"(?<![\w$.])([A-Za-z_$][\w$]{1,6})\(\)")
+
+
+class WirePatterns(NamedTuple):
+    """Byte-regexes rebuilt from a discovered (lazy, zod) alias pair."""
+
+    lazy: str
+    zod: str
+    def_start: re.Pattern[bytes]
+    boundary: re.Pattern[bytes]
+    union: re.Pattern[bytes]
+
+
+def build_patterns(lazy: bytes, zod: bytes) -> WirePatterns:
+    lz, zd = re.escape(lazy), re.escape(zod)
+    return WirePatterns(
+        lazy=lazy.decode(),
+        zod=zod.decode(),
+        # A schema definition starts at `NAME=<lazy>(` and ends where the next begins.
+        def_start=re.compile(rb"[^\w$](" + _IDENT + rb")=" + lz + rb"\("),
+        boundary=re.compile(rb"[,;({\[]\s*" + _IDENT + rb"=" + lz + rb"\("),
+        union=re.compile(
+            _IDENT + rb"=" + lz + rb"\(\(\)=>" + zd + rb"\.union\(\[[^\]]*\]\)\)"
+        ),
+    )
+
+
+class Extraction(NamedTuple):
+    """Everything `extract_schemas` recovers from the binary."""
+
+    union_text: str
+    # (minified_name, label, body_text) in BFS order from the union members.
+    results: list[tuple[str, str, str]]
+    # The discovered zod-namespace alias — needed by consumers that parse the
+    # bodies (e.g. the drift check's top-level-key scan).
+    zod: str
 
 
 class SchemaExtractionError(RuntimeError):
@@ -61,7 +112,20 @@ def resolve_binary(arg: str | None) -> Path:
     return Path(on_path).resolve()
 
 
-def index_definitions(data: bytes) -> dict[str, list[tuple[int, bytes]]]:
+def discover_aliases(data: bytes) -> list[tuple[re.Match[bytes], bytes, bytes]]:
+    """All `(anchor_match, lazy_alias, zod_alias)` candidates in the binary.
+
+    Anchored on the stable `"rate_limit_event"` literal; the aliases are read
+    from the surrounding bytes rather than assumed. Multiple candidates can
+    appear when the bundle carries more than one zod copy — callers try each.
+    """
+    out = []
+    for m in ALIAS_DISCOVERY.finditer(data):
+        out.append((m, m.group(2), m.group(3)))
+    return out
+
+
+def index_definitions(data: bytes, pats: WirePatterns) -> dict[str, list[tuple[int, bytes]]]:
     """One pass over the binary → {name: [(offset, body-bytes), ...]}.
 
     Minified names collide across bundle modules, so each name maps to every
@@ -70,10 +134,10 @@ def index_definitions(data: bytes) -> dict[str, list[tuple[int, bytes]]]:
     O(1) lookups — the difference between minutes and seconds on a ~250 MB ELF.
     """
     idx: dict[str, list[tuple[int, bytes]]] = {}
-    for m in DEF_START.finditer(data):
+    for m in pats.def_start.finditer(data):
         name = m.group(1).decode()
         start = m.start() + 1
-        nxt = BOUNDARY.search(data, m.end())
+        nxt = pats.boundary.search(data, m.end())
         end = nxt.start() + 1 if nxt else m.end() + 20_000
         idx.setdefault(name, []).append((start, data[start:end]))
     return idx
@@ -85,9 +149,10 @@ def pick_definition(cands: list[tuple[int, bytes]], anchor: int) -> bytes | None
     return min(cands, key=lambda c: abs(c[0] - anchor))[1]
 
 
-def label_of(body: str) -> str:
-    t = re.search(r'type:E\.literal\("([a-z_]+)"\)', body)
-    s = re.search(r'subtype:E\.literal\("([a-z_0-9]+)"\)', body)
+def label_of(body: str, zod: str) -> str:
+    z = re.escape(zod)
+    t = re.search(r"type:" + z + r'\.literal\("([a-z_]+)"\)', body)
+    s = re.search(r"subtype:" + z + r'\.literal\("([a-z_0-9]+)"\)', body)
     if t and s:
         return f"{t.group(1)}/{s.group(1)}"
     if t:
@@ -95,22 +160,11 @@ def label_of(body: str) -> str:
     return "(nested)"
 
 
-def extract_schemas(data: bytes) -> tuple[str, list[tuple[str, str, str]]]:
-    """Extract the SDK output union and every reachable schema.
-
-    Returns `(union_text, [(minified_name, label, body_text), ...])` in
-    breadth-first order from the union members. Raises
-    [`SchemaExtractionError`] if the anchor or union can't be found.
-    """
-    m = ANCHOR.search(data)
-    if not m:
-        raise SchemaExtractionError(
-            "rate_limit_event anchor schema not found — bundle layout changed?"
-        )
-    anchor_name, anchor_off = m.group(1).decode(), m.start()
+def _extract_with(data: bytes, anchor: re.Match[bytes], pats: WirePatterns) -> Extraction:
+    anchor_name = anchor.group(1).decode()
 
     union = None
-    for um in UNION.finditer(data):
+    for um in pats.union.finditer(data):
         if (anchor_name + "()").encode() in um.group(0):
             union = um
             break
@@ -119,7 +173,7 @@ def extract_schemas(data: bytes) -> tuple[str, list[tuple[str, str, str]]]:
     union_text = union.group(0).decode()
     members = REF_CALL.findall(union_text)
 
-    idx = index_definitions(data)
+    idx = index_definitions(data, pats)
     results: list[tuple[str, str, str]] = []
     seen: set[str] = set()
     queue = list(dict.fromkeys(members))
@@ -133,11 +187,36 @@ def extract_schemas(data: bytes) -> tuple[str, list[tuple[str, str, str]]]:
             results.append((name, "NOT FOUND", ""))
             continue
         text = body.decode("utf-8", "replace")
-        results.append((name, label_of(text), text))
+        results.append((name, label_of(text, pats.zod), text))
         for ref in REF_CALL.findall(text):
             if ref not in seen and ref not in queue:
                 queue.append(ref)
-    return union_text, results
+    return Extraction(union_text, results, pats.zod)
+
+
+def extract_schemas(data: bytes) -> Extraction:
+    """Extract the SDK output union and every reachable schema.
+
+    Discovers the minified lazy/zod aliases from the `rate_limit_event`
+    anchor, then walks the union. Raises [`SchemaExtractionError`] if no
+    anchor is found or no candidate alias pair yields the union.
+    """
+    candidates = discover_aliases(data)
+    if not candidates:
+        raise SchemaExtractionError(
+            "rate_limit_event anchor schema not found — bundle layout changed?"
+        )
+
+    failures = []
+    for anchor, lazy, zod in candidates:
+        pats = build_patterns(lazy, zod)
+        try:
+            return _extract_with(data, anchor, pats)
+        except SchemaExtractionError as e:
+            failures.append(f"aliases lazy={pats.lazy} zod={pats.zod}: {e}")
+    raise SchemaExtractionError(
+        "no candidate alias pair yielded the SDK output union: " + "; ".join(failures)
+    )
 
 
 def main() -> None:
@@ -151,11 +230,16 @@ def main() -> None:
     print(f"# read {binary} ({len(data):,} bytes)", file=sys.stderr)
 
     try:
-        union_text, results = extract_schemas(data)
+        extraction = extract_schemas(data)
     except SchemaExtractionError as e:
         sys.exit(f"error: {e}")
 
-    print(f"# union: {len(REF_CALL.findall(union_text))} members", file=sys.stderr)
+    union_text, results = extraction.union_text, extraction.results
+    print(
+        f"# union: {len(REF_CALL.findall(union_text))} members"
+        f" (aliases: zod={extraction.zod})",
+        file=sys.stderr,
+    )
     blocks = [f"// SDK output union\n{union_text}"]
     for name, label, text in results:
         blocks.append(f"// {name}: {label}\n{text}" if text else f"// {name}: {label}")


### PR DESCRIPTION
Fixes #217.

The extractor hard-coded the CLI 2.1.205 minified aliases (`E.object`, `Se(`) in its anchor/union regexes, so any release that minified them differently made `check_claude_schema_drift.py` exit 2 (soft skip) — the nightly went blind on 2.1.211+.

## Changes

- **Alias discovery**: anchor on the stable `"rate_limit_event"` literal, read the lazy-wrapper and zod-namespace tokens from the surrounding bytes, and rebuild every pattern from the discovered pair. If the bundle carries several zod copies, each candidate pair is tried until one yields the union. `extract_schemas` now returns an `Extraction` carrying the discovered zod alias; the drift check's top-level-key scan consumes it instead of assuming `E`.
- **Latent ref-matching bug fixed**: 2.1.218 minifies some schema names with a leading `$` (e.g. `$eE` = `stream_event`), and `REF_CALL`'s `\b` never matches before `$` — members were silently dropped/mislabeled. Replaced with a lookbehind guard, also excluding zod method calls (`.string()`) from ref matching.
- **Baseline re-snapshot (2.1.205)**: the fixed extractor reveals one label the old regex always lost — `system/task_started` (already modeled in the crate as `TaskStartedMessage`). That's the only snapshot change; `TESTED_VERSION` stays 2.1.205 since the crate hasn't adopted a newer CLI target.
- `RESNAPSHOTTING.md` updated to describe the discovered-alias flow.

## Verification (acceptance criteria from #217)

| Binary | Extractor | Drift check |
|---|---|---|
| 2.1.205 (aliases `E`/`Se`) | anchor+union resolved, 39 members | exit 0, no drift vs re-snapshotted baseline |
| 2.1.218 (aliases `b`/`_e`) | anchor+union resolved, 42 members | exit 1, real drift report |

The real 2.1.205 → 2.1.218 drift is additive: 3 new wire labels (`command_lifecycle`, `system/code_change_published`, `system/vcs_state_changed`) and new optional fields on `assistant`/`result`/`tool_progress`/`user`. The nightly workflow will now file that as a proper drift issue instead of soft-skipping; crate-side modeling is follow-up work.