### PR TITLE
codex-codes 0.146.1: re-snapshot app-server schema, fix drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.146.0"
+version = "0.146.1"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This workspace provides independent crates for interacting with [Claude Code](ht
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.166`, tested against Claude CLI `2.1.220`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.0`, tested against Codex CLI `0.146.0`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.1`, tested against Codex CLI `0.146.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.5`, tested against opencode `1.18.5`.
 
 `claude-codes` and `codex-codes` warn (or fail gracefully) when the installed

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.146.1] - 2026-07-31
+
+### Changed
+
+- **Re-snapshotted the Codex app-server schemas** against `openai/codex@main`
+  (resolves the codex-schema-drift report, issue #248); both snapshots are
+  byte-identical to upstream and schema coverage is 172/172 (100%).
+  Purely additive generated-type changes, no new client-request methods:
+  new `ExternalAgentDetectedConnectorCandidate` /
+  `ExternalAgentDetectedConnectorSource` definitions and additive fields on
+  `ExternalAgentConfigDetectResponse`, `CommandAction`, and `PlanType`.
+
 ## [0.146.0] - 2026-07-31
 
 ### Changed

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.146.0"
+version = "0.146.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -826,7 +826,7 @@ pub enum CommandAction {
     Read {
         command: String,
         name: String,
-        path: AbsolutePathBuf,
+        path: LegacyAppPathString,
     },
     #[serde(rename = "listFiles")]
     ListFiles {
@@ -1791,6 +1791,8 @@ pub struct ExternalAgentConfigDetectParams {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExternalAgentConfigDetectResponse {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connectors: Option<Vec<ExternalAgentDetectedConnectorCandidate>>,
     #[serde(default)]
     pub items: Vec<ExternalAgentConfigMigrationItem>,
 }
@@ -1995,6 +1997,25 @@ pub enum ExternalAgentConfigMigrationItemType {
     MEMORY,
     #[serde(rename = "SESSIONS")]
     SESSIONS,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalAgentDetectedConnectorCandidate {
+    #[serde(default)]
+    pub name: String,
+    #[serde(rename = "sessionCount", default)]
+    pub session_count: i64,
+    #[serde()]
+    pub source: ExternalAgentDetectedConnectorSource,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ExternalAgentDetectedConnectorSource {
+    #[serde(rename = "remoteMcpServersConfig")]
+    RemoteMcpServersConfig,
+    #[serde(rename = "sessionToolUse")]
+    SessionToolUse,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -4442,6 +4463,8 @@ pub enum PlanType {
     Business,
     #[serde(rename = "ent26")]
     Ent26,
+    #[serde(rename = "enterprise_cbp_automation")]
+    Enterprise_cbp_automation,
     #[serde(rename = "enterprise_cbp_usage_based")]
     Enterprise_cbp_usage_based,
     #[serde(rename = "enterprise")]

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -7649,7 +7649,7 @@
                 "type": "string"
               },
               "path": {
-                "$ref": "#/definitions/v2/AbsolutePathBuf"
+                "$ref": "#/definitions/v2/LegacyAppPathString"
               },
               "type": {
                 "enum": [
@@ -9763,6 +9763,13 @@
       "ExternalAgentConfigDetectResponse": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
+          "connectors": {
+            "default": [],
+            "items": {
+              "$ref": "#/definitions/v2/ExternalAgentDetectedConnectorCandidate"
+            },
+            "type": "array"
+          },
           "items": {
             "items": {
               "$ref": "#/definitions/v2/ExternalAgentConfigMigrationItem"
@@ -10171,6 +10178,34 @@
           "COMMANDS",
           "MEMORY",
           "SESSIONS"
+        ],
+        "type": "string"
+      },
+      "ExternalAgentDetectedConnectorCandidate": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "sessionCount": {
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "source": {
+            "$ref": "#/definitions/v2/ExternalAgentDetectedConnectorSource"
+          }
+        },
+        "required": [
+          "name",
+          "sessionCount",
+          "source"
+        ],
+        "type": "object"
+      },
+      "ExternalAgentDetectedConnectorSource": {
+        "enum": [
+          "remoteMcpServersConfig",
+          "sessionToolUse"
         ],
         "type": "string"
       },
@@ -14120,6 +14155,7 @@
           "self_serve_business_usage_based",
           "business",
           "ent26",
+          "enterprise_cbp_automation",
           "enterprise_cbp_usage_based",
           "enterprise",
           "edu",

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -3827,7 +3827,7 @@
               "type": "string"
             },
             "path": {
-              "$ref": "#/definitions/AbsolutePathBuf"
+              "$ref": "#/definitions/LegacyAppPathString"
             },
             "type": {
               "enum": [
@@ -5941,6 +5941,13 @@
     "ExternalAgentConfigDetectResponse": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
+        "connectors": {
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/ExternalAgentDetectedConnectorCandidate"
+          },
+          "type": "array"
+        },
         "items": {
           "items": {
             "$ref": "#/definitions/ExternalAgentConfigMigrationItem"
@@ -6349,6 +6356,34 @@
         "COMMANDS",
         "MEMORY",
         "SESSIONS"
+      ],
+      "type": "string"
+    },
+    "ExternalAgentDetectedConnectorCandidate": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "sessionCount": {
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "source": {
+          "$ref": "#/definitions/ExternalAgentDetectedConnectorSource"
+        }
+      },
+      "required": [
+        "name",
+        "sessionCount",
+        "source"
+      ],
+      "type": "object"
+    },
+    "ExternalAgentDetectedConnectorSource": {
+      "enum": [
+        "remoteMcpServersConfig",
+        "sessionToolUse"
       ],
       "type": "string"
     },
@@ -10462,6 +10497,7 @@
         "self_serve_business_usage_based",
         "business",
         "ent26",
+        "enterprise_cbp_automation",
         "enterprise_cbp_usage_based",
         "enterprise",
         "edu",


### PR DESCRIPTION
Fixes #248.

Routine re-snapshot from `openai/codex@main` — the cheapest recipe run yet: **purely additive generated-type changes, no new client-request methods**, so no hand-written constants or registry lines. New `ExternalAgentDetectedConnectorCandidate`/`Source` definitions plus additive fields on `ExternalAgentConfigDetectResponse`, `CommandAction`, and `PlanType`.

Verified: drift checker byte-identical ✅ · `schema_coverage` 172/172 (100%) ✅ · tests + clippy clean ✅

claude-codes (CLI 2.1.220) and opencode-codes (1.18.10) both checked clean today.

Since this run needed zero human judgment, it's a good baseline for the planned automation of the re-snapshot pipeline.