### PR TITLE
claude-codes: skip non-schema refs in extractor instead of NOT FOUND

### DIFF
--- a/claude-codes/RESNAPSHOTTING.md
+++ b/claude-codes/RESNAPSHOTTING.md
@@ -94,6 +94,11 @@ Two caveats that save confusion:
   not the CLI schema, so "the zod says unknown" is not drift.
 - Minified names collide across bundle modules. When extracting by hand,
   prefer the definition nearest the union's byte offset.
+- Not every `ref()`-shaped call inside a schema body is a schema reference:
+  module-initializer thunks (`NAME=S(()=>{...})`, a different wrapper than the
+  schema one) and plain helper calls match the same shape. The extractor only
+  follows names defined under the schema wrapper; the rest are skipped and
+  listed on stderr as `non-schema refs skipped`.
 
 ## Manual spelunking recipes
 

--- a/scripts/extract_claude_sdk_schemas.py
+++ b/scripts/extract_claude_sdk_schemas.py
@@ -97,6 +97,11 @@ class Extraction(NamedTuple):
     # The discovered zod-namespace alias — needed by consumers that parse the
     # bodies (e.g. the drift check's top-level-key scan).
     zod: str
+    # Referenced names with no definition under the schema wrapper — module
+    # initializer thunks and helper functions whose call sites happen to
+    # match the `ref()` shape, not schemas. Reported for transparency; they
+    # carry no wire fields.
+    unresolved: list[str]
 
 
 class SchemaExtractionError(RuntimeError):
@@ -149,6 +154,8 @@ def pick_definition(cands: list[tuple[int, bytes]], anchor: int) -> bytes | None
     return min(cands, key=lambda c: abs(c[0] - anchor))[1]
 
 
+
+
 def label_of(body: str, zod: str) -> str:
     z = re.escape(zod)
     t = re.search(r"type:" + z + r'\.literal\("([a-z_]+)"\)', body)
@@ -175,6 +182,7 @@ def _extract_with(data: bytes, anchor: re.Match[bytes], pats: WirePatterns) -> E
 
     idx = index_definitions(data, pats)
     results: list[tuple[str, str, str]] = []
+    unresolved: list[str] = []
     seen: set[str] = set()
     queue = list(dict.fromkeys(members))
     while queue:
@@ -184,14 +192,20 @@ def _extract_with(data: bytes, anchor: re.Match[bytes], pats: WirePatterns) -> E
         seen.add(name)
         body = pick_definition(idx.get(name, []), union.start())
         if body is None:
-            results.append((name, "NOT FOUND", ""))
+            # Not defined under the schema wrapper anywhere in the bundle —
+            # a module-initializer thunk (`NAME=S(()=>{...})`) or helper
+            # function whose call site happens to match the `ref()` shape,
+            # not a schema. Verified empirically: every such name in CLI
+            # 2.1.205/2.1.218 is a module init or helper, and following them
+            # crawls the bundler's module graph instead of the schema graph.
+            unresolved.append(name)
             continue
         text = body.decode("utf-8", "replace")
         results.append((name, label_of(text, pats.zod), text))
         for ref in REF_CALL.findall(text):
             if ref not in seen and ref not in queue:
                 queue.append(ref)
-    return Extraction(union_text, results, pats.zod)
+    return Extraction(union_text, results, pats.zod, unresolved)
 
 
 def extract_schemas(data: bytes) -> Extraction:
@@ -240,6 +254,12 @@ def main() -> None:
         f" (aliases: zod={extraction.zod})",
         file=sys.stderr,
     )
+    if extraction.unresolved:
+        print(
+            "# non-schema refs skipped (no lazy definition anywhere): "
+            + ", ".join(extraction.unresolved),
+            file=sys.stderr,
+        )
     blocks = [f"// SDK output union\n{union_text}"]
     for name, label, text in results:
         blocks.append(f"// {name}: {label}\n{text}" if text else f"// {name}: {label}")


### PR DESCRIPTION
Fixes #224. **Stacked on #222** (touches the same extractor; retarget to `main` happens automatically when #222's branch is deleted after merge). Independent of #225 — the drift fingerprint is unchanged.

## What the unresolved refs turned out to be

None of the `NOT FOUND` names are schemas:

- `zn`, `UA`, `ibm` (2.1.218) and `Jn`, `Gw`, `kcf` (2.1.205) are **bundler module-initializer thunks** — `NAME=S(()=>{...})`, a different lazy wrapper than the schema one, whose bodies run module setup (`zn();WOt();UA();`) rather than defining a wire shape.
- `isHuman` is a plain helper function call.

A wrapper-agnostic fallback (issue option 2) was implemented and **rejected**: following these names crawls the bundler's module graph instead of the schema graph — it "resolved" 6,000+ bogus schemas on 2.1.218.

## Change (issue options 1 + 3)

- A name is treated as a schema ref only when it has a definition under the anchor's schema wrapper.
- Skipped names ride the new `Extraction.unresolved` field and print as a stderr note (`# non-schema refs skipped: ...`) instead of emitting `NOT FOUND` rows into the extractor output.
- `RESNAPSHOTTING.md` documents the module-initializer confusion for future spelunkers.

## Verification

- 2.1.205: 60 schemas, 0 `NOT FOUND`, schema set byte-identical to before minus the noise rows; drift checker exits 0 against the committed baseline.
- 2.1.218: 63 schemas, 0 `NOT FOUND`, skips `zn, UA, ibm, isHuman` on stderr.

No crate code touched — scripts + docs only, so no version bump.