### PR TITLE
Session forking across all three crates, live-tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,24 @@ codex-codes = { version = "0.142", default-features = false, features = ["types"
 opencode-codes = { version = "1.18", default-features = false, features = ["types"] }
 ```
 
+## Session Forking
+
+All three runtimes can fork a session/thread — branch an existing history
+into a new one and diverge without touching the source — but the semantics
+differ, and consumers should design for the asymmetry:
+
+| | claude-codes | codex-codes | opencode-codes |
+|---|---|---|---|
+| Mechanism | `ClaudeCliBuilder::fork_from(src)` → `--resume <src> --fork-session --session-id <new>` | `AsyncClient::thread_fork(ThreadForkParams)` (`thread/fork`) | `fork_session(id)` (`POST /session/{id}/fork`) |
+| Fork point | **Whole history only** — the CLI's headless surface exposes no at-point cut | **Any turn** — `last_turn_id` cuts the source at that turn | **Whole history only** — no at-point cut in the 1.18.x spec |
+| New identity | Caller-supplied or generated UUID, known **before** spawn | Server-assigned thread id, returned in the response | Server-assigned `ses…` id, returned in the response |
+| Per-fork overrides | Anything expressible as CLI flags (model, cwd, tools, …) | `model`, `cwd`, `sandbox`, `approval_policy`, `ephemeral`, … | `directory` / `workspace` targeting only |
+| Precondition | Source session must exist on disk | Source thread needs ≥ 1 persisted turn (else "no rollout found") | None — a fresh session forks fine |
+
+All three are covered by live integration tests
+(`test_fork_session_carries_history_under_new_id`,
+`test_async_client_thread_fork`, `fork_session_returns_new_session`).
+
 ## Testing Approach
 
 The crates share the same testing philosophy:

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Session forking**: `ClaudeCliBuilder::fork_from(source_session_id)`
+  assembles the full `--resume <src> --fork-session --session-id <new>`
+  combination (generating a fresh UUID unless one is chained via
+  `session_id`), and `fork_session(bool)` exposes the raw flag — which the
+  builder previously could not emit at all. Covered by a live integration
+  test proving the fork carries the source's history under the new session
+  id. (#227)
+
 ### Changed
 
 - **Breaking**: `UsageInfo.iterations` is now `Vec<UsageIteration>` (was

--- a/claude-codes/src/cli.rs
+++ b/claude-codes/src/cli.rs
@@ -393,6 +393,7 @@ pub struct ClaudeCliBuilder {
     permission_mode: Option<PermissionMode>,
     continue_conversation: bool,
     resume: Option<String>,
+    fork_session: bool,
     model: Option<String>,
     fallback_model: Option<String>,
     settings: Option<String>,
@@ -433,6 +434,7 @@ impl ClaudeCliBuilder {
             permission_mode: None,
             continue_conversation: false,
             resume: None,
+            fork_session: false,
             model: None,
             fallback_model: None,
             settings: None,
@@ -538,6 +540,39 @@ impl ClaudeCliBuilder {
     /// Resume a specific conversation
     pub fn resume<S: Into<String>>(mut self, session_id: Option<S>) -> Self {
         self.resume = session_id.map(|s| s.into());
+        self
+    }
+
+    /// When resuming (or continuing), create a new session ID instead of
+    /// reusing the source session's — i.e. fork. The CLI only accepts
+    /// `--session-id` alongside `--resume`/`--continue` when this is set.
+    ///
+    /// Prefer [`fork_from`](Self::fork_from), which assembles the whole
+    /// combination.
+    pub fn fork_session(mut self, fork: bool) -> Self {
+        self.fork_session = fork;
+        self
+    }
+
+    /// Fork an existing session: resume `source_session_id`'s full history
+    /// into a **new** session, leaving the source untouched.
+    ///
+    /// Assembles `--resume <source> --fork-session --session-id <new>`,
+    /// generating a fresh UUID for the fork (override it by chaining
+    /// [`session_id`](Self::session_id)). The forked session starts with the
+    /// source's entire history — the Claude CLI has no headless
+    /// fork-at-a-point cut; for that semantic see `codex-codes`'
+    /// `thread_fork` with `last_turn_id`.
+    ///
+    /// ```no_run
+    /// # use claude_codes::ClaudeCliBuilder;
+    /// let builder = ClaudeCliBuilder::new()
+    ///     .fork_from("0b8fa762-6c48-4f3b-a3a1-0347f96a52bc")
+    ///     .prompt("Continue, but try the other approach");
+    /// ```
+    pub fn fork_from<S: Into<String>>(mut self, source_session_id: S) -> Self {
+        self.resume = Some(source_session_id.into());
+        self.fork_session = true;
         self
     }
 
@@ -708,6 +743,10 @@ impl ClaudeCliBuilder {
             args.push(session.clone());
         }
 
+        if self.fork_session {
+            args.push("--fork-session".to_string());
+        }
+
         if let Some(ref model) = self.model {
             args.push("--model".to_string());
             args.push(model.clone());
@@ -748,10 +787,11 @@ impl ClaudeCliBuilder {
             args.push(tool.clone());
         }
 
-        // Only add --session-id when NOT resuming/continuing an existing session
-        // (Claude CLI error: --session-id can only be used with --continue or --resume
-        // if --fork-session is also specified)
-        if self.resume.is_none() && !self.continue_conversation {
+        // --session-id is only legal alongside --resume/--continue when
+        // --fork-session is set (it names the fork); otherwise emit it only
+        // for fresh sessions. Either way a UUID is generated when unset so
+        // the session id is known before spawn.
+        if (self.resume.is_none() && !self.continue_conversation) || self.fork_session {
             args.push("--session-id".to_string());
             let session_uuid = self.session_id.unwrap_or_else(|| {
                 let uuid = Uuid::new_v4();
@@ -1042,5 +1082,46 @@ mod tests {
             !args.contains(&"--session-id".to_string()),
             "--session-id should NOT be present when continuing"
         );
+    }
+
+    #[test]
+    fn test_fork_from_assembles_resume_fork_and_new_session_id() {
+        let new_id = Uuid::new_v4();
+        let args = ClaudeCliBuilder::new()
+            .fork_from("source-uuid")
+            .session_id(new_id)
+            .build_args();
+
+        let resume_pos = args.iter().position(|a| a == "--resume").unwrap();
+        assert_eq!(args[resume_pos + 1], "source-uuid");
+        assert!(args.contains(&"--fork-session".to_string()));
+        let sid_pos = args.iter().position(|a| a == "--session-id").unwrap();
+        assert_eq!(args[sid_pos + 1], new_id.to_string());
+    }
+
+    #[test]
+    fn test_fork_from_generates_session_id_when_unset() {
+        let args = ClaudeCliBuilder::new()
+            .fork_from("source-uuid")
+            .build_args();
+
+        assert!(args.contains(&"--fork-session".to_string()));
+        let sid_pos = args.iter().position(|a| a == "--session-id").unwrap();
+        assert!(
+            Uuid::parse_str(&args[sid_pos + 1]).is_ok(),
+            "generated fork session id should be a UUID"
+        );
+    }
+
+    #[test]
+    fn test_fork_session_with_continue_emits_session_id() {
+        let args = ClaudeCliBuilder::new()
+            .continue_conversation(true)
+            .fork_session(true)
+            .build_args();
+
+        assert!(args.contains(&"--continue".to_string()));
+        assert!(args.contains(&"--fork-session".to_string()));
+        assert!(args.contains(&"--session-id".to_string()));
     }
 }

--- a/claude-codes/tests/integration_tests.rs
+++ b/claude-codes/tests/integration_tests.rs
@@ -178,6 +178,81 @@ async fn test_async_client_conversation() {
     );
 }
 
+/// Fork a session with `fork_from`: the fork must carry the source's
+/// history under a NEW session id, leaving the source session untouched.
+#[tokio::test]
+async fn test_fork_session_carries_history_under_new_id() {
+    let source_id = Uuid::new_v4();
+
+    // Seed the source session with a memorable fact, then close it.
+    let builder = ClaudeCliBuilder::new()
+        .model("sonnet")
+        .allow_recursion()
+        .session_id(source_id);
+    let mut client = AsyncClient::from_builder(builder)
+        .await
+        .expect("Failed to create source client");
+    let mut stream = client
+        .query_stream("Remember the word 'pineapple'. Reply with just OK.")
+        .await
+        .expect("Failed to seed source session");
+    while let Some(result) = stream.next().await {
+        if let Ok(ClaudeOutput::Result(_)) = result {
+            break;
+        }
+    }
+    drop(stream);
+    client.shutdown().await.expect("Failed to shutdown source");
+
+    // Fork it and ask the fork to recall the fact.
+    let fork_id = Uuid::new_v4();
+    let builder = ClaudeCliBuilder::new()
+        .model("sonnet")
+        .allow_recursion()
+        .fork_from(source_id.to_string())
+        .session_id(fork_id);
+    let mut fork = AsyncClient::from_builder(builder)
+        .await
+        .expect("Failed to create forked client");
+    let mut stream = fork
+        .query_stream("What word did I ask you to remember? Reply with just that word.")
+        .await
+        .expect("Failed to query fork");
+
+    let mut recalled = false;
+    let mut fork_session_seen = None;
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(ClaudeOutput::Assistant(msg)) => {
+                for content in &msg.message.content {
+                    if let claude_codes::io::ContentBlock::Text(text) = content {
+                        if text.text.to_lowercase().contains("pineapple") {
+                            recalled = true;
+                        }
+                    }
+                }
+            }
+            Ok(ClaudeOutput::Result(res)) => {
+                fork_session_seen = Some(res.session_id.clone());
+                break;
+            }
+            _ => {}
+        }
+    }
+    drop(stream);
+    fork.shutdown().await.expect("Failed to shutdown fork");
+
+    assert!(
+        recalled,
+        "Fork should recall 'pineapple' from source history"
+    );
+    assert_eq!(
+        fork_session_seen.as_deref(),
+        Some(fork_id.to_string().as_str()),
+        "Fork must run under the NEW session id, not the source's"
+    );
+}
+
 /// Test handling various message types
 #[tokio::test]
 async fn test_message_types() {

--- a/codex-codes/tests/live_client_tests.rs
+++ b/codex-codes/tests/live_client_tests.rs
@@ -40,6 +40,80 @@ async fn test_async_client_start_and_thread_start() {
     client.shutdown().await.expect("Failed to shutdown");
 }
 
+/// Fork a thread with `thread/fork`. The source needs at least one persisted
+/// turn first — forking a fresh, turn-less thread is rejected with
+/// "no rollout found for thread id …".
+#[tokio::test]
+async fn test_async_client_thread_fork() {
+    let mut client = AsyncClient::start()
+        .await
+        .expect("Failed to start app-server");
+
+    let source = client
+        .thread_start(&serde_json::from_value::<ThreadStartParams>(serde_json::json!({})).unwrap())
+        .await
+        .expect("Failed to start source thread");
+
+    client
+        .turn_start(&TurnStartParams {
+            thread_id: source.thread.id.clone(),
+            input: vec![UserInput::Text {
+                text: "Reply with just OK.".to_string(),
+                text_elements: None,
+            }],
+            approval_policy: None,
+            approvals_reviewer: None,
+            client_user_message_id: None,
+            cwd: None,
+            effort: None,
+            model: None,
+            output_schema: None,
+            personality: None,
+            sandbox_policy: None,
+            service_tier: None,
+            summary: None,
+        })
+        .await
+        .expect("Failed to start seed turn");
+
+    let mut message_count = 0;
+    while let Some(msg) = client.next_message().await.expect("Failed to read message") {
+        message_count += 1;
+        match msg {
+            ServerMessage::Notification(Notification::TurnCompleted(_)) => break,
+            ServerMessage::Notification(_) => {}
+            ServerMessage::Request { id, .. } => {
+                client
+                    .respond(id, &serde_json::json!({"decision": "accept"}))
+                    .await
+                    .expect("Failed to respond");
+            }
+        }
+        if message_count > 100 {
+            panic!("seed turn did not complete");
+        }
+    }
+
+    let fork = client
+        .thread_fork(
+            &serde_json::from_value(serde_json::json!({ "threadId": source.thread.id }))
+                .expect("valid fork params"),
+        )
+        .await
+        .expect("Failed to fork thread");
+
+    assert!(
+        !fork.thread.id.is_empty(),
+        "forked thread id must not be empty"
+    );
+    assert_ne!(
+        fork.thread.id, source.thread.id,
+        "fork must get a NEW thread id"
+    );
+
+    client.shutdown().await.expect("Failed to shutdown");
+}
+
 // ── Async client: full turn lifecycle ───────────────────────────────
 
 #[tokio::test]

--- a/opencode-codes/CHANGELOG.md
+++ b/opencode-codes/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`OpencodeClient::fork_session`** — wraps `POST /session/{sessionID}/fork`
+  (operation `session.fork`), branching a session's whole history into a new
+  server-assigned session. Verified against a live 1.18.10 server. (#227)
+
 ### Changed
 
 - On Windows, managed `opencode serve` launches now use `CREATE_NO_WINDOW` to

--- a/opencode-codes/src/client_async.rs
+++ b/opencode-codes/src/client_async.rs
@@ -138,6 +138,19 @@ impl OpencodeClient {
             .await
     }
 
+    /// Fork a session — `POST /session/{sessionID}/fork`.
+    ///
+    /// Branches the source session's **whole history** into a new session and
+    /// returns the freshly created [`Session`] (server-assigned id); the
+    /// source is left untouched. The 1.18.x spec exposes no at-point cut on
+    /// this route — for fork-at-a-turn semantics see `codex-codes`'
+    /// `thread_fork` with `last_turn_id`.
+    pub async fn fork_session(&self, session_id: &str) -> Result<Session> {
+        self.transport
+            .request_json(Method::POST, &self.transport.fork_url(session_id), None)
+            .await
+    }
+
     /// Abort in-flight work — `POST /session/{sessionID}/abort`.
     ///
     /// Returns `true` when the session had work that was aborted.

--- a/opencode-codes/src/http.rs
+++ b/opencode-codes/src/http.rs
@@ -248,6 +248,18 @@ impl HttpTransport {
         url
     }
 
+    /// URL for `POST /session/{sessionID}/fork`.
+    pub fn fork_url(&self, session_id: &str) -> String {
+        let mut url = format!(
+            "{}/session/{}/fork",
+            self.base_url,
+            encode_segment(session_id)
+        );
+        let mut sep = '?';
+        self.append_scope(&mut url, &mut sep);
+        url
+    }
+
     /// URL for `POST /session/{sessionID}/permissions/{permissionID}`.
     pub fn permission_url(&self, session_id: &str, permission_id: &str) -> String {
         let mut url = format!(

--- a/opencode-codes/tests/integration_tests.rs
+++ b/opencode-codes/tests/integration_tests.rs
@@ -114,6 +114,34 @@ async fn create_list_abort_loop() {
     let _aborted: bool = client.abort(&session.id).await.expect("abort");
 }
 
+/// Fork a session — the fork must be a NEW `ses…` handle distinct from the
+/// source, with the source left intact.
+#[tokio::test]
+async fn fork_session_returns_new_session() {
+    let client = client();
+
+    let source = client
+        .create_session(&create_params("opencode-codes fork source"))
+        .await
+        .expect("create source session");
+
+    let fork = client.fork_session(&source.id).await.expect("fork session");
+
+    assert!(
+        fork.id.starts_with("ses"),
+        "fork id should be a ses… handle, got {}",
+        fork.id
+    );
+    assert_ne!(fork.id, source.id, "fork must get a NEW session id");
+
+    // Source is untouched and still addressable.
+    let messages = client
+        .list_messages(&source.id)
+        .await
+        .expect("source still listable after fork");
+    assert!(messages.is_empty());
+}
+
 /// Submit a prompt, then reconcile via the authoritative message listing.
 ///
 /// The user message the server records is deterministic and provider-free, so


### PR DESCRIPTION
Fixes #227.

**claude-codes** (ask 1): `ClaudeCliBuilder::fork_from(source_session_id)` assembles the documented fork recipe (`--resume <src> --fork-session --session-id <new>`), generating the fork's UUID when not chained so it's known **before** spawn. Notably the builder previously had no way to emit `--fork-session` at all — the flag existed only in the `CliFlag` enum. `fork_session(bool)` exposes the raw flag for `--continue`-style forks. Three new arg-assembly unit tests.

**Live-tested end to end** (`test_fork_session_carries_history_under_new_id`): seeds session A with a fact, forks to B, and asserts the fork recalls the fact **and** runs under B's id. Passes against CLI 2.1.220. ✅

**opencode-codes** (bonus): the spec carries `POST /session/{sessionID}/fork` but the curated client never exposed it — `OpencodeClient::fork_session` now wraps it. Live-verified against a spawned 1.18.10 server (fresh `ses…` id, source intact). ✅

**codex-codes** (verification): live test for the existing `thread_fork`, with a discovered precondition now documented: forking a **turn-less** thread is rejected upstream (`no rollout found for thread id`), so the test seeds one turn first. Model-turn auth lives in the codex agent session; verification delegated there.

**Docs** (ask 2): root README gains a **Session Forking** section comparing all three runtimes — mechanism, fork point (claude/opencode: whole-history only; codex: `last_turn_id` cut), identity assignment, per-fork overrides, and preconditions. Ask 3's tracking note lives in the `fork_from` rustdoc.