### PR TITLE
claude-codes 2.1.220: re-align version with tested Claude CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.166"
+version = "2.1.220"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This workspace provides independent crates for interacting with [Claude Code](ht
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.166`, tested against Claude CLI `2.1.220`.
+- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.220`, tested against Claude CLI `2.1.220`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.1`, tested against Codex CLI `0.146.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.5`, tested against opencode `1.18.5`.
 

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.1.220] - 2026-07-31
+
+Version jumps 2.1.166 → 2.1.220 to re-align with the tested Claude CLI
+version, per the crate's versioning convention.
 
 ### Added
 
@@ -20,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - On Windows, Claude CLI launches and version checks now use
   `CREATE_NO_WINDOW` to avoid opening console windows.
+
+### Contributors
+
+- Thanks to @ozitrance — a first-time contributor to this crate — for the
+  entire feature set in this release: `RawAsyncClient`,
+  `user_message_without_session`, `working_directory`, and the Windows
+  `CREATE_NO_WINDOW` support (#243, #244, #245).
 
 ## [2.1.166] - 2026-07-27
 

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.166"
+version = "2.1.220"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]


### PR DESCRIPTION
Re-aligns the crate version with the Claude CLI it tracks (2.1.166 → **2.1.220**), same convention codex-codes follows.

- Full integration suite run against the installed 2.1.220 binary before cutting: **284 passed, 0 failed** (including the 26 live-CLI tests and the subagent audit).
- Folds the `[Unreleased]` features from @ozitrance's #243/#244/#245 — `RawAsyncClient`, `user_message_without_session`, `working_directory`, Windows `CREATE_NO_WINDOW` — with a first-time-contributor credit in the changelog.
- No wire/schema changes; drift checker remains clean against 2.1.220.

Publishing to crates.io from main after merge.