### PR TITLE
claude-codes 2.1.165: typed accessors for vcs and PR system events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.164"
+version = "2.1.165"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This workspace provides two independent crates for interacting with [Claude Code
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.164`, tested against Claude CLI `2.1.219`.
+- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.165`, tested against Claude CLI `2.1.219`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.143.5`, tested against Codex CLI `0.143.0`.
 
 Both crates will warn (or fail gracefully) if the installed CLI version diverges from the tested version.

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.165] - 2026-07-25
+
+### Added
+
+- **`SystemMessage::as_code_change_published()` / `as_vcs_state_changed()`**
+  (plus `is_*` checks) — dedicated typed accessors following the
+  `as_init()` pattern, so consumers reach `CodeChangePublishedMessage` /
+  `VcsStateChangedMessage` without matching on `KnownSystemEvent` or poking
+  raw JSON (#231). Note: the `vcs_state_changed` SDK frame is flat
+  (`kind` + `cwd`) — the CLI's internal git/gh watcher event carries richer
+  `commit`/`push`/`branch`/`pr` sections, but the emitter flattens each to
+  one-or-more `kind` frames before they cross the wire.
+
 ## [2.1.164] - 2026-07-24
 
 Catches up to CLI 2.1.219 — the Opus 5 release. Snapshot baseline and

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.164"
+version = "2.1.165"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/src/io/message_types.rs
+++ b/claude-codes/src/io/message_types.rs
@@ -970,6 +970,32 @@ impl SystemMessage {
         serde_json::from_value(self.data.clone()).ok()
     }
 
+    /// Check if this is a code_change_published message
+    pub fn is_code_change_published(&self) -> bool {
+        self.subtype == SystemSubtype::CodeChangePublished
+    }
+
+    /// Try to parse as a code_change_published message
+    pub fn as_code_change_published(&self) -> Option<CodeChangePublishedMessage> {
+        if self.subtype != SystemSubtype::CodeChangePublished {
+            return None;
+        }
+        serde_json::from_value(self.data.clone()).ok()
+    }
+
+    /// Check if this is a vcs_state_changed message
+    pub fn is_vcs_state_changed(&self) -> bool {
+        self.subtype == SystemSubtype::VcsStateChanged
+    }
+
+    /// Try to parse as a vcs_state_changed message
+    pub fn as_vcs_state_changed(&self) -> Option<VcsStateChangedMessage> {
+        if self.subtype != SystemSubtype::VcsStateChanged {
+            return None;
+        }
+        serde_json::from_value(self.data.clone()).ok()
+    }
+
     /// Parse any typed system subtype known to this crate version.
     pub fn as_known_system_event(&self) -> Option<KnownSystemEvent> {
         macro_rules! parse {
@@ -3022,6 +3048,12 @@ mod tests {
         assert_eq!(msg.provider, "github");
         assert_eq!(msg.repo, "owner/repo");
         assert_eq!(msg.identifier, "42");
+
+        assert!(sys.is_code_change_published());
+        assert!(!sys.is_vcs_state_changed());
+        let direct = sys.as_code_change_published().expect("direct accessor");
+        assert_eq!(direct.url, "https://github.com/owner/repo/pull/42");
+        assert!(sys.as_vcs_state_changed().is_none());
     }
 
     #[test]
@@ -3062,6 +3094,11 @@ mod tests {
             panic!("expected VcsStateChanged event");
         };
         assert_eq!(msg.kind, VcsMutationKind::Unknown("tag".to_string()));
+
+        assert!(sys.is_vcs_state_changed());
+        let direct = sys.as_vcs_state_changed().expect("direct accessor");
+        assert_eq!(direct.cwd, "/repo");
+        assert!(sys.as_code_change_published().is_none());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #231.

Adds `SystemMessage::as_code_change_published()` / `as_vcs_state_changed()` (plus `is_*` checks) following the existing `as_init()` pattern. The typed payload structs already landed in 2.1.164; this completes the ergonomic path agent-portal needs (no `KnownSystemEvent` matching, no JSON poking).

**Wire-shape note for the issue's `vcs_state_changed` sketch:** the nested `commit`/`push`/`branch`/`pr` sections belong to the CLI's *internal* git/gh watcher event. Verified in the 2.1.219 binary's emitter: it flattens that event into one-or-more flat SDK frames —

```js
if(e.commit)t.push("commit");if(e.push)t.push("push");
if(e.branch){let r={merged:"merge",rebased:"rebase"};t.push(r[e.branch.action])}
for(let r of t)lA({type:"system",subtype:"vcs_state_changed",kind:r,cwd:Ht()})
```

— so the existing flat `VcsStateChangedMessage { kind, cwd }` is the actual wire contract (also confirmed by the CLI's own zod schema and the drift snapshot). PR-detail consumers should bind on `code_change_published`, which does carry `provider`/`url`/`repo`/`identifier`.

Version 2.1.165 with changelog. Tests extended to exercise the accessors; workspace clippy clean.