### PR TITLE
codex-codes 0.143.6: re-snapshot app-server schema, fix drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.143.5"
+version = "0.143.6"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.164`, tested against Claude CLI `2.1.219`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.143.5`, tested against Codex CLI `0.143.0`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.143.6`, tested against Codex CLI `0.143.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.
 

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.143.6] - 2026-07-25
+
+Re-snapshot of the app-server schema from `openai/codex@main`, resolving the
+nightly drift report (#232). Snapshots are byte-identical to upstream again
+and schema coverage is 170/170 (100%).
+
+### Added
+
+- **`externalAgentConfig/import/recordHistory` client request** — new method
+  constant (`methods::EXTERNALAGENTCONFIG_IMPORT_RECORDHISTORY`) with
+  generated `ExternalAgentConfigImportHistoryRecordParams`/`Response` types.
+- **`BrowserUseRequirements`** definition (carried on `ConfigRequirements`
+  as the new optional `browser_use` field).
+- Additive fields across `AppToolSummary`, `ConfigBatchWriteParams`,
+  `ExternalAgentConfigImportHistory`, `ExternalAgentConfigImportParams`,
+  `PlanType`, `PluginShareContext`, `PluginShareSaveResponse`,
+  `SkillInterface`, and `ThreadItem`.
+
 ## [0.143.5] - 2026-07-22
 
 Re-snapshot of the app-server schema from `openai/codex@main`, resolving the

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.143.5"
+version = "0.143.6"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/examples/schema_coverage.rs
+++ b/codex-codes/examples/schema_coverage.rs
@@ -566,6 +566,7 @@ mod samples {
             methods::ACCOUNT_RATELIMITRESETCREDIT_CONSUME,
             methods::ACCOUNT_WORKSPACEMESSAGES_READ,
             methods::EXTERNALAGENTCONFIG_IMPORT_READHISTORIES,
+            methods::EXTERNALAGENTCONFIG_IMPORT_RECORDHISTORY,
         ]
         .into_iter()
         .collect()

--- a/codex-codes/src/protocol.rs
+++ b/codex-codes/src/protocol.rs
@@ -118,6 +118,8 @@ pub mod methods {
     pub const ACCOUNT_WORKSPACEMESSAGES_READ: &str = "account/workspaceMessages/read";
     pub const EXTERNALAGENTCONFIG_IMPORT_READHISTORIES: &str =
         "externalAgentConfig/import/readHistories";
+    pub const EXTERNALAGENTCONFIG_IMPORT_RECORDHISTORY: &str =
+        "externalAgentConfig/import/recordHistory";
 
     // Server → client notifications
     pub const THREAD_STARTED: &str = "thread/started";

--- a/codex-codes/src/protocol_generated/samples.rs
+++ b/codex-codes/src/protocol_generated/samples.rs
@@ -278,6 +278,10 @@ pub fn client_request_samples() -> Vec<(&'static str, Value)> {
         ("externalAgentConfig/detect", json!({})),
         ("externalAgentConfig/import", json!({"migrationItems": []})),
         ("externalAgentConfig/import/readHistories", json!({})),
+        (
+            "externalAgentConfig/import/recordHistory",
+            json!({"itemTypeResults": [], "providerId": "x"}),
+        ),
         ("feedback/upload", json!({"classification": "x"})),
         (
             "fs/copy",

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -416,6 +416,20 @@ pub enum AppTemplateUnavailableReason {
 pub struct AppToolSummary {
     #[serde(default)]
     pub description: String,
+    #[serde(
+        rename = "disabledReason",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub disabled_reason: Option<String>,
+    #[serde(rename = "isEnabled", default, skip_serializing_if = "Option::is_none")]
+    pub is_enabled: Option<bool>,
+    #[serde(
+        rename = "isReadOnly",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub is_read_only: Option<bool>,
     #[serde(default)]
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -590,6 +604,17 @@ pub enum AutoCompactTokenLimitScope {
 pub enum AutoReviewDecisionSource {
     #[serde(rename = "agent")]
     Agent,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrowserUseRequirements {
+    #[serde(
+        rename = "disableAutoReview",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub disable_auto_review: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1333,6 +1358,12 @@ pub struct ConfigRequirements {
     )]
     pub allowed_windows_sandbox_implementations: Option<Vec<WindowsSandboxSetupMode>>,
     #[serde(
+        rename = "browserUse",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub browser_use: Option<BrowserUseRequirements>,
+    #[serde(
         rename = "checkForUpdateOnStartup",
         default,
         skip_serializing_if = "Option::is_none"
@@ -1791,8 +1822,30 @@ pub struct ExternalAgentConfigImportHistory {
     pub failures: Vec<ExternalAgentConfigImportItemTypeFailure>,
     #[serde(rename = "importId", default)]
     pub import_id: String,
+    #[serde(
+        rename = "providerId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub provider_id: Option<String>,
     #[serde(default)]
     pub successes: Vec<ExternalAgentConfigImportItemTypeSuccess>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalAgentConfigImportHistoryRecordParams {
+    #[serde(rename = "itemTypeResults", default)]
+    pub item_type_results: Vec<ExternalAgentConfigImportTypeResult>,
+    #[serde(rename = "providerId", default)]
+    pub provider_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalAgentConfigImportHistoryRecordResponse {
+    #[serde(rename = "importId", default)]
+    pub import_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -4355,6 +4408,8 @@ pub enum PlanType {
     Self_serve_business_usage_based,
     #[serde(rename = "business")]
     Business,
+    #[serde(rename = "ent26")]
+    Ent26,
     #[serde(rename = "enterprise_cbp_usage_based")]
     Enterprise_cbp_usage_based,
     #[serde(rename = "enterprise")]
@@ -4712,6 +4767,12 @@ pub struct PluginShareCheckoutResponse {
 #[serde(rename_all = "camelCase")]
 pub struct PluginShareContext {
     #[serde(
+        rename = "canPublishToWorkspace",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub can_publish_to_workspace: Option<bool>,
+    #[serde(
         rename = "creatorAccountUserId",
         default,
         skip_serializing_if = "Option::is_none"
@@ -4851,6 +4912,12 @@ pub struct PluginShareSaveParams {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PluginShareSaveResponse {
+    #[serde(
+        rename = "canPublishToWorkspace",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub can_publish_to_workspace: Option<bool>,
     #[serde(rename = "remotePluginId", default)]
     pub remote_plugin_id: String,
     #[serde(rename = "shareUrl", default)]
@@ -5658,8 +5725,20 @@ pub struct SkillInterface {
     pub display_name: Option<String>,
     #[serde(rename = "iconLarge", default, skip_serializing_if = "Option::is_none")]
     pub icon_large: Option<AbsolutePathBuf>,
+    #[serde(
+        rename = "iconLargeUrl",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub icon_large_url: Option<String>,
     #[serde(rename = "iconSmall", default, skip_serializing_if = "Option::is_none")]
     pub icon_small: Option<AbsolutePathBuf>,
+    #[serde(
+        rename = "iconSmallUrl",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub icon_small_url: Option<String>,
     #[serde(
         rename = "shortDescription",
         default,
@@ -6368,8 +6447,16 @@ pub enum ThreadItem {
         #[serde(rename = "exitCode", default, skip_serializing_if = "Option::is_none")]
         exit_code: Option<i64>,
         id: String,
+        #[serde(rename = "pluginId", default, skip_serializing_if = "Option::is_none")]
+        plugin_id: Option<String>,
         #[serde(rename = "processId", default, skip_serializing_if = "Option::is_none")]
         process_id: Option<String>,
+        #[serde(
+            rename = "scriptPath",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        script_path: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<Value>,
         status: CommandExecutionStatus,

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -2202,6 +2202,30 @@
             },
             "method": {
               "enum": [
+                "externalAgentConfig/import/recordHistory"
+              ],
+              "title": "ExternalAgentConfig/import/recordHistoryRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ExternalAgentConfigImportHistoryRecordParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "ExternalAgentConfig/import/recordHistoryRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
                 "externalAgentConfig/import/readHistories"
               ],
               "title": "ExternalAgentConfig/import/readHistoriesRequestMethod",
@@ -6853,6 +6877,20 @@
           "description": {
             "type": "string"
           },
+          "disabledReason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "isEnabled": {
+            "default": true,
+            "type": "boolean"
+          },
+          "isReadOnly": {
+            "default": false,
+            "type": "boolean"
+          },
           "name": {
             "type": "string"
           },
@@ -7203,6 +7241,17 @@
           "agent"
         ],
         "type": "string"
+      },
+      "BrowserUseRequirements": {
+        "properties": {
+          "disableAutoReview": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
       },
       "ByteRange": {
         "properties": {
@@ -8227,7 +8276,7 @@
             ]
           },
           "reloadUserConfig": {
-            "description": "When true, hot-reload the updated user config into all loaded threads after writing.",
+            "description": "When true, hot-reload updated runtime settings into loaded threads after writing. Session-static model, reasoning-effort, Plan-mode reasoning-effort, service-tier, and personality defaults are not reloaded.",
             "type": "boolean"
           }
         },
@@ -8597,6 +8646,16 @@
             "type": [
               "array",
               "null"
+            ]
+          },
+          "browserUse": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/BrowserUseRequirements"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "checkForUpdateOnStartup": {
@@ -9727,6 +9786,12 @@
           "importId": {
             "type": "string"
           },
+          "providerId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "successes": {
             "items": {
               "$ref": "#/definitions/v2/ExternalAgentConfigImportItemTypeSuccess"
@@ -9740,6 +9805,41 @@
           "importId",
           "successes"
         ],
+        "type": "object"
+      },
+      "ExternalAgentConfigImportHistoryRecordParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "itemTypeResults": {
+            "description": "Completed results grouped by imported item type.",
+            "items": {
+              "$ref": "#/definitions/v2/ExternalAgentConfigImportTypeResult"
+            },
+            "type": "array"
+          },
+          "providerId": {
+            "description": "Opaque provider identifier for the externally completed import.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "itemTypeResults",
+          "providerId"
+        ],
+        "title": "ExternalAgentConfigImportHistoryRecordParams",
+        "type": "object"
+      },
+      "ExternalAgentConfigImportHistoryRecordResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "importId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "importId"
+        ],
+        "title": "ExternalAgentConfigImportHistoryRecordResponse",
         "type": "object"
       },
       "ExternalAgentConfigImportItemTypeFailure": {
@@ -9831,7 +9931,7 @@
             ]
           },
           "providerId": {
-            "description": "Opaque provider identifier supplied by the caller for analytics attribution. This does not select the migration source.",
+            "description": "Opaque provider identifier supplied by the caller for analytics attribution and import history display. This does not select the migration source.",
             "type": [
               "string",
               "null"
@@ -13899,6 +13999,7 @@
           "team",
           "self_serve_business_usage_based",
           "business",
+          "ent26",
           "enterprise_cbp_usage_based",
           "enterprise",
           "edu",
@@ -14494,6 +14595,13 @@
       },
       "PluginShareContext": {
         "properties": {
+          "canPublishToWorkspace": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "creatorAccountUserId": {
             "type": [
               "string",
@@ -14696,6 +14804,13 @@
       "PluginShareSaveResponse": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
+          "canPublishToWorkspace": {
+            "default": null,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "remotePluginId": {
             "type": "string"
           },
@@ -17379,6 +17494,13 @@
               }
             ]
           },
+          "iconLargeUrl": {
+            "description": "Remote large icon URL from the plugin catalog.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "iconSmall": {
             "anyOf": [
               {
@@ -17387,6 +17509,13 @@
               {
                 "type": "null"
               }
+            ]
+          },
+          "iconSmallUrl": {
+            "description": "Remote small icon URL from the plugin catalog.",
+            "type": [
+              "string",
+              "null"
             ]
           },
           "shortDescription": {
@@ -18815,8 +18944,24 @@
               "id": {
                 "type": "string"
               },
+              "pluginId": {
+                "default": null,
+                "description": "Trusted first-party plugin id when this command resolves to one plugin script.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "processId": {
                 "description": "Identifier for the underlying PTY process (when available).",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "scriptPath": {
+                "default": null,
+                "description": "Safe plugin-relative path when this command resolves to one plugin script.",
                 "type": [
                   "string",
                   "null"

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -869,6 +869,20 @@
         "description": {
           "type": "string"
         },
+        "disabledReason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "isEnabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "isReadOnly": {
+          "default": false,
+          "type": "boolean"
+        },
         "name": {
           "type": "string"
         },
@@ -1219,6 +1233,17 @@
         "agent"
       ],
       "type": "string"
+    },
+    "BrowserUseRequirements": {
+      "properties": {
+        "disableAutoReview": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
     },
     "ByteRange": {
       "properties": {
@@ -3327,6 +3352,30 @@
             },
             "method": {
               "enum": [
+                "externalAgentConfig/import/recordHistory"
+              ],
+              "title": "ExternalAgentConfig/import/recordHistoryRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ExternalAgentConfigImportHistoryRecordParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "ExternalAgentConfig/import/recordHistoryRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
                 "externalAgentConfig/import/readHistories"
               ],
               "title": "ExternalAgentConfig/import/readHistoriesRequestMethod",
@@ -4405,7 +4454,7 @@
           ]
         },
         "reloadUserConfig": {
-          "description": "When true, hot-reload the updated user config into all loaded threads after writing.",
+          "description": "When true, hot-reload updated runtime settings into loaded threads after writing. Session-static model, reasoning-effort, Plan-mode reasoning-effort, service-tier, and personality defaults are not reloaded.",
           "type": "boolean"
         }
       },
@@ -4775,6 +4824,16 @@
           "type": [
             "array",
             "null"
+          ]
+        },
+        "browserUse": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BrowserUseRequirements"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "checkForUpdateOnStartup": {
@@ -5905,6 +5964,12 @@
         "importId": {
           "type": "string"
         },
+        "providerId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "successes": {
           "items": {
             "$ref": "#/definitions/ExternalAgentConfigImportItemTypeSuccess"
@@ -5918,6 +5983,41 @@
         "importId",
         "successes"
       ],
+      "type": "object"
+    },
+    "ExternalAgentConfigImportHistoryRecordParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "itemTypeResults": {
+          "description": "Completed results grouped by imported item type.",
+          "items": {
+            "$ref": "#/definitions/ExternalAgentConfigImportTypeResult"
+          },
+          "type": "array"
+        },
+        "providerId": {
+          "description": "Opaque provider identifier for the externally completed import.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "itemTypeResults",
+        "providerId"
+      ],
+      "title": "ExternalAgentConfigImportHistoryRecordParams",
+      "type": "object"
+    },
+    "ExternalAgentConfigImportHistoryRecordResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "importId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "importId"
+      ],
+      "title": "ExternalAgentConfigImportHistoryRecordResponse",
       "type": "object"
     },
     "ExternalAgentConfigImportItemTypeFailure": {
@@ -6009,7 +6109,7 @@
           ]
         },
         "providerId": {
-          "description": "Opaque provider identifier supplied by the caller for analytics attribution. This does not select the migration source.",
+          "description": "Opaque provider identifier supplied by the caller for analytics attribution and import history display. This does not select the migration source.",
           "type": [
             "string",
             "null"
@@ -10241,6 +10341,7 @@
         "team",
         "self_serve_business_usage_based",
         "business",
+        "ent26",
         "enterprise_cbp_usage_based",
         "enterprise",
         "edu",
@@ -10836,6 +10937,13 @@
     },
     "PluginShareContext": {
       "properties": {
+        "canPublishToWorkspace": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "creatorAccountUserId": {
           "type": [
             "string",
@@ -11038,6 +11146,13 @@
     "PluginShareSaveResponse": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
+        "canPublishToWorkspace": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "remotePluginId": {
           "type": "string"
         },
@@ -15143,6 +15258,13 @@
             }
           ]
         },
+        "iconLargeUrl": {
+          "description": "Remote large icon URL from the plugin catalog.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "iconSmall": {
           "anyOf": [
             {
@@ -15151,6 +15273,13 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "iconSmallUrl": {
+          "description": "Remote small icon URL from the plugin catalog.",
+          "type": [
+            "string",
+            "null"
           ]
         },
         "shortDescription": {
@@ -16579,8 +16708,24 @@
             "id": {
               "type": "string"
             },
+            "pluginId": {
+              "default": null,
+              "description": "Trusted first-party plugin id when this command resolves to one plugin script.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "processId": {
               "description": "Identifier for the underlying PTY process (when available).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "scriptPath": {
+              "default": null,
+              "description": "Safe plugin-relative path when this command resolves to one plugin script.",
               "type": [
                 "string",
                 "null"


### PR DESCRIPTION
Fixes #232.

Refreshes both app-server schema snapshots from `openai/codex@main` (byte-identical per `check_codex_schema_drift.py`) and regenerates typed structs/samples.

- **New client request modeled**: `externalAgentConfig/import/recordHistory` — method constant + generated `ExternalAgentConfigImportHistoryRecordParams`/`Response`.
- **New definition**: `BrowserUseRequirements` (optional `browser_use` on `ConfigRequirements`).
- Additive fields across `AppToolSummary`, `PlanType`, `PluginShareContext`/`SaveResponse`, `SkillInterface`, `ThreadItem`, and the external-agent-config import types. No breaking changes to hand-written helpers this time.
- Version 0.143.6 with changelog; README pin updated.

Verified: drift check byte-identical ✅, `schema_coverage` 170/170 (100%) ✅, workspace tests + clippy clean ✅.