### PR TITLE
codex-codes 0.145.1: re-snapshot app-server schema, fix drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.145.0"
+version = "0.145.1"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This workspace provides independent crates for interacting with [Claude Code](ht
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.166`, tested against Claude CLI `2.1.220`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.145.0`, tested against Codex CLI `0.145.0`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.145.1`, tested against Codex CLI `0.145.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.5`, tested against opencode `1.18.5`.
 
 `claude-codes` and `codex-codes` warn (or fail gracefully) when the installed

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,17 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.145.1] - 2026-07-30
 
 ### Added
 
 - `RawAsyncClient` for newline-framed, undecoded access to the Codex app-server
   protocol.
+- **`threadSection/list` and `thread/section/move` client requests** — new
+  method constants with generated `ThreadSection`,
+  `ThreadSectionListParams`/`Response`, and
+  `ThreadSectionMoveParams`/`Response` types.
+- **New generated definitions**: `PluginDisabledReason`, `ThreadSearchSortKey`,
+  `ExternalAgentConfigImportHistoryRecordSuccessParams` /
+  `RecordTypeResultParams`; additive fields across `Thread`,
+  `ThreadListParams`, `ThreadMetadataUpdateParams`, `PlanType`, and the
+  plugin/import types.
 
 ### Changed
 
 - On Windows, Codex app-server launches and version checks now use
   `CREATE_NO_WINDOW` to avoid opening console windows.
+- **Re-snapshotted the Codex app-server schemas** against `openai/codex@main`
+  (resolves the codex-schema-drift report, issue #241); both snapshots are
+  byte-identical to upstream and schema coverage is 172/172 (100%).
 
 ## [0.145.0] - 2026-07-27
 

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.145.0"
+version = "0.145.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/examples/schema_coverage.rs
+++ b/codex-codes/examples/schema_coverage.rs
@@ -563,6 +563,8 @@ mod samples {
             methods::THREAD_GOAL_GET,
             methods::THREAD_GOAL_SET,
             methods::THREAD_GOAL_CLEAR,
+            methods::THREADSECTION_LIST,
+            methods::THREAD_SECTION_MOVE,
             methods::ACCOUNT_RATELIMITRESETCREDIT_CONSUME,
             methods::ACCOUNT_WORKSPACEMESSAGES_READ,
             methods::EXTERNALAGENTCONFIG_IMPORT_READHISTORIES,

--- a/codex-codes/src/messages.rs
+++ b/codex-codes/src/messages.rs
@@ -822,6 +822,9 @@ impl ServerRequest {
 /// Match on the outer variant first to distinguish notifications (no response)
 /// from requests (need [`crate::AsyncClient::respond`] /
 /// [`crate::SyncClient::respond`]).
+/// Keep variants unboxed so pattern matches and constructors stay ergonomic;
+/// the size skew comes from the generated notification payloads.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum ServerMessage {
     /// A notification — no response required.

--- a/codex-codes/src/protocol.rs
+++ b/codex-codes/src/protocol.rs
@@ -114,6 +114,8 @@ pub mod methods {
     pub const THREAD_GOAL_GET: &str = "thread/goal/get";
     pub const THREAD_GOAL_SET: &str = "thread/goal/set";
     pub const THREAD_GOAL_CLEAR: &str = "thread/goal/clear";
+    pub const THREADSECTION_LIST: &str = "threadSection/list";
+    pub const THREAD_SECTION_MOVE: &str = "thread/section/move";
     pub const ACCOUNT_RATELIMITRESETCREDIT_CONSUME: &str = "account/rateLimitResetCredit/consume";
     pub const ACCOUNT_WORKSPACEMESSAGES_READ: &str = "account/workspaceMessages/read";
     pub const EXTERNALAGENTCONFIG_IMPORT_READHISTORIES: &str =

--- a/codex-codes/src/protocol_generated/samples.rs
+++ b/codex-codes/src/protocol_generated/samples.rs
@@ -361,12 +361,17 @@ pub fn client_request_samples() -> Vec<(&'static str, Value)> {
         ("thread/resume", json!({"threadId": "x"})),
         ("thread/rollback", json!({"numTurns": 0, "threadId": "x"})),
         (
+            "thread/section/move",
+            json!({"sectionId": "x", "threadId": "x"}),
+        ),
+        (
             "thread/shellCommand",
             json!({"command": "x", "threadId": "x"}),
         ),
         ("thread/start", json!({})),
         ("thread/unarchive", json!({"threadId": "x"})),
         ("thread/unsubscribe", json!({"threadId": "x"})),
+        ("threadSection/list", json!({})),
         ("turn/interrupt", json!({"threadId": "x", "turnId": "x"})),
         ("turn/start", json!({"input": [], "threadId": "x"})),
         (

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -1836,7 +1836,7 @@ pub struct ExternalAgentConfigImportHistory {
 #[serde(rename_all = "camelCase")]
 pub struct ExternalAgentConfigImportHistoryRecordParams {
     #[serde(rename = "itemTypeResults", default)]
-    pub item_type_results: Vec<ExternalAgentConfigImportTypeResult>,
+    pub item_type_results: Vec<ExternalAgentConfigImportHistoryRecordTypeResultParams>,
     #[serde(rename = "providerId", default)]
     pub provider_id: String,
 }
@@ -1846,6 +1846,32 @@ pub struct ExternalAgentConfigImportHistoryRecordParams {
 pub struct ExternalAgentConfigImportHistoryRecordResponse {
     #[serde(rename = "importId", default)]
     pub import_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalAgentConfigImportHistoryRecordSuccessParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(rename = "itemType")]
+    pub item_type: ExternalAgentConfigMigrationItemType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalAgentConfigImportHistoryRecordTypeResultParams {
+    #[serde(default)]
+    pub failures: Vec<ExternalAgentConfigImportItemTypeFailure>,
+    #[serde(rename = "itemType")]
+    pub item_type: ExternalAgentConfigMigrationItemType,
+    #[serde(default)]
+    pub successes: Vec<ExternalAgentConfigImportHistoryRecordSuccessParams>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1882,6 +1908,8 @@ pub struct ExternalAgentConfigImportItemTypeSuccess {
     pub source: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -3301,6 +3329,8 @@ pub struct MarketplaceUpgradeResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum McpAuthStatus {
+    #[serde(rename = "unknown")]
+    Unknown,
     #[serde(rename = "unsupported")]
     Unsupported,
     #[serde(rename = "notLoggedIn")]
@@ -4404,6 +4434,8 @@ pub enum PlanType {
     Prolite,
     #[serde(rename = "team")]
     Team,
+    #[serde(rename = "self_serve_business_prolite")]
+    Self_serve_business_prolite,
     #[serde(rename = "self_serve_business_usage_based")]
     Self_serve_business_usage_based,
     #[serde(rename = "business")]
@@ -4468,6 +4500,18 @@ pub struct PluginDetail {
     pub skills: Vec<SkillSummary>,
     #[serde()]
     pub summary: PluginSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PluginDisabledReason {
+    #[serde(rename = "disabled_by_admin")]
+    Disabled_by_admin,
+    #[serde(rename = "plan_not_eligible")]
+    Plan_not_eligible,
+    #[serde(rename = "required_app_unavailable")]
+    Required_app_unavailable,
+    #[serde(rename = "unknown")]
+    Unknown,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -5023,6 +5067,18 @@ pub struct PluginSummary {
     pub auth_policy: PluginAuthPolicy,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub availability: Option<Value>,
+    #[serde(
+        rename = "disabledReason",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub disabled_reason: Option<PluginDisabledReason>,
+    #[serde(
+        rename = "eligiblePlanTypes",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub eligible_plan_types: Option<Vec<String>>,
     #[serde(default)]
     pub enabled: bool,
     #[serde(default)]
@@ -5037,6 +5093,12 @@ pub struct PluginSummary {
     pub install_policy_source: Option<PluginInstallPolicySource>,
     #[serde(default)]
     pub installed: bool,
+    #[serde(
+        rename = "installedAt",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub installed_at: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub interface: Option<PluginInterface>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6031,8 +6093,6 @@ pub struct Thread {
     pub git_info: Option<GitInfo>,
     #[serde(default)]
     pub id: String,
-    #[serde(rename = "isPinned", default, skip_serializing_if = "Option::is_none")]
-    pub is_pinned: Option<bool>,
     #[serde(rename = "modelProvider", default)]
     pub model_provider: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6049,6 +6109,14 @@ pub struct Thread {
     pub preview: String,
     #[serde(rename = "recencyAt", default, skip_serializing_if = "Option::is_none")]
     pub recency_at: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub section: Option<ThreadSection>,
+    #[serde(
+        rename = "sectionEnteredAt",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub section_entered_at: Option<i64>,
     #[serde(rename = "sessionId", default)]
     pub session_id: String,
     #[serde(default)]
@@ -6493,6 +6561,12 @@ pub enum ThreadItem {
         mcp_app_resource_uri: Option<String>,
         #[serde(rename = "pluginId", default, skip_serializing_if = "Option::is_none")]
         plugin_id: Option<String>,
+        #[serde(
+            rename = "readOnlyHint",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        read_only_hint: Option<bool>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         result: Option<McpToolCallResult>,
         server: String,
@@ -6618,8 +6692,6 @@ pub struct ThreadListParams {
     pub cursor: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cwd: Option<ThreadListCwdFilter>,
-    #[serde(rename = "isPinned", default, skip_serializing_if = "Option::is_none")]
-    pub is_pinned: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<i64>,
     #[serde(
@@ -6634,6 +6706,8 @@ pub struct ThreadListParams {
         skip_serializing_if = "Option::is_none"
     )]
     pub search_term: Option<String>,
+    #[serde(rename = "sectionId", default, skip_serializing_if = "Option::is_none")]
+    pub section_id: Option<String>,
     #[serde(
         rename = "sortDirection",
         default,
@@ -6713,8 +6787,6 @@ pub struct ThreadMetadataGitInfoUpdateParams {
 pub struct ThreadMetadataUpdateParams {
     #[serde(rename = "gitInfo", default, skip_serializing_if = "Option::is_none")]
     pub git_info: Option<ThreadMetadataGitInfoUpdateParams>,
-    #[serde(rename = "isPinned", default, skip_serializing_if = "Option::is_none")]
-    pub is_pinned: Option<bool>,
     #[serde(rename = "threadId", default)]
     pub thread_id: String,
 }
@@ -6968,6 +7040,59 @@ pub struct ThreadRollbackResponse {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ThreadSection {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadSectionListParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadSectionListResponse {
+    #[serde(default)]
+    pub data: Vec<ThreadSection>,
+    #[serde(
+        rename = "nextCursor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadSectionMoveParams {
+    #[serde(
+        rename = "beforeThreadId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub before_thread_id: Option<String>,
+    #[serde(rename = "sectionId", default, skip_serializing_if = "Option::is_none")]
+    pub section_id: Option<String>,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadSectionMoveResponse {
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ThreadSetNameParams {
     #[serde(default)]
     pub name: String,
@@ -7052,6 +7177,8 @@ pub enum ThreadSortKey {
     Updated_at,
     #[serde(rename = "recency_at")]
     Recency_at,
+    #[serde(rename = "section_position")]
+    Section_position,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -499,6 +499,30 @@
             },
             "method": {
               "enum": [
+                "thread/section/move"
+              ],
+              "title": "Thread/section/moveRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadSectionMoveParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/section/moveRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
                 "thread/unarchive"
               ],
               "title": "Thread/unarchiveRequestMethod",
@@ -634,6 +658,30 @@
             "params"
           ],
           "title": "Thread/listRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/v2/RequestId"
+            },
+            "method": {
+              "enum": [
+                "threadSection/list"
+              ],
+              "title": "ThreadSection/listRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/v2/ThreadSectionListParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "ThreadSection/listRequest",
           "type": "object"
         },
         {
@@ -9813,7 +9861,7 @@
           "itemTypeResults": {
             "description": "Completed results grouped by imported item type.",
             "items": {
-              "$ref": "#/definitions/v2/ExternalAgentConfigImportTypeResult"
+              "$ref": "#/definitions/v2/ExternalAgentConfigImportHistoryRecordTypeResultParams"
             },
             "type": "array"
           },
@@ -9840,6 +9888,68 @@
           "importId"
         ],
         "title": "ExternalAgentConfigImportHistoryRecordResponse",
+        "type": "object"
+      },
+      "ExternalAgentConfigImportHistoryRecordSuccessParams": {
+        "properties": {
+          "cwd": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "itemType": {
+            "$ref": "#/definitions/v2/ExternalAgentConfigMigrationItemType"
+          },
+          "source": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "target": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "title": {
+            "default": null,
+            "description": "Original title for an imported session, when available.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "itemType"
+        ],
+        "type": "object"
+      },
+      "ExternalAgentConfigImportHistoryRecordTypeResultParams": {
+        "properties": {
+          "failures": {
+            "items": {
+              "$ref": "#/definitions/v2/ExternalAgentConfigImportItemTypeFailure"
+            },
+            "type": "array"
+          },
+          "itemType": {
+            "$ref": "#/definitions/v2/ExternalAgentConfigMigrationItemType"
+          },
+          "successes": {
+            "items": {
+              "$ref": "#/definitions/v2/ExternalAgentConfigImportHistoryRecordSuccessParams"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "failures",
+          "itemType",
+          "successes"
+        ],
         "type": "object"
       },
       "ExternalAgentConfigImportItemTypeFailure": {
@@ -9903,6 +10013,14 @@
             ]
           },
           "target": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "title": {
+            "default": null,
+            "description": "Original title for an imported session; null for other item types.",
             "type": [
               "string",
               "null"
@@ -12659,6 +12777,7 @@
       },
       "McpAuthStatus": {
         "enum": [
+          "unknown",
           "unsupported",
           "notLoggedIn",
           "bearerToken",
@@ -13997,6 +14116,7 @@
           "pro",
           "prolite",
           "team",
+          "self_serve_business_prolite",
           "self_serve_business_usage_based",
           "business",
           "ent26",
@@ -14111,6 +14231,15 @@
           "summary"
         ],
         "type": "object"
+      },
+      "PluginDisabledReason": {
+        "enum": [
+          "disabled_by_admin",
+          "plan_not_eligible",
+          "required_app_unavailable",
+          "unknown"
+        ],
+        "type": "string"
       },
       "PluginHookSummary": {
         "properties": {
@@ -15064,6 +15193,29 @@
             "default": "AVAILABLE",
             "description": "Availability state for installing and using the plugin."
           },
+          "disabledReason": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/PluginDisabledReason"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Why the remote plugin is unavailable, when provided by plugin-service."
+          },
+          "eligiblePlanTypes": {
+            "default": null,
+            "description": "Raw plugin-service plan identifiers eligible to install the plugin.",
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
           "enabled": {
             "type": "boolean"
           },
@@ -15085,6 +15237,15 @@
           },
           "installed": {
             "type": "boolean"
+          },
+          "installedAt": {
+            "default": null,
+            "description": "Unix timestamp in seconds when the remote plugin was installed, when available.",
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "interface": {
             "anyOf": [
@@ -16279,6 +16440,15 @@
               },
               "call_id": {
                 "type": "string"
+              },
+              "encrypted_function_args": {
+                "items": {
+                  "type": "string"
+                },
+                "type": [
+                  "array",
+                  "null"
+                ]
               },
               "id": {
                 "type": [
@@ -18089,11 +18259,6 @@
             "description": "Identifier for this thread. Codex-generated thread IDs are UUIDv7.",
             "type": "string"
           },
-          "isPinned": {
-            "default": false,
-            "description": "Whether the thread has been pinned by the user.",
-            "type": "boolean"
-          },
           "modelProvider": {
             "description": "Model provider used for this thread (for example, 'openai').",
             "type": "string"
@@ -18125,6 +18290,27 @@
           },
           "recencyAt": {
             "description": "Unix timestamp (in seconds) used for thread recency ordering.",
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "section": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ThreadSection"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "The independently persisted section selected for this thread, if any."
+          },
+          "sectionEnteredAt": {
+            "default": null,
+            "description": "Unix timestamp in seconds when the thread entered its current section.",
             "format": "int64",
             "type": [
               "integer",
@@ -19075,6 +19261,12 @@
                   "null"
                 ]
               },
+              "readOnlyHint": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
               "result": {
                 "anyOf": [
                   {
@@ -19554,13 +19746,6 @@
             ],
             "description": "Optional cwd filter or filters; when set, only threads whose session cwd exactly matches one of these paths are returned."
           },
-          "isPinned": {
-            "description": "Optional pinned filter; when set, only threads matching this value are returned.",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "limit": {
             "description": "Optional page size; defaults to a reasonable server-side value.",
             "format": "uint32",
@@ -19582,6 +19767,13 @@
           },
           "searchTerm": {
             "description": "Optional substring filter for the extracted thread title.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sectionId": {
+            "description": "Omit to include every section, set to `null` for unsectioned threads, or provide a section ID to return only threads in that section.",
             "type": [
               "string",
               "null"
@@ -19750,13 +19942,6 @@
               }
             ],
             "description": "Patch the stored Git metadata for this thread. Omit a field to leave it unchanged, set it to `null` to clear it, or provide a string to replace the stored value."
-          },
-          "isPinned": {
-            "description": "Patch whether this thread is pinned. Omit to leave the stored value unchanged.",
-            "type": [
-              "boolean",
-              "null"
-            ]
           },
           "threadId": {
             "type": "string"
@@ -20346,6 +20531,115 @@
         ],
         "type": "object"
       },
+      "ThreadSearchSortKey": {
+        "enum": [
+          "created_at",
+          "updated_at",
+          "recency_at"
+        ],
+        "type": "string"
+      },
+      "ThreadSection": {
+        "description": "An independently persisted, user-visible thread section.",
+        "properties": {
+          "id": {
+            "description": "Opaque UUIDv7 identity that remains stable when the section is renamed.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The current user-visible section name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "ThreadSectionListParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "Parameters for listing independently persisted thread sections.",
+        "properties": {
+          "cursor": {
+            "description": "Opaque pagination cursor returned by a previous call.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "limit": {
+            "description": "Maximum number of sections to return.",
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "title": "ThreadSectionListParams",
+        "type": "object"
+      },
+      "ThreadSectionListResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "One page of independently persisted thread sections.",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/definitions/v2/ThreadSection"
+            },
+            "type": "array"
+          },
+          "nextCursor": {
+            "description": "Opaque cursor for the next page, or `null` when no sections remain.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "ThreadSectionListResponse",
+        "type": "object"
+      },
+      "ThreadSectionMoveParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "description": "Parameters for moving a thread within a server-owned section ordering.",
+        "properties": {
+          "beforeThreadId": {
+            "description": "Existing thread to insert before; omission or null appends to the section.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sectionId": {
+            "description": "Destination section, or `null` to remove the thread from its section.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "threadId": {
+            "description": "Thread to move into, within, or out of a section.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "sectionId",
+          "threadId"
+        ],
+        "title": "ThreadSectionMoveParams",
+        "type": "object"
+      },
+      "ThreadSectionMoveResponse": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ThreadSectionMoveResponse",
+        "type": "object"
+      },
       "ThreadSetNameParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
@@ -20493,7 +20787,8 @@
         "enum": [
           "created_at",
           "updated_at",
-          "recency_at"
+          "recency_at",
+          "section_position"
         ],
         "type": "string"
       },

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -1649,6 +1649,30 @@
             },
             "method": {
               "enum": [
+                "thread/section/move"
+              ],
+              "title": "Thread/section/moveRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadSectionMoveParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "Thread/section/moveRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
                 "thread/unarchive"
               ],
               "title": "Thread/unarchiveRequestMethod",
@@ -1784,6 +1808,30 @@
             "params"
           ],
           "title": "Thread/listRequest",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/RequestId"
+            },
+            "method": {
+              "enum": [
+                "threadSection/list"
+              ],
+              "title": "ThreadSection/listRequestMethod",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/definitions/ThreadSectionListParams"
+            }
+          },
+          "required": [
+            "id",
+            "method",
+            "params"
+          ],
+          "title": "ThreadSection/listRequest",
           "type": "object"
         },
         {
@@ -5991,7 +6039,7 @@
         "itemTypeResults": {
           "description": "Completed results grouped by imported item type.",
           "items": {
-            "$ref": "#/definitions/ExternalAgentConfigImportTypeResult"
+            "$ref": "#/definitions/ExternalAgentConfigImportHistoryRecordTypeResultParams"
           },
           "type": "array"
         },
@@ -6018,6 +6066,68 @@
         "importId"
       ],
       "title": "ExternalAgentConfigImportHistoryRecordResponse",
+      "type": "object"
+    },
+    "ExternalAgentConfigImportHistoryRecordSuccessParams": {
+      "properties": {
+        "cwd": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "itemType": {
+          "$ref": "#/definitions/ExternalAgentConfigMigrationItemType"
+        },
+        "source": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "target": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "default": null,
+          "description": "Original title for an imported session, when available.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "itemType"
+      ],
+      "type": "object"
+    },
+    "ExternalAgentConfigImportHistoryRecordTypeResultParams": {
+      "properties": {
+        "failures": {
+          "items": {
+            "$ref": "#/definitions/ExternalAgentConfigImportItemTypeFailure"
+          },
+          "type": "array"
+        },
+        "itemType": {
+          "$ref": "#/definitions/ExternalAgentConfigMigrationItemType"
+        },
+        "successes": {
+          "items": {
+            "$ref": "#/definitions/ExternalAgentConfigImportHistoryRecordSuccessParams"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "failures",
+        "itemType",
+        "successes"
+      ],
       "type": "object"
     },
     "ExternalAgentConfigImportItemTypeFailure": {
@@ -6081,6 +6191,14 @@
           ]
         },
         "target": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "default": null,
+          "description": "Original title for an imported session; null for other item types.",
           "type": [
             "string",
             "null"
@@ -9001,6 +9119,7 @@
     },
     "McpAuthStatus": {
       "enum": [
+        "unknown",
         "unsupported",
         "notLoggedIn",
         "bearerToken",
@@ -10339,6 +10458,7 @@
         "pro",
         "prolite",
         "team",
+        "self_serve_business_prolite",
         "self_serve_business_usage_based",
         "business",
         "ent26",
@@ -10453,6 +10573,15 @@
         "summary"
       ],
       "type": "object"
+    },
+    "PluginDisabledReason": {
+      "enum": [
+        "disabled_by_admin",
+        "plan_not_eligible",
+        "required_app_unavailable",
+        "unknown"
+      ],
+      "type": "string"
     },
     "PluginHookSummary": {
       "properties": {
@@ -11406,6 +11535,29 @@
           "default": "AVAILABLE",
           "description": "Availability state for installing and using the plugin."
         },
+        "disabledReason": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PluginDisabledReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Why the remote plugin is unavailable, when provided by plugin-service."
+        },
+        "eligiblePlanTypes": {
+          "default": null,
+          "description": "Raw plugin-service plan identifiers eligible to install the plugin.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
         "enabled": {
           "type": "boolean"
         },
@@ -11427,6 +11579,15 @@
         },
         "installed": {
           "type": "boolean"
+        },
+        "installedAt": {
+          "default": null,
+          "description": "Unix timestamp in seconds when the remote plugin was installed, when available.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "interface": {
           "anyOf": [
@@ -12621,6 +12782,15 @@
             },
             "call_id": {
               "type": "string"
+            },
+            "encrypted_function_args": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
             },
             "id": {
               "type": [
@@ -15853,11 +16023,6 @@
           "description": "Identifier for this thread. Codex-generated thread IDs are UUIDv7.",
           "type": "string"
         },
-        "isPinned": {
-          "default": false,
-          "description": "Whether the thread has been pinned by the user.",
-          "type": "boolean"
-        },
         "modelProvider": {
           "description": "Model provider used for this thread (for example, 'openai').",
           "type": "string"
@@ -15889,6 +16054,27 @@
         },
         "recencyAt": {
           "description": "Unix timestamp (in seconds) used for thread recency ordering.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "section": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadSection"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The independently persisted section selected for this thread, if any."
+        },
+        "sectionEnteredAt": {
+          "default": null,
+          "description": "Unix timestamp in seconds when the thread entered its current section.",
           "format": "int64",
           "type": [
             "integer",
@@ -16839,6 +17025,12 @@
                 "null"
               ]
             },
+            "readOnlyHint": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "result": {
               "anyOf": [
                 {
@@ -17318,13 +17510,6 @@
           ],
           "description": "Optional cwd filter or filters; when set, only threads whose session cwd exactly matches one of these paths are returned."
         },
-        "isPinned": {
-          "description": "Optional pinned filter; when set, only threads matching this value are returned.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
         "limit": {
           "description": "Optional page size; defaults to a reasonable server-side value.",
           "format": "uint32",
@@ -17346,6 +17531,13 @@
         },
         "searchTerm": {
           "description": "Optional substring filter for the extracted thread title.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sectionId": {
+          "description": "Omit to include every section, set to `null` for unsectioned threads, or provide a section ID to return only threads in that section.",
           "type": [
             "string",
             "null"
@@ -17514,13 +17706,6 @@
             }
           ],
           "description": "Patch the stored Git metadata for this thread. Omit a field to leave it unchanged, set it to `null` to clear it, or provide a string to replace the stored value."
-        },
-        "isPinned": {
-          "description": "Patch whether this thread is pinned. Omit to leave the stored value unchanged.",
-          "type": [
-            "boolean",
-            "null"
-          ]
         },
         "threadId": {
           "type": "string"
@@ -18110,6 +18295,115 @@
       ],
       "type": "object"
     },
+    "ThreadSearchSortKey": {
+      "enum": [
+        "created_at",
+        "updated_at",
+        "recency_at"
+      ],
+      "type": "string"
+    },
+    "ThreadSection": {
+      "description": "An independently persisted, user-visible thread section.",
+      "properties": {
+        "id": {
+          "description": "Opaque UUIDv7 identity that remains stable when the section is renamed.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The current user-visible section name.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ],
+      "type": "object"
+    },
+    "ThreadSectionListParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "Parameters for listing independently persisted thread sections.",
+      "properties": {
+        "cursor": {
+          "description": "Opaque pagination cursor returned by a previous call.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "limit": {
+          "description": "Maximum number of sections to return.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "title": "ThreadSectionListParams",
+      "type": "object"
+    },
+    "ThreadSectionListResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "One page of independently persisted thread sections.",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/ThreadSection"
+          },
+          "type": "array"
+        },
+        "nextCursor": {
+          "description": "Opaque cursor for the next page, or `null` when no sections remain.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "title": "ThreadSectionListResponse",
+      "type": "object"
+    },
+    "ThreadSectionMoveParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "Parameters for moving a thread within a server-owned section ordering.",
+      "properties": {
+        "beforeThreadId": {
+          "description": "Existing thread to insert before; omission or null appends to the section.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sectionId": {
+          "description": "Destination section, or `null` to remove the thread from its section.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "threadId": {
+          "description": "Thread to move into, within, or out of a section.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "sectionId",
+        "threadId"
+      ],
+      "title": "ThreadSectionMoveParams",
+      "type": "object"
+    },
+    "ThreadSectionMoveResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ThreadSectionMoveResponse",
+      "type": "object"
+    },
     "ThreadSetNameParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
@@ -18257,7 +18551,8 @@
       "enum": [
         "created_at",
         "updated_at",
-        "recency_at"
+        "recency_at",
+        "section_position"
       ],
       "type": "string"
     },


### PR DESCRIPTION
Fixes #241.

Routine re-snapshot from `openai/codex@main` (byte-identical per the drift checker). Models the new **thread sections** surface (`threadSection/list`, `thread/section/move` + generated types) and picks up `PluginDisabledReason`, `ThreadSearchSortKey`, import-history record params, and additive fields across thread/plugin/import types.

Releases as **0.145.1**, folding the `[Unreleased]` entries from @ozitrance's #244/#245 (RawAsyncClient, Windows `CREATE_NO_WINDOW`).

Verified: drift checker byte-identical ✅ · `schema_coverage` 172/172 (100%) ✅ · workspace tests + clippy clean ✅

claude-codes (CLI 2.1.220) and opencode-codes (1.18.10) both checked clean — no drift anywhere else.