### PR TITLE
codex-codes: expose process configuration

### DIFF
--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `AppServerBuilder::env` and `envs` for configuring the app-server process
+  environment.
+- `AppServerBuilder::build_command` and `build_command_sync`, plus
+  `AsyncClient::new` and `SyncClient::new`, for customizing and spawning the
+  app-server separately from client construction.
+
 ## [0.143.6] - 2026-07-25
 
 Re-snapshot of the app-server schema from `openai/codex@main`, resolving the

--- a/codex-codes/src/cli.rs
+++ b/codex-codes/src/cli.rs
@@ -4,6 +4,7 @@
 //! a long-lived process that speaks JSON-RPC over newline-delimited stdio.
 
 use log::debug;
+use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::process::Stdio;
 
@@ -19,6 +20,8 @@ use std::process::Stdio;
 pub struct AppServerBuilder {
     command: PathBuf,
     working_directory: Option<PathBuf>,
+    /// Environment variables set on the app-server child process.
+    environment: Vec<(OsString, OsString)>,
     /// `-c key=value` overrides, in insertion order. Emitted *before* the
     /// `app-server` subcommand because `-c` is a global `codex` flag.
     config_overrides: Vec<(String, String)>,
@@ -39,6 +42,7 @@ impl AppServerBuilder {
         Self {
             command: PathBuf::from("codex"),
             working_directory: None,
+            environment: Vec::new(),
             config_overrides: Vec::new(),
             extra_args: Vec::new(),
         }
@@ -53,6 +57,46 @@ impl AppServerBuilder {
     /// Set the working directory for the app-server process.
     pub fn working_directory<P: Into<PathBuf>>(mut self, dir: P) -> Self {
         self.working_directory = Some(dir.into());
+        self
+    }
+
+    /// Set an environment variable on the app-server child process.
+    ///
+    /// Calling this more than once with the same key follows
+    /// [`std::process::Command::env`] semantics: the last value wins.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use codex_codes::AppServerBuilder;
+    ///
+    /// let builder = AppServerBuilder::new().env("CODEX_HOME", "/tmp/codex-home");
+    /// ```
+    pub fn env<K, V>(mut self, key: K, value: V) -> Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.environment
+            .push((key.as_ref().to_os_string(), value.as_ref().to_os_string()));
+        self
+    }
+
+    /// Set environment variables on the app-server child process.
+    ///
+    /// If the iterator contains duplicate keys, or a key was already set by
+    /// [`env`](Self::env), the last value wins.
+    pub fn envs<I, K, V>(mut self, variables: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.environment.extend(
+            variables
+                .into_iter()
+                .map(|(key, value)| (key.as_ref().to_os_string(), value.as_ref().to_os_string())),
+        );
         self
     }
 
@@ -139,53 +183,62 @@ impl AppServerBuilder {
         args
     }
 
-    /// Spawn the app-server process asynchronously.
+    /// Build a Tokio command without spawning it.
+    ///
+    /// This is the escape hatch for process configuration not modeled by the
+    /// builder. The command is fully configured for app-server stdio; callers
+    /// can make further adjustments before spawning it.
+    ///
+    /// Pair this with [`crate::AsyncClient::new`] to customize the command
+    /// while preserving the SDK's stdio setup.
     #[cfg(feature = "async-client")]
-    pub async fn spawn(self) -> crate::error::Result<tokio::process::Child> {
+    pub fn build_command(self) -> crate::error::Result<tokio::process::Command> {
+        self.build_command_sync().map(tokio::process::Command::from)
+    }
+
+    /// Build a standard-library command without spawning it.
+    ///
+    /// This is the synchronous counterpart to [`build_command`](Self::build_command).
+    /// Pair it with [`crate::SyncClient::new`] to customize the command while
+    /// preserving the SDK's stdio setup.
+    pub fn build_command_sync(self) -> crate::error::Result<std::process::Command> {
         let resolved = self.resolve_command()?;
         let args = self.build_args();
 
         debug!(
-            "[CLI] Spawning async app-server: {} {}",
+            "[CLI] Building app-server command: {} {}",
             resolved.display(),
             args.join(" ")
         );
 
-        let mut cmd = tokio::process::Command::new(&resolved);
-        cmd.args(&args)
+        let mut command = std::process::Command::new(resolved);
+        command
+            .args(args)
+            .envs(self.environment)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
-        if let Some(ref dir) = self.working_directory {
-            cmd.current_dir(dir);
+        if let Some(dir) = self.working_directory {
+            command.current_dir(dir);
         }
 
-        cmd.spawn().map_err(crate::error::Error::Io)
+        Ok(command)
+    }
+
+    /// Spawn the app-server process asynchronously.
+    #[cfg(feature = "async-client")]
+    pub async fn spawn(self) -> crate::error::Result<tokio::process::Child> {
+        self.build_command()?
+            .spawn()
+            .map_err(crate::error::Error::Io)
     }
 
     /// Spawn the app-server process synchronously.
     pub fn spawn_sync(self) -> crate::error::Result<std::process::Child> {
-        let resolved = self.resolve_command()?;
-        let args = self.build_args();
-
-        debug!(
-            "[CLI] Spawning sync app-server: {} {}",
-            resolved.display(),
-            args.join(" ")
-        );
-
-        let mut cmd = std::process::Command::new(&resolved);
-        cmd.args(&args)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
-        if let Some(ref dir) = self.working_directory {
-            cmd.current_dir(dir);
-        }
-
-        cmd.spawn().map_err(crate::error::Error::Io)
+        self.build_command_sync()?
+            .spawn()
+            .map_err(crate::error::Error::Io)
     }
 }
 
@@ -211,6 +264,43 @@ mod tests {
     fn test_working_directory() {
         let builder = AppServerBuilder::new().working_directory("/tmp/work");
         assert_eq!(builder.working_directory, Some(PathBuf::from("/tmp/work")));
+    }
+
+    #[test]
+    fn test_build_command_sync_applies_process_configuration() {
+        let executable = std::env::current_exe().unwrap();
+        let command = AppServerBuilder::new()
+            .command(&executable)
+            .working_directory("/tmp/work")
+            .env("CODEX_HOME", "/tmp/original")
+            .envs([("RUST_LOG", "debug"), ("CODEX_HOME", "/tmp/codex-home")])
+            .config_override("approval_policy", "never")
+            .extra_args(["--strict-config"])
+            .build_command_sync()
+            .unwrap();
+
+        assert_eq!(command.get_program(), executable);
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            [
+                "-c",
+                "approval_policy=never",
+                "app-server",
+                "--listen",
+                "stdio://",
+                "--strict-config",
+            ]
+        );
+        assert_eq!(
+            command.get_current_dir(),
+            Some(std::path::Path::new("/tmp/work"))
+        );
+        assert!(command.get_envs().any(|(key, value)| {
+            key == "CODEX_HOME" && value == Some(OsStr::new("/tmp/codex-home"))
+        }));
+        assert!(command
+            .get_envs()
+            .any(|(key, value)| key == "RUST_LOG" && value == Some(OsStr::new("debug"))));
     }
 
     #[test]

--- a/codex-codes/src/client_async.rs
+++ b/codex-codes/src/client_async.rs
@@ -88,55 +88,13 @@ pub struct AsyncClient {
 }
 
 impl AsyncClient {
-    /// Start an app-server with default settings.
+    /// Create a client from an existing Tokio child process.
     ///
-    /// Spawns `codex app-server --listen stdio://`, performs the required
-    /// `initialize` handshake, and returns a connected client ready for
-    /// `thread_start()`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the `codex` CLI is not installed, the version is
-    /// incompatible, the process fails to start, or the initialization
-    /// handshake fails.
-    pub async fn start() -> Result<Self> {
-        Self::start_with(AppServerBuilder::new()).await
-    }
-
-    /// Start an app-server with a custom [`AppServerBuilder`].
-    ///
-    /// Performs the required `initialize` handshake before returning.
-    /// Use this to configure a custom binary path or working directory.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the process fails to start, stdio pipes
-    /// cannot be established, or the initialization handshake fails.
-    pub async fn start_with(builder: AppServerBuilder) -> Result<Self> {
-        let mut client = Self::spawn(builder).await?;
-        client
-            .initialize(&InitializeParams {
-                client_info: ClientInfo {
-                    name: "codex-codes".to_string(),
-                    version: env!("CARGO_PKG_VERSION").to_string(),
-                    title: None,
-                },
-                capabilities: None,
-            })
-            .await?;
-        Ok(client)
-    }
-
-    /// Spawn an app-server without performing the `initialize` handshake.
-    ///
-    /// Use this if you need to send a custom [`InitializeParams`] (e.g., with
-    /// specific capabilities). You **must** call [`AsyncClient::initialize`]
-    /// before any other requests.
-    pub async fn spawn(builder: AppServerBuilder) -> Result<Self> {
-        crate::version::check_codex_version_async().await?;
-
-        let mut child = builder.spawn().await?;
-
+    /// The child's stdin, stdout, and stderr must all be piped. This does not
+    /// perform the app-server `initialize` handshake or a Codex version check.
+    /// Use [`AppServerBuilder::build_command`] to retain the SDK's command-line
+    /// and stdio configuration while customizing how the process is spawned.
+    pub fn new(mut child: Child) -> Result<Self> {
         let stdin = child
             .stdin
             .take()
@@ -164,6 +122,56 @@ impl AsyncClient {
             next_id: AtomicI64::new(1),
             buffered: VecDeque::new(),
         })
+    }
+
+    /// Start an app-server with default settings.
+    ///
+    /// Spawns `codex app-server --listen stdio://`, performs the required
+    /// `initialize` handshake, and returns a connected client ready for
+    /// `thread_start()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `codex` CLI is not installed, the version is
+    /// incompatible, the process fails to start, or the initialization
+    /// handshake fails.
+    pub async fn start() -> Result<Self> {
+        Self::start_with(AppServerBuilder::new()).await
+    }
+
+    /// Start an app-server with a custom [`AppServerBuilder`].
+    ///
+    /// Performs the required `initialize` handshake before returning.
+    /// Use this to configure the binary path, working directory, environment,
+    /// or CLI arguments.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the process fails to start, stdio pipes
+    /// cannot be established, or the initialization handshake fails.
+    pub async fn start_with(builder: AppServerBuilder) -> Result<Self> {
+        let mut client = Self::spawn(builder).await?;
+        client
+            .initialize(&InitializeParams {
+                client_info: ClientInfo {
+                    name: "codex-codes".to_string(),
+                    version: env!("CARGO_PKG_VERSION").to_string(),
+                    title: None,
+                },
+                capabilities: None,
+            })
+            .await?;
+        Ok(client)
+    }
+
+    /// Spawn an app-server without performing the `initialize` handshake.
+    ///
+    /// Use this if you need to send a custom [`InitializeParams`] (e.g., with
+    /// specific capabilities). You **must** call [`AsyncClient::initialize`]
+    /// before any other requests.
+    pub async fn spawn(builder: AppServerBuilder) -> Result<Self> {
+        crate::version::check_codex_version_async().await?;
+        Self::new(builder.spawn().await?)
     }
 
     /// Send a JSON-RPC request and wait for the matching response.

--- a/codex-codes/src/client_sync.rs
+++ b/codex-codes/src/client_sync.rs
@@ -85,53 +85,14 @@ pub struct SyncClient {
 }
 
 impl SyncClient {
-    /// Start an app-server with default settings.
+    /// Create a client from an existing child process.
     ///
-    /// Spawns `codex app-server --listen stdio://`, performs the required
-    /// `initialize` handshake, and returns a connected client ready for
-    /// `thread_start()`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the `codex` CLI is not installed, the version is
-    /// incompatible, the process fails to start, or the initialization
-    /// handshake fails.
-    pub fn start() -> Result<Self> {
-        Self::start_with(AppServerBuilder::new())
-    }
-
-    /// Start an app-server with a custom [`AppServerBuilder`].
-    ///
-    /// Performs the required `initialize` handshake before returning.
-    /// Use this to configure a custom binary path or working directory.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the process fails to start, stdio pipes
-    /// cannot be established, or the initialization handshake fails.
-    pub fn start_with(builder: AppServerBuilder) -> Result<Self> {
-        let mut client = Self::spawn(builder)?;
-        client.initialize(&InitializeParams {
-            client_info: ClientInfo {
-                name: "codex-codes".to_string(),
-                version: env!("CARGO_PKG_VERSION").to_string(),
-                title: None,
-            },
-            capabilities: None,
-        })?;
-        Ok(client)
-    }
-
-    /// Spawn an app-server without performing the `initialize` handshake.
-    ///
-    /// Use this if you need to send a custom [`InitializeParams`] (e.g., with
-    /// specific capabilities). You **must** call [`SyncClient::initialize`]
-    /// before any other requests.
-    pub fn spawn(builder: AppServerBuilder) -> Result<Self> {
-        crate::version::check_codex_version()?;
-
-        let mut child = builder.spawn_sync()?;
-
+    /// The child's stdin, stdout, and stderr must all be piped. This does not
+    /// perform the app-server `initialize` handshake or a Codex version check.
+    /// Use [`AppServerBuilder::build_command_sync`] to retain the SDK's
+    /// command-line and stdio configuration while customizing how the process
+    /// is spawned.
+    pub fn new(mut child: Child) -> Result<Self> {
         let stdin = child
             .stdin
             .take()
@@ -159,6 +120,54 @@ impl SyncClient {
             next_id: 1,
             buffered: VecDeque::new(),
         })
+    }
+
+    /// Start an app-server with default settings.
+    ///
+    /// Spawns `codex app-server --listen stdio://`, performs the required
+    /// `initialize` handshake, and returns a connected client ready for
+    /// `thread_start()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `codex` CLI is not installed, the version is
+    /// incompatible, the process fails to start, or the initialization
+    /// handshake fails.
+    pub fn start() -> Result<Self> {
+        Self::start_with(AppServerBuilder::new())
+    }
+
+    /// Start an app-server with a custom [`AppServerBuilder`].
+    ///
+    /// Performs the required `initialize` handshake before returning.
+    /// Use this to configure the binary path, working directory, environment,
+    /// or CLI arguments.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the process fails to start, stdio pipes
+    /// cannot be established, or the initialization handshake fails.
+    pub fn start_with(builder: AppServerBuilder) -> Result<Self> {
+        let mut client = Self::spawn(builder)?;
+        client.initialize(&InitializeParams {
+            client_info: ClientInfo {
+                name: "codex-codes".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                title: None,
+            },
+            capabilities: None,
+        })?;
+        Ok(client)
+    }
+
+    /// Spawn an app-server without performing the `initialize` handshake.
+    ///
+    /// Use this if you need to send a custom [`InitializeParams`] (e.g., with
+    /// specific capabilities). You **must** call [`SyncClient::initialize`]
+    /// before any other requests.
+    pub fn spawn(builder: AppServerBuilder) -> Result<Self> {
+        crate::version::check_codex_version()?;
+        Self::new(builder.spawn_sync()?)
     }
 
     /// Send a JSON-RPC request and wait for the matching response.

--- a/codex-codes/tests/live_client_tests.rs
+++ b/codex-codes/tests/live_client_tests.rs
@@ -130,6 +130,7 @@ async fn test_async_client_custom_initialize() {
             },
             capabilities: Some(InitializeCapabilities {
                 experimental_api: Some(false),
+                mcp_server_openai_form_elicitation: None,
                 opt_out_notification_methods: None,
                 request_attestation: None,
             }),
@@ -497,6 +498,9 @@ async fn test_typed_message_audit_strict() {
                     Notification::ExternalAgentConfigImportCompleted(_) => {
                         "ExternalAgentConfigImportCompleted"
                     }
+                    Notification::ExternalAgentConfigImportProgress(_) => {
+                        "ExternalAgentConfigImportProgress"
+                    }
                     Notification::FuzzyFileSearchSessionCompleted(_) => {
                         "FuzzyFileSearchSessionCompleted"
                     }
@@ -514,12 +518,17 @@ async fn test_typed_message_audit_strict() {
                     Notification::TerminalInteraction(_) => "TerminalInteraction",
                     Notification::McpToolCallProgress(_) => "McpToolCallProgress",
                     Notification::ModelRerouted(_) => "ModelRerouted",
+                    Notification::ModelSafetyBufferingUpdated(_) => "ModelSafetyBufferingUpdated",
                     Notification::ModelVerification(_) => "ModelVerification",
                     Notification::ProcessExited(_) => "ProcessExited",
                     Notification::ProcessOutputDelta(_) => "ProcessOutputDelta",
                     Notification::ServerRequestResolved(_) => "ServerRequestResolved",
                     Notification::ContextCompacted(_) => "ContextCompacted",
                     Notification::ThreadGoalUpdated(_) => "ThreadGoalUpdated",
+                    Notification::ThreadEnvironmentConnected(_) => "ThreadEnvironmentConnected",
+                    Notification::ThreadEnvironmentDisconnected(_) => {
+                        "ThreadEnvironmentDisconnected"
+                    }
                     Notification::ThreadRealtimeClosed(_) => "ThreadRealtimeClosed",
                     Notification::ThreadRealtimeError(_) => "ThreadRealtimeError",
                     Notification::ThreadRealtimeItemAdded(_) => "ThreadRealtimeItemAdded",


### PR DESCRIPTION
## Motivation

`codex-codes` currently couples app-server process construction, spawning, and client setup. Embedders that need an isolated `CODEX_HOME`, a curated environment, or platform-specific `Command` configuration must either duplicate the SDK's CLI/stdio setup or bypass the high-level client.

`claude-codes` already exposes the process/client boundary through `build_command` and `AsyncClient::new` / `SyncClient::new`. Aligning `codex-codes` with that shape makes the two SDKs easier to integrate consistently while preserving the existing version-checked convenience APIs.

## Changes

- Add `AppServerBuilder::env` and `envs`.
- Add `build_command` and `build_command_sync` as pre-spawn customization points.
- Add `AsyncClient::new` and `SyncClient::new` for caller-spawned children.
- Refactor existing spawn paths through the new APIs.
- Document stdio, initialization, and version-check responsibilities.
- Test command arguments, working directory, environment propagation, and last-value-wins behavior.

Existing `start`, `start_with`, and `spawn` behavior remains unchanged.