### PR TITLE
claude-codes, codex-codes: add raw async clients

### DIFF
--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `RawAsyncClient` for newline-framed, undecoded access to the Claude
+  stream-json protocol.
+- `ClaudeInput::user_message_without_session` for messages associated with the
+  current CLI process session.
+
 ## [2.1.166] - 2026-07-27
 
 ### Changed

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -127,6 +127,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### Raw Protocol Access
 
+Use `RawAsyncClient` when the caller owns protocol interpretation and only
+needs newline framing. Neither method decodes JSON.
+
+```rust,no_run
+use claude_codes::{ClaudeCliBuilder, RawAsyncClient};
+
+# async fn example() -> claude_codes::Result<()> {
+let builder = ClaudeCliBuilder::new();
+let mut client = RawAsyncClient::start_with(builder).await?;
+let input = claude_codes::ClaudeInput::user_message_without_session("Hello");
+client.send(&input).await?;
+let raw_line = client.next_line().await?;
+# Ok(())
+# }
+```
+
+Typed protocol parsing remains available separately:
+
 ```rust
 use claude_codes::{Protocol, ClaudeOutput};
 

--- a/claude-codes/src/client_raw_async.rs
+++ b/claude-codes/src/client_raw_async.rs
@@ -1,0 +1,157 @@
+//! Raw asynchronous transport for Claude Code's stream-json protocol.
+//!
+//! This client only frames newline-delimited messages. It does not decode JSON.
+
+use crate::cli::ClaudeCliBuilder;
+use crate::error::{Error, Result};
+use log::{debug, error};
+use serde::Serialize;
+use std::process::ExitStatus;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
+use tokio::process::Child;
+
+const STDOUT_BUFFER_SIZE: usize = 10 * 1024 * 1024;
+
+pub struct RawAsyncClient {
+    child: Child,
+    writer: BufWriter<tokio::process::ChildStdin>,
+    reader: BufReader<tokio::process::ChildStdout>,
+    _stderr_drain: tokio::task::JoinHandle<()>,
+}
+
+impl RawAsyncClient {
+    pub async fn start_with(builder: ClaudeCliBuilder) -> Result<Self> {
+        crate::version::check_claude_version_async().await?;
+        Self::new(builder.spawn().await?)
+    }
+
+    pub fn new(mut child: Child) -> Result<Self> {
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| Error::Protocol("Failed to get stdin".to_string()))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| Error::Protocol("Failed to get stdout".to_string()))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| Error::Protocol("Failed to get stderr".to_string()))?;
+        let stderr_drain = tokio::spawn(async move {
+            let mut stderr = BufReader::new(stderr);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match stderr.read_line(&mut line).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => debug!("[RAW CLIENT STDERR] {}", line.trim_end()),
+                }
+            }
+        });
+
+        Ok(Self {
+            child,
+            writer: BufWriter::new(stdin),
+            reader: BufReader::with_capacity(STDOUT_BUFFER_SIZE, stdout),
+            _stderr_drain: stderr_drain,
+        })
+    }
+
+    /// Serialize and write one typed SDK message.
+    pub async fn send<T: Serialize>(&mut self, message: &T) -> Result<()> {
+        let line = serde_json::to_string(message).map_err(Error::Json)?;
+        self.write_line(&line).await
+    }
+
+    async fn write_line(&mut self, line: &str) -> Result<()> {
+        let line = single_line(line)?;
+        debug!("[RAW CLIENT] Sending {} bytes", line.len());
+        self.writer
+            .write_all(line.as_bytes())
+            .await
+            .map_err(Error::Io)?;
+        self.writer.write_all(b"\n").await.map_err(Error::Io)?;
+        self.writer.flush().await.map_err(Error::Io)
+    }
+
+    /// Read one complete JSONL frame without inspecting its contents.
+    pub async fn next_line(&mut self) -> Result<Option<String>> {
+        let mut line = String::new();
+        loop {
+            line.clear();
+            if self.reader.read_line(&mut line).await.map_err(Error::Io)? == 0 {
+                return Ok(None);
+            }
+            remove_line_ending(&mut line);
+            if line.trim().is_empty() {
+                continue;
+            }
+            debug!("[RAW CLIENT] Received {} bytes", line.len());
+            return Ok(Some(line));
+        }
+    }
+
+    pub fn pid(&self) -> Option<u32> {
+        self.child.id()
+    }
+
+    pub fn is_alive(&mut self) -> bool {
+        self.child.try_wait().ok().flatten().is_none()
+    }
+
+    pub async fn wait_for_exit(&mut self) -> Result<ExitStatus> {
+        self.child.wait().await.map_err(Error::Io)
+    }
+
+    pub async fn shutdown(mut self) -> Result<()> {
+        self.child.kill().await.map_err(Error::Io)
+    }
+}
+
+impl Drop for RawAsyncClient {
+    fn drop(&mut self) {
+        if self.is_alive() {
+            if let Err(error) = self.child.start_kill() {
+                error!("Failed to kill raw Claude process on drop: {error}");
+            }
+        }
+    }
+}
+
+fn single_line(line: &str) -> Result<&str> {
+    let line = line.trim_end_matches(['\r', '\n']);
+    if line.contains(['\r', '\n']) {
+        return Err(Error::Protocol(
+            "raw Claude frame contains an embedded line break".to_string(),
+        ));
+    }
+    Ok(line)
+}
+
+fn remove_line_ending(line: &mut String) {
+    if line.ends_with('\n') {
+        line.pop();
+        if line.ends_with('\r') {
+            line.pop();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_one_frame_with_a_line_ending() {
+        assert_eq!(
+            single_line("{\"type\":\"user\"}\r\n").unwrap(),
+            "{\"type\":\"user\"}"
+        );
+    }
+
+    #[test]
+    fn rejects_multiple_frames() {
+        assert!(single_line("{\"type\":\"user\"}\n{}").is_err());
+    }
+}

--- a/claude-codes/src/io/claude_input.rs
+++ b/claude-codes/src/io/claude_input.rs
@@ -30,6 +30,16 @@ pub enum ClaudeInput {
 impl ClaudeInput {
     /// Create a simple text user message
     pub fn user_message(text: impl Into<String>, session_id: Uuid) -> Self {
+        Self::text_user_message(text, Some(session_id))
+    }
+
+    /// Create a simple text user message associated with the current CLI
+    /// process session.
+    pub fn user_message_without_session(text: impl Into<String>) -> Self {
+        Self::text_user_message(text, None)
+    }
+
+    fn text_user_message(text: impl Into<String>, session_id: Option<Uuid>) -> Self {
         ClaudeInput::User(UserMessage {
             message: MessageContent {
                 role: super::MessageRole::User,
@@ -38,7 +48,7 @@ impl ClaudeInput {
                     citations: Vec::new(),
                 })],
             },
-            session_id: Some(session_id),
+            session_id,
             parent_tool_use_id: None,
             uuid: None,
             timestamp: None,
@@ -185,5 +195,13 @@ mod tests {
         assert!(json.contains("\"role\":\"user\""));
         assert!(json.contains("\"text\":\"Hello, Claude!\""));
         assert!(json.contains("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    #[test]
+    fn test_serialize_user_message_without_session() {
+        let input = ClaudeInput::user_message_without_session("Hello, Claude!");
+        let json = serde_json::to_string(&input).unwrap();
+        assert!(json.contains("\"type\":\"user\""));
+        assert!(!json.contains("session_id"));
     }
 }

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -110,6 +110,8 @@ pub mod types;
 // Client modules
 #[cfg(feature = "async-client")]
 pub mod client_async;
+#[cfg(feature = "async-client")]
+pub mod client_raw_async;
 #[cfg(feature = "sync-client")]
 pub mod client_sync;
 
@@ -202,6 +204,8 @@ pub use tool_inputs::{
 // Client exports
 #[cfg(feature = "async-client")]
 pub use client_async::{AsyncClient, AsyncStreamProcessor};
+#[cfg(feature = "async-client")]
+pub use client_raw_async::RawAsyncClient;
 #[cfg(feature = "sync-client")]
 pub use client_sync::{StreamProcessor, SyncClient};
 

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `RawAsyncClient` for newline-framed, undecoded access to the Codex app-server
+  protocol.
+
 ## [0.145.0] - 2026-07-27
 
 Version jumps 0.143.6 → 0.145.0 to re-align with the tested Codex CLI

--- a/codex-codes/README.md
+++ b/codex-codes/README.md
@@ -128,6 +128,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### Raw Protocol Access
 
+Use `RawAsyncClient` when the caller owns JSON-RPC correlation and only needs
+newline framing. Neither method decodes JSON.
+
+```rust,no_run
+use codex_codes::{AppServerBuilder, JsonRpcRequest, RawAsyncClient, RequestId};
+
+# async fn example() -> codex_codes::Result<()> {
+let builder = AppServerBuilder::new().working_directory("/workspace");
+let mut client = RawAsyncClient::start_with(builder).await?;
+let request = JsonRpcRequest {
+    id: RequestId::Integer(1),
+    method: "initialize".to_string(),
+    params: Some(serde_json::json!({})),
+};
+client.send(&request).await?;
+let raw_line = client.next_line().await?;
+# Ok(())
+# }
+```
+
+Typed protocol parsing remains available separately:
+
 ```rust
 use codex_codes::{ThreadItem, JsonRpcMessage, RequestId};
 

