### PR TITLE
all crates: suppress child console windows on Windows

### DIFF
--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- On Windows, Claude CLI launches and version checks now use
+  `CREATE_NO_WINDOW` to avoid opening console windows.
+
 ## [2.1.166] - 2026-07-27
 
 ### Changed

--- a/claude-codes/src/cli.rs
+++ b/claude-codes/src/cli.rs
@@ -791,6 +791,7 @@ impl ClaudeCliBuilder {
             cmd.env("ANTHROPIC_API_KEY", key);
         }
 
+        crate::process::configure_no_window(cmd.as_std_mut());
         let child = cmd.spawn().map_err(Error::Io)?;
 
         Ok(child)
@@ -819,6 +820,7 @@ impl ClaudeCliBuilder {
             cmd.env("ANTHROPIC_API_KEY", key);
         }
 
+        crate::process::configure_no_window(cmd.as_std_mut());
         Ok(cmd)
     }
 
@@ -851,6 +853,7 @@ impl ClaudeCliBuilder {
             cmd.env("ANTHROPIC_API_KEY", key);
         }
 
+        crate::process::configure_no_window(&mut cmd);
         cmd.spawn().map_err(Error::Io)
     }
 }

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -119,6 +119,9 @@ pub mod cli;
 #[cfg(any(feature = "sync-client", feature = "async-client"))]
 pub mod version;
 
