### PR TITLE
claude-codes: add working-directory support

### DIFF
--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `ClaudeCliBuilder::working_directory` for setting the working directory of
+  spawned Claude CLI processes.
+
 ## [2.1.166] - 2026-07-27
 
 ### Changed

--- a/claude-codes/src/cli.rs
+++ b/claude-codes/src/cli.rs
@@ -381,6 +381,7 @@ impl CliFlag {
 #[derive(Debug, Clone)]
 pub struct ClaudeCliBuilder {
     command: PathBuf,
+    working_directory: Option<PathBuf>,
     prompt: Option<String>,
     debug: Option<String>,
     verbose: bool,
@@ -420,6 +421,7 @@ impl ClaudeCliBuilder {
     pub fn new() -> Self {
         Self {
             command: PathBuf::from("claude"),
+            working_directory: None,
             prompt: None,
             debug: None,
             verbose: false,
@@ -449,6 +451,12 @@ impl ClaudeCliBuilder {
     /// Set custom path to Claude binary
     pub fn command<P: Into<PathBuf>>(mut self, path: P) -> Self {
         self.command = path.into();
+        self
+    }
+
+    /// Set the working directory for the Claude process.
+    pub fn working_directory<P: Into<PathBuf>>(mut self, path: P) -> Self {
+        self.working_directory = Some(path.into());
         self
     }
 
@@ -779,6 +787,10 @@ impl ClaudeCliBuilder {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
+        if let Some(ref dir) = self.working_directory {
+            cmd.current_dir(dir);
+        }
+
         if self.allow_recursion {
             cmd.env_remove("CLAUDECODE");
         }
@@ -806,6 +818,10 @@ impl ClaudeCliBuilder {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+
+        if let Some(ref dir) = self.working_directory {
+            cmd.current_dir(dir);
+        }
 
         if self.allow_recursion {
             cmd.env_remove("CLAUDECODE");
@@ -839,6 +855,10 @@ impl ClaudeCliBuilder {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
+        if let Some(ref dir) = self.working_directory {
+            cmd.current_dir(dir);
+        }
+
         if self.allow_recursion {
             cmd.env_remove("CLAUDECODE");
         }
@@ -858,6 +878,12 @@ impl ClaudeCliBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_working_directory() {
+        let builder = ClaudeCliBuilder::new().working_directory("workspace");
+        assert_eq!(builder.working_directory, Some(PathBuf::from("workspace")));
+    }
 
     #[test]
     fn test_streaming_flags_always_present() {


### PR DESCRIPTION
Adds `ClaudeCliBuilder::working_directory` and applies it to async and synchronous Claude process launches.

Includes a unit test and changelog entry.

Part of #242.