### PR TITLE
claude-codes 2.1.164: Opus 5 catalog + CLI 2.1.219 wire drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.163"
+version = "2.1.164"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.163`, tested against Claude CLI `2.1.218`.
+- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.164`, tested against Claude CLI `2.1.219`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.143.5`, tested against Codex CLI `0.143.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.164] - 2026-07-24
+
+Catches up to CLI 2.1.219 — the Opus 5 release. Snapshot baseline and
+`TESTED_VERSION` move to 2.1.219; the full integration suite passes against
+the installed binary.
+
+### Added
+
+- **`ClaudeModel::Opus5`** — pinned variant for `claude-opus-5` (display name
+  "Opus 5", knowledge cutoff May 2026). The floating `opus` alias resolves to
+  `claude-opus-5` first-party as of CLI 2.1.219 (noted on the `Opus` variant
+  doc). Model table refreshed from the 2.1.219 binary; the accepted floating
+  aliases are unchanged.
+- **`FastModeDisabledReason`** — open enum (`free`, `preference`,
+  `extra_usage_disabled`, `network_error`, `unknown`, `not_first_party`,
+  `disabled_by_env`, `model_not_allowed`, `sdk_opt_in_required`, `pending`,
+  plus `Unknown(String)`) carried as the new optional
+  `fast_mode_disabled_reason` on `ResultMessage` and `InitMessage`: why fast
+  mode can't serve right now, complementing the existing `fast_mode_state`.
+- **`InitMessage.mcp_server_errors`** — new `McpServerError` struct (`name`,
+  `type`, `message`) recording `--mcp-config` entries that failed validation
+  and were skipped.
+- **`PluginInfo.version`** — installed plugin version on the init plugin
+  list (caught by the live wire-fidelity audit, not the drift fingerprint —
+  it is a nested field).
+
 ## [2.1.163] - 2026-07-22
 
 Models the CLI 2.1.205 → 2.1.218 stream-json drift surfaced by the fixed

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.163"
+version = "2.1.164"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -138,7 +138,7 @@ let serialized = Protocol::serialize(&output)?;
 
 ## Compatibility
 
-**Tested against:** Claude CLI 2.1.218
+**Tested against:** Claude CLI 2.1.219
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/io/message_types.rs
+++ b/claude-codes/src/io/message_types.rs
@@ -1466,6 +1466,9 @@ pub struct PluginInfo {
     /// Plugin registry source (e.g., "rust-analyzer-lsp@claude-plugins-official")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
+    /// Installed plugin version (e.g., "1.0.0"). Added in CLI 2.1.219.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
 }
 
 /// Plugin load diagnostic reported by system init.
@@ -1486,6 +1489,18 @@ pub struct MemoryPaths {
     pub team: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Map<String, Value>,
+}
+
+/// An MCP server config entry that failed validation, reported by system
+/// init (e.g. a `url` entry with no `type`). The affected server is skipped
+/// and absent from `InitMessage::mcp_servers`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct McpServerError {
+    pub name: String,
+    /// Stable error category.
+    #[serde(rename = "type")]
+    pub error_type: String,
+    pub message: String,
 }
 
 /// Init system message data - sent at session start
@@ -1541,6 +1556,15 @@ pub struct InitMessage {
     /// Fast mode toggle state (e.g., "off")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fast_mode_state: Option<String>,
+
+    /// Why fast mode can't serve right now. Absent when nothing blocks it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fast_mode_disabled_reason: Option<super::result::FastModeDisabledReason>,
+
+    /// MCP server config entries (from `--mcp-config`) that failed validation
+    /// and were skipped. Affected servers are absent from `mcp_servers`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp_server_errors: Option<Vec<McpServerError>>,
 
     /// Whether analytics collection is disabled for this session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2939,6 +2963,36 @@ mod tests {
         let result = user.subagent_result().expect("lenient parse");
         assert_eq!(result.total_tokens, None);
         assert_eq!(result.agent_type, None);
+    }
+
+    #[test]
+    fn test_init_fast_mode_reason_and_mcp_server_errors_fully_wrapped() {
+        use serde_json::Value;
+
+        let raw: Value = serde_json::from_str(
+            r#"{
+            "type":"system","subtype":"init","session_id":"s1","uuid":"u1",
+            "fast_mode_state":"off",
+            "fast_mode_disabled_reason":"not_first_party",
+            "mcp_server_errors":[{"name":"broken","type":"invalid_config","message":"url entry with no type"}]
+        }"#,
+        )
+        .unwrap();
+        crate::io::assert_fully_wrapped(&raw);
+
+        let output: ClaudeOutput = serde_json::from_value(raw).unwrap();
+        let ClaudeOutput::System(sys) = output else {
+            panic!("expected System");
+        };
+        let init = sys.as_init().expect("parses as init");
+        assert_eq!(
+            init.fast_mode_disabled_reason,
+            Some(crate::FastModeDisabledReason::NotFirstParty)
+        );
+        let errs = init.mcp_server_errors.unwrap();
+        assert_eq!(errs.len(), 1);
+        assert_eq!(errs[0].name, "broken");
+        assert_eq!(errs[0].error_type, "invalid_config");
     }
 
     #[test]

