### PR TITLE
Hoist shared deps and lint policy to workspace root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,22 @@
 [workspace]
 members = ["claude-codes", "codex-codes", "opencode-codes"]
 resolver = "2"
+
+# Dependencies shared by two or more workspace crates. Members reference these
+# with `{ workspace = true }` so versions move in lockstep.
+[workspace.dependencies]
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.143"
+thiserror = "2.0.16"
+tokio = { version = "1.49.0", features = ["full"] }
+log = "0.4.29"
+which = "8.0.2"
+env_logger = "0.11.9"
+jsonschema = "0.46.5"
+
+# Lint policy shared across workspace crates; members opt in with
+# `[lints] workspace = true`. `deny` rather than `forbid` so the one vetted
+# unsafe site (opencode-codes' process-group signal FFI) can carry a scoped
+# `#[allow]` with its SAFETY comment.
+[workspace.lints.rust]
+unsafe_code = "deny"

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Shared dependencies and lint policy moved to the workspace root: `serde`,
+  `serde_json`, `thiserror`, `tokio`, `log`, `which`, and dev `env_logger` are
+  now `{ workspace = true }`, and the crate opts into `[workspace.lints]`
+  (`unsafe_code = "deny"`). Aligns previously drifted versions: `tokio`
+  1.47.1 → 1.49.0, `log` 0.4.27 → 0.4.29, `env_logger` 0.11.8 → 0.11.9.
+
 ## [2.1.165] - 2026-07-25
 
 ### Added

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -17,19 +17,22 @@ exclude = [
     "*.sh",
 ]
 
+[lints]
+workspace = true
+
 [dependencies]
 # Core dependencies always needed for types
 chrono = { version = "0.4.41", features = ["serde"] }
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.143"
-thiserror = "2.0.16"
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 uuid = { version = "1.18.0", default-features = false, features = ["serde"] }
 
 # Optional dependencies for clients
 anyhow = { version = "1.0.99", optional = true }
-tokio = { version = "1.47.1", features = ["full"], optional = true }
-log = { version = "0.4.27", optional = true }
-which = { version = "8.0.2", optional = true }
+tokio = { workspace = true, optional = true }
+log = { workspace = true, optional = true }
+which = { workspace = true, optional = true }
 
 [features]
 default = ["types", "sync-client", "async-client"]
@@ -41,10 +44,10 @@ corpus-test = []
 log = ["dep:log"]
 
 [dev-dependencies]
-env_logger = "0.11.8"
+env_logger = { workspace = true }
 base64 = "0.22.1"
 uuid = { version = "1.18.0", features = ["v4"] }
-tokio = { version = "1.47.1", features = ["full"] }
+tokio = { workspace = true }
 anyhow = "1.0.99"
 
 [[example]]

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AsyncClient::new` and `SyncClient::new`, for customizing and spawning the
   app-server separately from client construction.
 
+### Changed
+
+- Shared dependencies and lint policy moved to the workspace root: `serde`,
+  `serde_json`, `thiserror`, `tokio`, `log`, `which`, and dev `env_logger` /
+  `jsonschema` are now `{ workspace = true }`, and the crate opts into
+  `[workspace.lints]` (`unsafe_code = "deny"`). No dependency version changes.
+
 ## [0.143.6] - 2026-07-25
 
 Re-snapshot of the app-server schema from `openai/codex@main`, resolving the

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -18,19 +18,22 @@ exclude = [
     "*.sh",
 ]
 
+[lints]
+workspace = true
+
 [dependencies]
-log = { version = "0.4.29", optional = true }
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.143"
-thiserror = "2.0.16"
-tokio = { version = "1.49.0", features = ["full"], optional = true }
-which = { version = "8.0.2", optional = true }
+log = { workspace = true, optional = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, optional = true }
+which = { workspace = true, optional = true }
 
 [dev-dependencies]
-env_logger = "0.11.9"
-jsonschema = "0.46.5"
-serde_json = "1.0.143"
-tokio = { version = "1.49.0", features = ["full"] }
+env_logger = { workspace = true }
+jsonschema = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
 
 [features]
 default = ["types", "sync-client", "async-client"]

--- a/opencode-codes/CHANGELOG.md
+++ b/opencode-codes/CHANGELOG.md
@@ -32,3 +32,11 @@ release train.
   waits for health, and tears the process group down on drop.
 - OpenAPI 3.1 snapshot of opencode 1.18.5 at
   `tests/schemas/opencode_openapi.json` as the drift-check ground truth.
+
+### Changed
+
+- Shared dependencies and lint policy moved to the workspace root: `serde`,
+  `serde_json`, `thiserror`, `tokio`, and dev `jsonschema` are now
+  `{ workspace = true }`, and the crate opts into `[workspace.lints]`
+  (`unsafe_code = "deny"`) with a scoped `#[allow]` on the vetted
+  process-group signal FFI in `server.rs`. No dependency version changes.