--- a/codex-codes/src/client_raw_async.rs
+++ b/codex-codes/src/client_raw_async.rs
@@ -1,0 +1,148 @@
+//! Raw asynchronous transport for the Codex app-server.
+//!
+//! This client only frames newline-delimited messages. It does not decode JSON
+//! or correlate JSON-RPC requests and responses.
+
+use crate::cli::AppServerBuilder;
+use crate::error::{Error, Result};
+use log::{debug, error};
+use serde::Serialize;
+use std::process::ExitStatus;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
+use tokio::process::Child;
+
+const STDOUT_BUFFER_SIZE: usize = 10 * 1024 * 1024;
+
+pub struct RawAsyncClient {
+    child: Child,
+    writer: BufWriter<tokio::process::ChildStdin>,
+    reader: BufReader<tokio::process::ChildStdout>,
+    _stderr_drain: tokio::task::JoinHandle<()>,
+}
+
+impl RawAsyncClient {
+    pub async fn start() -> Result<Self> {
+        Self::start_with(AppServerBuilder::new()).await
+    }
+
+    pub async fn start_with(builder: AppServerBuilder) -> Result<Self> {
+        crate::version::check_codex_version_async().await?;
+        Self::new(builder.spawn().await?)
+    }
+
+    pub fn new(mut child: Child) -> Result<Self> {
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| Error::Protocol("Failed to get stdin".to_string()))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| Error::Protocol("Failed to get stdout".to_string()))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| Error::Protocol("Failed to get stderr".to_string()))?;
+
+        Ok(Self {
+            child,
+            writer: BufWriter::new(stdin),
+            reader: BufReader::with_capacity(STDOUT_BUFFER_SIZE, stdout),
+            _stderr_drain: crate::stderr_drain::spawn_async(stderr),
+        })
+    }
+
+    /// Serialize and write one typed SDK message.
+    pub async fn send<T: Serialize>(&mut self, message: &T) -> Result<()> {
+        let line = serde_json::to_string(message).map_err(Error::Json)?;
+        self.write_line(&line).await
+    }
+
+    async fn write_line(&mut self, line: &str) -> Result<()> {
+        let line = single_line(line)?;
+        debug!("[RAW CLIENT] Sending {} bytes", line.len());
+        self.writer
+            .write_all(line.as_bytes())
+            .await
+            .map_err(Error::Io)?;
+        self.writer.write_all(b"\n").await.map_err(Error::Io)?;
+        self.writer.flush().await.map_err(Error::Io)
+    }
+
+    /// Read one complete JSONL frame without inspecting its contents.
+    pub async fn next_line(&mut self) -> Result<Option<String>> {
+        let mut line = String::new();
+        loop {
+            line.clear();
+            if self.reader.read_line(&mut line).await.map_err(Error::Io)? == 0 {
+                return Ok(None);
+            }
+            remove_line_ending(&mut line);
+            if line.trim().is_empty() {
+                continue;
+            }
+            debug!("[RAW CLIENT] Received {} bytes", line.len());
+            return Ok(Some(line));
+        }
+    }
+
+    pub fn pid(&self) -> Option<u32> {
+        self.child.id()
+    }
+
+    pub fn is_alive(&mut self) -> bool {
+        self.child.try_wait().ok().flatten().is_none()
+    }
+
+    pub async fn wait_for_exit(&mut self) -> Result<ExitStatus> {
+        self.child.wait().await.map_err(Error::Io)
+    }
+
+    pub async fn shutdown(mut self) -> Result<()> {
+        self.child.kill().await.map_err(Error::Io)
+    }
+}
+
+impl Drop for RawAsyncClient {
+    fn drop(&mut self) {
+        if self.is_alive() {
+            if let Err(error) = self.child.start_kill() {
+                error!("Failed to kill raw app-server process on drop: {error}");
+            }
+        }
+    }
+}
+
+fn single_line(line: &str) -> Result<&str> {
+    let line = line.trim_end_matches(['\r', '\n']);
+    if line.contains(['\r', '\n']) {
+        return Err(Error::Protocol(
+            "raw app-server frame contains an embedded line break".to_string(),
+        ));
+    }
+    Ok(line)
+}
+
+fn remove_line_ending(line: &mut String) {
+    if line.ends_with('\n') {
+        line.pop();
+        if line.ends_with('\r') {
+            line.pop();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_one_frame_with_a_line_ending() {
+        assert_eq!(single_line("{\"id\":1}\r\n").unwrap(), "{\"id\":1}");
+    }
+
+    #[test]
+    fn rejects_multiple_frames() {
+        assert!(single_line("{\"id\":1}\n{\"id\":2}").is_err());
+    }
+}

--- a/codex-codes/src/lib.rs
+++ b/codex-codes/src/lib.rs
@@ -128,6 +128,9 @@ pub mod client_sync;
 #[cfg(feature = "async-client")]
 pub mod client_async;
 
+#[cfg(feature = "async-client")]
+pub mod client_raw_async;
+
 // Exec-level event types (JSONL protocol)
 pub use io::events::{
     ItemCompletedEvent, ItemStartedEvent, ItemUpdatedEvent, ThreadError, ThreadErrorEvent,
@@ -164,3 +167,6 @@ pub use client_sync::{EventIterator, SyncClient};
 // Async client
 #[cfg(feature = "async-client")]
 pub use client_async::{AsyncClient, EventStream};
+
+#[cfg(feature = "async-client")]
+pub use client_raw_async::RawAsyncClient;


### PR DESCRIPTION
Adds `RawAsyncClient` for newline-framed access to the Claude and Codex protocols, along with documentation and tests.

Also adds `ClaudeInput::user_message_without_session`.

The raw clients remain under the existing `async-client` feature because they use the same dependencies.

Part of #242.