--- a/claude-codes/src/io/result.rs
+++ b/claude-codes/src/io/result.rs
@@ -85,6 +85,12 @@ pub struct ResultMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fast_mode_state: Option<String>,
 
+    /// Why fast mode can't serve right now. Absent when nothing blocks it.
+    /// A paused-after-rate-limit run is not reported here; it rides
+    /// `fast_mode_state` as `"cooldown"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fast_mode_disabled_reason: Option<FastModeDisabledReason>,
+
     /// Per-model cost breakdown, keyed by model name (e.g. `"claude-opus-4-8"`).
     #[serde(skip_serializing_if = "Option::is_none", rename = "modelUsage")]
     pub model_usage: Option<std::collections::BTreeMap<String, ModelUsageEntry>>,
@@ -152,6 +158,89 @@ pub struct PermissionDenial {
 
     /// The unique identifier for this tool use request
     pub tool_use_id: String,
+}
+
+/// Why fast mode can't serve right now, carried on `result` frames and
+/// `system/init` (CLI 2.1.219+). Absent when nothing blocks fast mode.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum FastModeDisabledReason {
+    /// Free-tier account.
+    Free,
+    /// Disabled by user preference.
+    Preference,
+    /// Extra-usage purchases are disabled for the account.
+    ExtraUsageDisabled,
+    /// A network error prevented fast-mode eligibility from resolving.
+    NetworkError,
+    /// The CLI could not determine the reason.
+    UnknownReason,
+    /// Not a first-party API session (e.g. Bedrock/Vertex).
+    NotFirstParty,
+    /// Disabled via environment variable.
+    DisabledByEnv,
+    /// The active model does not support fast mode.
+    ModelNotAllowed,
+    /// SDK sessions must opt in to fast mode.
+    SdkOptInRequired,
+    /// Eligibility is still being determined.
+    Pending,
+    /// A reason not yet known to this version of the crate.
+    Unknown(String),
+}
+
+impl FastModeDisabledReason {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Free => "free",
+            Self::Preference => "preference",
+            Self::ExtraUsageDisabled => "extra_usage_disabled",
+            Self::NetworkError => "network_error",
+            Self::UnknownReason => "unknown",
+            Self::NotFirstParty => "not_first_party",
+            Self::DisabledByEnv => "disabled_by_env",
+            Self::ModelNotAllowed => "model_not_allowed",
+            Self::SdkOptInRequired => "sdk_opt_in_required",
+            Self::Pending => "pending",
+            Self::Unknown(s) => s.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for FastModeDisabledReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<&str> for FastModeDisabledReason {
+    fn from(s: &str) -> Self {
+        match s {
+            "free" => Self::Free,
+            "preference" => Self::Preference,
+            "extra_usage_disabled" => Self::ExtraUsageDisabled,
+            "network_error" => Self::NetworkError,
+            "unknown" => Self::UnknownReason,
+            "not_first_party" => Self::NotFirstParty,
+            "disabled_by_env" => Self::DisabledByEnv,
+            "model_not_allowed" => Self::ModelNotAllowed,
+            "sdk_opt_in_required" => Self::SdkOptInRequired,
+            "pending" => Self::Pending,
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+}
+
+impl Serialize for FastModeDisabledReason {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for FastModeDisabledReason {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self::from(s.as_str()))
+    }
 }
 
 /// Result subtypes
@@ -536,6 +625,38 @@ mod tests {
         } else {
             panic!("Expected Result");
         }
+    }
+
+    #[test]
+    fn test_result_fast_mode_disabled_reason() {
+        let json = r#"{
+            "type":"result","subtype":"success","is_error":false,
+            "duration_ms":100,"duration_api_ms":80,"num_turns":1,
+            "session_id":"s1","total_cost_usd":0.01,
+            "fast_mode_state":"off",
+            "fast_mode_disabled_reason":"sdk_opt_in_required"
+        }"#;
+        let output: crate::ClaudeOutput = serde_json::from_str(json).unwrap();
+        let crate::ClaudeOutput::Result(res) = &output else {
+            panic!("expected Result");
+        };
+        assert_eq!(
+            res.fast_mode_disabled_reason,
+            Some(FastModeDisabledReason::SdkOptInRequired)
+        );
+        assert!(serde_json::to_string(&output)
+            .unwrap()
+            .contains("\"fast_mode_disabled_reason\":\"sdk_opt_in_required\""));
+
+        // Unknown reasons survive decode and round-trip verbatim; the wire
+        // literal "unknown" maps to the typed UnknownReason, not the fallback.
+        assert_eq!(
+            FastModeDisabledReason::from("unknown"),
+            FastModeDisabledReason::UnknownReason
+        );
+        let novel = FastModeDisabledReason::from("solar_flare");
+        assert_eq!(novel, FastModeDisabledReason::Unknown("solar_flare".into()));
+        assert_eq!(novel.as_str(), "solar_flare");
     }
 
     #[test]

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -78,7 +78,7 @@
 //! ⚠️ **Important**: The Claude CLI protocol is unstable and evolving. This crate
 //! automatically checks your Claude CLI version and warns if it's newer than tested.
 //!