--- a/opencode-codes/Cargo.toml
+++ b/opencode-codes/Cargo.toml
@@ -17,16 +17,19 @@ exclude = [
     "*.sh",
 ]
 
+[lints]
+workspace = true
+
 [dependencies]
 # Core dependencies always needed for the `types` tier (must build on wasm32).
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.143"
-thiserror = "2.0.16"
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 
 # Optional dependencies for the async HTTP/SSE client.
 reqwest = { version = "0.12.28", default-features = false, features = ["rustls-tls", "json", "stream"], optional = true }
 reqwest-eventsource = { version = "0.6.0", optional = true }
-tokio = { version = "1.49.0", features = ["full"], optional = true }
+tokio = { workspace = true, optional = true }
 futures-core = { version = "0.3.32", optional = true }
 
 # Optional dependency for the managed local-server launcher.
@@ -46,6 +49,6 @@ server = ["async-client", "dep:portpicker"]
 integration-tests = []
 
 [dev-dependencies]
-jsonschema = "0.46.5"
-serde_json = "1.0.143"
-tokio = { version = "1.49.0", features = ["full"] }
+jsonschema = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }

--- a/opencode-codes/src/server.rs
+++ b/opencode-codes/src/server.rs
@@ -55,6 +55,7 @@ const SIGKILL: i32 = 9;
 /// `ESRCH`) is the desired state, and there is nothing actionable to do on any
 /// other failure during teardown.
 #[cfg(unix)]
+#[allow(unsafe_code)] // The workspace denies unsafe_code; this FFI signal call is the one vetted exception.
 fn signal_process_group(pgid: i32, sig: i32) {
     extern "C" {
         fn kill(pid: i32, sig: i32) -> i32;


### PR DESCRIPTION
Fresh implementation of what #177 set out to do, redone against the current three-crate workspace (the original predates opencode-codes and four release cycles of manifest churn — unrescuable by rebase).

## Changes

- **`[workspace.dependencies]`**: everything shared by ≥2 crates — `serde`, `serde_json`, `thiserror`, `tokio`, `log`, `which`, dev `env_logger`/`jsonschema` — hoisted; members use `{ workspace = true }`. Crate-specific deps (`chrono`, `uuid`, `anyhow`, `base64`, `reqwest`, `reqwest-eventsource`, `futures-core`, `portpicker`) stay local.
- **Version lockstep restored** (the drift #177 originally flagged, still present): claude-codes `tokio` 1.47.1 → 1.49.0, `log` 0.4.27 → 0.4.29, `env_logger` 0.11.8 → 0.11.9. codex/opencode versions unchanged.
- **`[workspace.lints.rust] unsafe_code = "deny"`**, all three crates opting in via `[lints] workspace = true`. One deliberate divergence from #177's `forbid`: its "no unsafe exists" premise is stale — opencode-codes has one vetted unsafe site (process-group `kill` FFI in `server.rs`, SAFETY-documented), which now carries a scoped `#[allow(unsafe_code)]`. `deny` permits that; `forbid` wouldn't.
- Changelog entries in all three crates (claude under `[Unreleased]`, codex appended to its existing `[Unreleased]`, opencode folded into the unpublished 1.18.5 entry).

## Verification

- `cargo test --workspace` ✅ · clippy `--all-targets` **and** `--all-features` zero warnings ✅ · `cargo +1.85 check --workspace` (MSRV) ✅ · wasm32 types-only builds for claude/opencode ✅ · `cargo fmt --check` ✅

Supersedes #177.