### PR TITLE
Release train: claude-codes 2.1.166, codex-codes 0.145.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.165"
+version = "2.1.166"
 dependencies = [
  "anyhow",
  "base64",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.143.6"
+version = "0.145.0"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ This workspace provides independent crates for interacting with [Claude Code](ht
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.165`, tested against Claude CLI `2.1.219`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.143.6`, tested against Codex CLI `0.143.0`.
+- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.166`, tested against Claude CLI `2.1.220`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.145.0`, tested against Codex CLI `0.145.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.5`, tested against opencode `1.18.5`.
 
 `claude-codes` and `codex-codes` warn (or fail gracefully) when the installed

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.1.166] - 2026-07-27
 
 ### Changed
 
+- **Tested Claude CLI version** bumped to 2.1.220 — no wire drift vs the
+  2.1.219 snapshot, and the full integration suite passes against the
+  installed binary.
 - Shared dependencies and lint policy moved to the workspace root: `serde`,
   `serde_json`, `thiserror`, `tokio`, `log`, `which`, and dev `env_logger` are
   now `{ workspace = true }`, and the crate opts into `[workspace.lints]`

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.165"
+version = "2.1.166"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -138,7 +138,7 @@ let serialized = Protocol::serialize(&output)?;
 
 ## Compatibility
 
-**Tested against:** Claude CLI 2.1.219
+**Tested against:** Claude CLI 2.1.220
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -78,7 +78,7 @@
 //! ⚠️ **Important**: The Claude CLI protocol is unstable and evolving. This crate
 //! automatically checks your Claude CLI version and warns if it's newer than tested.
 //!
-//! Current tested version: **2.1.219**
+//! Current tested version: **2.1.220**
 //!
 //! Report compatibility issues at: <https://github.com/meawoppl/rust-claude-codes/pulls>
 //!

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.219";
+const TESTED_VERSION: &str = "2.1.220";
 
 /// Ensures version warning is only shown once per session
 static VERSION_CHECK: Once = Once::new();

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.145.0] - 2026-07-27
+
+Version jumps 0.143.6 → 0.145.0 to re-align with the tested Codex CLI
+version, per the crate's versioning convention.
+
+### Changed
+
+- **Tested Codex CLI version** bumped to 0.145.0. Verified live: the full
+  integration suite passes against the installed binary (protocol-level
+  suite in one environment, model-turn tests under live auth in another;
+  one startup flake observed under sandboxed parallel runs — run the live
+  suite with `--test-threads=1`).
 
 ### Added
 

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.143.6"
+version = "0.145.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/README.md
+++ b/codex-codes/README.md
@@ -14,7 +14,7 @@ Part of the [rust-code-agent-sdks](https://github.com/meawoppl/rust-code-agent-s
 
 This crate provides type-safe Rust representations of the Codex CLI's JSON-RPC protocol, used by `codex app-server`. It includes optional sync and async clients for multi-turn conversations with the Codex agent.
 
-**Tested against:** Codex CLI 0.143.0
+**Tested against:** Codex CLI 0.145.0
 
 ## Installation
 
@@ -193,7 +193,7 @@ Discriminated union of agent action items (shared between exec and app-server):
 
 ## Compatibility
 
-**Tested against:** Codex CLI 0.143.0
+**Tested against:** Codex CLI 0.145.0
 
 The crate version tracks the Codex CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/codex-codes/src/version.rs
+++ b/codex-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Codex CLI version we've tested against.
-const TESTED_VERSION: &str = "0.143.0";
+const TESTED_VERSION: &str = "0.145.0";
 
 /// Ensures version warning is only shown once per session.
 static VERSION_CHECK: Once = Once::new();


### PR DESCRIPTION
Version bumps for publishing all three crates.

| Crate | Version | Tested against |
|---|---|---|
| claude-codes | 2.1.165 → **2.1.166** | Claude CLI **2.1.220** (no drift vs 2.1.219 snapshot; full integration suite green, 26 live + subagent audit) |
| codex-codes | 0.143.6 → **0.145.0** | Codex CLI **0.145.0** (re-aligned with CLI per versioning convention; folds #237's process-config API + workspace hoist) |
| opencode-codes | **1.18.5** (unchanged) | opencode 1.18.5 (first publish; maturity warning included) |

Codex verification was a two-environment affair: the protocol-level live suite passes locally, and the model-turn tests pass under live auth in the codex agent session on this machine (104 passed / 1 startup flake). The live suite spawns one app-server per test and is parallelism-sensitive — noted in the changelog to run with `--test-threads=1`.

Publishing all three from main after merge.