### PR TITLE
codex-codes 0.146.0: bump tested Codex CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.145.1"
+version = "0.146.0"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This workspace provides independent crates for interacting with [Claude Code](ht
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.166`, tested against Claude CLI `2.1.220`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.145.1`, tested against Codex CLI `0.145.0`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.0`, tested against Codex CLI `0.146.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.5`, tested against opencode `1.18.5`.
 
 `claude-codes` and `codex-codes` warn (or fail gracefully) when the installed

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.146.0] - 2026-07-31
+
+### Changed
+
+- **Tested Codex CLI version** bumped to 0.146.0. Verified live: the full
+  `codex-codes` integration suite passes against the installed binary with
+  `--test-threads=1`.
+
+### Contributors
+
+- Thanks to @ozitrance for the Codex-side `RawAsyncClient` contribution and
+  Windows `CREATE_NO_WINDOW` process-launch support that landed in this release
+  train.
+
 ## [0.145.1] - 2026-07-30
 
 ### Added

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.145.1"
+version = "0.146.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/README.md
+++ b/codex-codes/README.md
@@ -14,7 +14,7 @@ Part of the [rust-code-agent-sdks](https://github.com/meawoppl/rust-code-agent-s
 
 This crate provides type-safe Rust representations of the Codex CLI's JSON-RPC protocol, used by `codex app-server`. It includes optional sync and async clients for multi-turn conversations with the Codex agent.
 
-**Tested against:** Codex CLI 0.145.0
+**Tested against:** Codex CLI 0.146.0
 
 ## Installation
 
@@ -215,7 +215,7 @@ Discriminated union of agent action items (shared between exec and app-server):
 
 ## Compatibility
 
-**Tested against:** Codex CLI 0.145.0
+**Tested against:** Codex CLI 0.146.0
 
 The crate version tracks the Codex CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/codex-codes/src/version.rs
+++ b/codex-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Codex CLI version we've tested against.
-const TESTED_VERSION: &str = "0.145.0";
+const TESTED_VERSION: &str = "0.146.0";
 
 /// Ensures version warning is only shown once per session.
 static VERSION_CHECK: Once = Once::new();


### PR DESCRIPTION
## Summary
- Bump codex-codes package version to 0.146.0.
- Update tested Codex CLI references to 0.146.0.
- Add changelog entry crediting @ozitrance for the Codex RawAsyncClient and Windows CREATE_NO_WINDOW process-launch support.

## Verification
- codex --version: codex-cli 0.146.0
- cargo check -p codex-codes --all-features
- cargo test -p codex-codes --features integration-tests -- --test-threads=1