+#[cfg(any(feature = "sync-client", feature = "async-client"))]
+mod process;
+
 // Core exports always available
 pub use error::{Error, Result};
 pub use io::{

--- a/claude-codes/src/process.rs
+++ b/claude-codes/src/process.rs
@@ -1,0 +1,9 @@
+pub(crate) fn configure_no_window(_command: &mut std::process::Command) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        _command.creation_flags(CREATE_NO_WINDOW);
+    }
+}

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -25,10 +25,10 @@ pub fn check_claude_version() -> Result<()> {
 /// Internal implementation of version checking
 fn check_version_impl() -> Result<()> {
     // Run claude --version
-    let output = Command::new("claude")
-        .arg("--version")
-        .output()
-        .map_err(crate::error::Error::Io)?;
+    let mut command = Command::new("claude");
+    command.arg("--version");
+    crate::process::configure_no_window(&mut command);
+    let output = command.output().map_err(crate::error::Error::Io)?;
 
     if !output.status.success() {
         debug!("Failed to check Claude CLI version - command failed");
@@ -107,11 +107,10 @@ async fn check_version_impl_async() -> Result<()> {
     use tokio::process::Command;
 
     // Run claude --version
-    let output = Command::new("claude")
-        .arg("--version")
-        .output()
-        .await
-        .map_err(crate::error::Error::Io)?;
+    let mut command = Command::new("claude");
+    command.arg("--version");
+    crate::process::configure_no_window(command.as_std_mut());
+    let output = command.output().await.map_err(crate::error::Error::Io)?;
 
     if !output.status.success() {
         debug!("Failed to check Claude CLI version - command failed");

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- On Windows, Codex app-server launches and version checks now use
+  `CREATE_NO_WINDOW` to avoid opening console windows.
+
 ## [0.145.0] - 2026-07-27
 
 Version jumps 0.143.6 → 0.145.0 to re-align with the tested Codex CLI

--- a/codex-codes/src/cli.rs
+++ b/codex-codes/src/cli.rs
@@ -223,6 +223,7 @@ impl AppServerBuilder {
             command.current_dir(dir);
         }
 
+        crate::process::configure_no_window(&mut command);
         Ok(command)
     }
 

--- a/codex-codes/src/lib.rs
+++ b/codex-codes/src/lib.rs
@@ -120,6 +120,9 @@ pub mod cli;
 pub mod version;
 
 #[cfg(any(feature = "sync-client", feature = "async-client"))]
+mod process;
+
+#[cfg(any(feature = "sync-client", feature = "async-client"))]
 mod stderr_drain;
 
 #[cfg(feature = "sync-client")]

--- a/codex-codes/src/process.rs
+++ b/codex-codes/src/process.rs
@@ -1,0 +1,9 @@
+pub(crate) fn configure_no_window(_command: &mut std::process::Command) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        _command.creation_flags(CREATE_NO_WINDOW);
+    }
+}

--- a/codex-codes/src/version.rs
+++ b/codex-codes/src/version.rs
@@ -24,10 +24,10 @@ pub fn check_codex_version() -> Result<()> {
 }
 
 fn check_version_impl() -> Result<()> {
-    let output = Command::new("codex")
-        .arg("--version")
-        .output()
-        .map_err(crate::error::Error::Io)?;
+    let mut command = Command::new("codex");
+    command.arg("--version");
+    crate::process::configure_no_window(&mut command);
+    let output = command.output().map_err(crate::error::Error::Io)?;
 
     if !output.status.success() {
         debug!("Failed to check Codex CLI version - command failed");
@@ -102,11 +102,10 @@ pub async fn check_codex_version_async() -> Result<()> {
 async fn check_version_impl_async() -> Result<()> {
     use tokio::process::Command;
 
-    let output = Command::new("codex")
-        .arg("--version")
-        .output()
-        .await
-        .map_err(crate::error::Error::Io)?;
+    let mut command = Command::new("codex");
+    command.arg("--version");
+    crate::process::configure_no_window(command.as_std_mut());
+    let output = command.output().await.map_err(crate::error::Error::Io)?;
 
     if !output.status.success() {
         debug!("Failed to check Codex CLI version - command failed");

--- a/opencode-codes/CHANGELOG.md
+++ b/opencode-codes/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- On Windows, managed `opencode serve` launches now use `CREATE_NO_WINDOW` to
+  avoid opening console windows.
+
 ## [1.18.5] - 2026-07-25
 
 Initial release. Wraps the opencode local HTTP + Server-Sent Events server,

--- a/opencode-codes/src/lib.rs
+++ b/opencode-codes/src/lib.rs
@@ -98,4 +98,7 @@ pub use client_async::{OpencodeClient, OpencodeClientBuilder};
 pub mod server;
 
 #[cfg(feature = "server")]
+mod process;
+
+#[cfg(feature = "server")]
 pub use server::{ManagedServer, ManagedServerBuilder};

--- a/opencode-codes/src/process.rs
+++ b/opencode-codes/src/process.rs
@@ -1,0 +1,9 @@
+pub(crate) fn configure_no_window(_command: &mut std::process::Command) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        _command.creation_flags(CREATE_NO_WINDOW);
+    }
+}

--- a/opencode-codes/src/server.rs
+++ b/opencode-codes/src/server.rs
@@ -40,6 +40,7 @@ use crate::http::DEFAULT_USERNAME;
 const LISTENING_MARKER: &str = "listening on ";
 
 /// Grace period between `SIGTERM` and `SIGKILL` when terminating the group.
+#[cfg(unix)]
 const KILL_GRACE: Duration = Duration::from_millis(250);
 
 #[cfg(unix)]
@@ -194,6 +195,7 @@ pub struct ManagedServer {
     port: u16,
     password: Option<String>,
     /// Process-group id for whole-tree termination on Unix.
+    #[cfg(unix)]
     pgid: Option<i32>,
 }
 
@@ -242,6 +244,7 @@ impl ManagedServer {
             cmd.env("OPENCODE_SERVER_PASSWORD", password);
         }
 
+        crate::process::configure_no_window(cmd.as_std_mut());
         let mut child = cmd.spawn().map_err(|e| {
             Error::Server(format!(
                 "failed to spawn `{}`: {e}",
@@ -285,6 +288,7 @@ impl ManagedServer {
             base_url,
             port,
             password: builder.password,
+            #[cfg(unix)]
             pgid,
         };
 


### PR DESCRIPTION
Uses `CREATE_NO_WINDOW` for Claude, Codex, and OpenCode process launches on Windows, including Claude and Codex version checks.

This is a no-op on other platforms. Includes changelog entries for all three crates.

Part of #242.