### PR TITLE
opencode-codes: add maturity warning to README and crate docs

### DIFF
--- a/opencode-codes/README.md
+++ b/opencode-codes/README.md
@@ -11,6 +11,14 @@ HTTP + Server-Sent Events protocol.
 
 Part of the [rust-code-agent-sdks](https://github.com/meawoppl/rust-code-agent-sdks) workspace.
 
+> ⚠️ **Maturity warning**: this crate is new and should be considered
+> **highly untested** — it is under active development. The types are
+> generated from opencode's published OpenAPI spec and the suite passes
+> against a live server, but real-world mileage is minimal and the API may
+> change between releases while the surface settles. Bug reports and wire
+> captures that break the types are very welcome:
+> <https://github.com/meawoppl/rust-code-agent-sdks/issues>.
+
 ## Overview
 
 Where the sibling crates wrap CLIs that speak JSON-Lines over stdio,

--- a/opencode-codes/src/lib.rs
+++ b/opencode-codes/src/lib.rs
@@ -1,5 +1,17 @@
 //! A typed Rust interface for the [opencode](https://opencode.ai) agent server.
 //!
+//! <div class="warning">
+//!
+//! **Maturity warning**: this crate is new and should be considered **highly
+//! untested** — it is under active development. The types are generated from
+//! opencode's published OpenAPI spec and the suite passes against a live
+//! server, but real-world mileage is minimal and the API may change between
+//! releases while the surface settles. Bug reports and wire captures that
+//! break the types are very welcome at
+//! <https://github.com/meawoppl/rust-code-agent-sdks/issues>.
+//!
+//! </div>
+//!
 //! Unlike its sibling crates ([`claude-codes`](https://docs.rs/claude-codes) and
 //! [`codex-codes`](https://docs.rs/codex-codes)), which wrap CLIs that speak a
 //! JSON-Lines protocol over stdio, opencode runs a **local HTTP server** with a


### PR DESCRIPTION
Adds a prominent "highly untested, under active development" warning where consumers will actually see it before the first crates.io publish:

- `opencode-codes/README.md` — blockquote warning right under the intro (crates.io renders the README as the package page)
- `opencode-codes/src/lib.rs` — the same note in a rustdoc `<div class="warning">` block at the top of the crate docs (docs.rs renders it as a warning callout)

Both invite bug reports and wire captures that break the types. Docs-only; `cargo doc` clean, no code changes.