-//! Current tested version: **2.1.205**
+//! Current tested version: **2.1.219**
 //!
 //! Report compatibility issues at: <https://github.com/meawoppl/rust-claude-codes/pulls>
 //!
@@ -156,15 +156,15 @@ pub use io::{
     CompactBoundaryMessage, CompactMetadata, CompactionTrigger, ControlRequestProgressMessage,
     ElicitationCompleteMessage, FailedPersistedFile, FilesPersistedMessage, HookProgressMessage,
     HookResponseMessage, HookStartedMessage, InformationalMessage, InitMessage, InitPermissionMode,
-    KnownSystemEvent, LocalCommandOutputMessage, McpMeta, MemoryPaths, MemoryRecallItem,
-    MemoryRecallMessage, MessageOrigin, MessageRole, MirrorErrorKey, MirrorErrorMessage,
-    ModelRefusalFallbackMessage, ModelRefusalNoFallbackMessage, NotificationMessage, OutputStyle,
-    PermissionDeniedMessage, PersistedFile, PluginDiagnostic, PluginInfo, PluginInstallMessage,
-    PreservedMessages, PreservedSegment, StatusMessage, StatusMessageStatus, StopReason,
-    SummarizeMetadata, SystemMessage, SystemSubtype, TaskNotificationMessage, TaskPatch,
-    TaskProgressMessage, TaskStartedMessage, TaskStatus, TaskType, TaskUpdatedMessage, TaskUsage,
-    ThinkingTokensMessage, ToolResultMeta, ToolUseMeta, VcsMutationKind, VcsStateChangedMessage,
-    WorkerShuttingDownMessage,
+    KnownSystemEvent, LocalCommandOutputMessage, McpMeta, McpServerError, MemoryPaths,
+    MemoryRecallItem, MemoryRecallMessage, MessageOrigin, MessageRole, MirrorErrorKey,
+    MirrorErrorMessage, ModelRefusalFallbackMessage, ModelRefusalNoFallbackMessage,
+    NotificationMessage, OutputStyle, PermissionDeniedMessage, PersistedFile, PluginDiagnostic,
+    PluginInfo, PluginInstallMessage, PreservedMessages, PreservedSegment, StatusMessage,
+    StatusMessageStatus, StopReason, SummarizeMetadata, SystemMessage, SystemSubtype,
+    TaskNotificationMessage, TaskPatch, TaskProgressMessage, TaskStartedMessage, TaskStatus,
+    TaskType, TaskUpdatedMessage, TaskUsage, ThinkingTokensMessage, ToolResultMeta, ToolUseMeta,
+    VcsMutationKind, VcsStateChangedMessage, WorkerShuttingDownMessage,
 };
 
 // Additional top-level output message wrappers
@@ -185,8 +185,8 @@ pub use io::{
 
 // Usage types
 pub use io::{
-    AssistantUsage, CacheCreationDetails, DeferredToolUse, ServerToolUse, SubagentResult,
-    SubagentToolStats, SubagentUsageRollup, UsageInfo,
+    AssistantUsage, CacheCreationDetails, DeferredToolUse, FastModeDisabledReason, ServerToolUse,
+    SubagentResult, SubagentToolStats, SubagentUsageRollup, UsageInfo,
 };
 
 // Typed tool input types

--- a/claude-codes/src/models.rs
+++ b/claude-codes/src/models.rs
@@ -5,7 +5,7 @@
 //! `ClaudeCliBuilder::model`, which accepts the enum directly via
 //! `Into<String>`).
 //!
-//! The model table was extracted from the Claude CLI 2.1.205 binary's model
+//! The model table was extracted from the Claude CLI 2.1.219 binary's model
 //! registry. Aliases (`sonnet`, `opus`, …) float to the newest model of that
 //! family on the CLI side; pinned variants name one concrete model. Unknown
 //! or future model strings round-trip through [`ClaudeModel::Custom`].
@@ -18,7 +18,8 @@ use std::fmt;
 pub enum ClaudeModel {
     /// Newest Sonnet-family model (floating alias `sonnet`).
     Sonnet,
-    /// Newest Opus-family model (floating alias `opus`).
+    /// Newest Opus-family model (floating alias `opus`). Resolves to
+    /// `claude-opus-5` first-party as of CLI 2.1.219.
     Opus,
     /// Newest Haiku-family model (floating alias `haiku`).
     Haiku,
@@ -38,6 +39,8 @@ pub enum ClaudeModel {
     Fable5,
     /// Mythos 5 (`claude-mythos-5`).
     Mythos5,
+    /// Opus 5 (`claude-opus-5`).
+    Opus5,
     /// Opus 4.8 (`claude-opus-4-8`).
     Opus48,
     /// Opus 4.7 (`claude-opus-4-7`).
@@ -86,6 +89,7 @@ impl ClaudeModel {
             Self::Fable1m => "fable[1m]",
             Self::Fable5 => "claude-fable-5",
             Self::Mythos5 => "claude-mythos-5",
+            Self::Opus5 => "claude-opus-5",
             Self::Opus48 => "claude-opus-4-8",
             Self::Opus47 => "claude-opus-4-7",
             Self::Opus46 => "claude-opus-4-6",
@@ -124,6 +128,7 @@ impl ClaudeModel {
             Self::Fable1m => "Fable (latest, 1M context)",
             Self::Fable5 => "Fable 5",
             Self::Mythos5 => "Mythos 5",
+            Self::Opus5 => "Opus 5",
             Self::Opus48 => "Opus 4.8",
             Self::Opus47 => "Opus 4.7",
             Self::Opus46 => "Opus 4.6",
@@ -173,6 +178,7 @@ impl ClaudeModel {
             Self::Fable1m,
             Self::Fable5,
             Self::Mythos5,
+            Self::Opus5,
             Self::Opus48,
             Self::Opus47,
             Self::Opus46,
@@ -211,6 +217,7 @@ impl From<&str> for ClaudeModel {
             "fable[1m]" => Self::Fable1m,
             "claude-fable-5" => Self::Fable5,
             "claude-mythos-5" => Self::Mythos5,
+            "claude-opus-5" => Self::Opus5,
             "claude-opus-4-8" => Self::Opus48,
             "claude-opus-4-7" => Self::Opus47,
             "claude-opus-4-6" => Self::Opus46,
@@ -278,6 +285,8 @@ mod tests {
 
     #[test]
     fn test_display_names() {
+        assert_eq!(ClaudeModel::Opus5.display_name(), "Opus 5");
+        assert_eq!(ClaudeModel::Opus5.cli_arg(), "claude-opus-5");
         assert_eq!(ClaudeModel::Fable5.display_name(), "Fable 5");
         assert_eq!(ClaudeModel::Opus48.display_name(), "Opus 4.8");
         assert_eq!(ClaudeModel::Sonnet.display_name(), "Sonnet (latest)");

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.218";
+const TESTED_VERSION: &str = "2.1.219";
 
 /// Ensures version warning is only shown once per session
 static VERSION_CHECK: Once = Once::new();

--- a/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
+++ b/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
@@ -11,8 +11,8 @@ command_lifecycle: command_uuid, session_id, state, type, uuid
 conversation_reset: new_conversation_id, session_id, type, uuid
 prompt_suggestion: session_id, suggestion, type, uuid
 rate_limit_event: rate_limit_info, session_id, type, uuid
-result: duration_api_ms, duration_ms, errors, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, session_id, stop_reason, subtype, terminal_reason, total_cost_usd, type, usage, uuid
-result/success: api_error_status, deferred_tool_use, duration_api_ms, duration_ms, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, request_sent_wall_ms, result, session_id, stop_reason, structured_output, subtype, terminal_reason, time_origin_ms, time_to_request_from_spawn_ms, time_to_request_ms, total_cost_usd, ttft_ms, ttft_stream_ms, type, usage, user_message_uuid, uuid, warm_spare_claimed
+result: duration_api_ms, duration_ms, errors, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, session_id, stop_reason, subtype, terminal_reason, total_cost_usd, type, usage, uuid
+result/success: api_error_status, deferred_tool_use, duration_api_ms, duration_ms, fast_mode_disabled_reason, fast_mode_state, is_error, modelUsage, num_turns, origin, permission_denials, request_sent_wall_ms, result, session_id, stop_reason, structured_output, subtype, terminal_reason, time_origin_ms, time_to_request_from_spawn_ms, time_to_request_ms, total_cost_usd, ttft_ms, ttft_stream_ms, type, usage, user_message_uuid, uuid, warm_spare_claimed
 stream_event: event, parent_tool_use_id, session_id, ttft_ms, type, uuid
 system/api_retry: attempt, error, error_status, max_retries, retry_delay_ms, session_id, subtype, type, uuid
 system/background_tasks_changed: session_id, subtype, tasks, type, uuid
@@ -26,7 +26,7 @@ system/hook_progress: hook_event, hook_id, hook_name, output, session_id, stderr
 system/hook_response: exit_code, hook_event, hook_id, hook_name, outcome, output, session_id, stderr, stdout, subtype, type, uuid
 system/hook_started: hook_event, hook_id, hook_name, session_id, subtype, type, uuid
 system/informational: content, level, prevent_continuation, session_id, subtype, tool_use_id, type, uuid
-system/init: agents, analytics_disabled, apiKeySource, betas, capabilities, claude_code_version, cwd, fast_mode_state, mcp_servers, memory_paths, model, output_style, permissionMode, plugin_errors, plugin_warnings, plugins, product_feedback_disabled, session_id, skills, slash_commands, subtype, tools, type, uuid
+system/init: agents, analytics_disabled, apiKeySource, betas, capabilities, claude_code_version, cwd, fast_mode_disabled_reason, fast_mode_state, mcp_server_errors, mcp_servers, memory_paths, model, output_style, permissionMode, plugin_errors, plugin_warnings, plugins, product_feedback_disabled, session_id, skills, slash_commands, subtype, tools, type, uuid
 system/local_command_output: content, session_id, subtype, type, uuid
 system/memory_recall: memories, mode, session_id, subtype, type, uuid
 system/mirror_error: error, key, session_id, subtype, type, uuid


### PR DESCRIPTION
Catches the crate up to CLI **2.1.219** — the Opus 5 release.

## Model catalog

- **`ClaudeModel::Opus5`** — pinned `claude-opus-5` (display "Opus 5", knowledge cutoff May 2026). The floating `opus` alias resolves to it first-party as of 2.1.219 (noted on the `Opus` doc). Model table header refreshed; accepted floating aliases unchanged.

## Wire drift (2.1.218 → 2.1.219, additive)

- **`FastModeDisabledReason`** open enum (10 wire values + `Unknown(String)`), carried as optional `fast_mode_disabled_reason` on `ResultMessage` and `InitMessage`.
- **`InitMessage.mcp_server_errors`** — new `McpServerError` struct for `--mcp-config` entries that failed validation.
- **`PluginInfo.version`** — caught by the **live wire-fidelity audit** during integration testing, not the drift fingerprint (nested field); the live init frame also confirmed `fast_mode_disabled_reason: "sdk_opt_in_required"` in the wild.

## Housekeeping

- Snapshot baseline re-generated against 2.1.219 (drift checker exits 0).
- `TESTED_VERSION` → 2.1.219; root README, crate README, and lib.rs doc pins updated; version 2.1.164 with changelog.

## Verification

- `cargo test -p claude-codes --features integration-tests` — **full live suite passes against the installed 2.1.219 binary** (26 live tests + live subagent wrapping audit + 177 unit tests).
- Workspace clippy `--all-targets` clean; drift checker ✅.