### PR TITLE
Press copy affordance once when success confirmed without token

### DIFF
--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -27,6 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Copy-affordance nudge on confirmed success**: when the credentials store
+  updates but no token is yet observable, `submit_code_and_wait` presses `c`
+  (the TUI's "c to copy" affordance) once, giving the OSC 52 channel a chance
+  to deliver the exact token bytes before the grace window closes — reducing
+  the frequency of `token: None` successes that downstream must treat as
+  re-login-after-redeploy mode. Best-effort: a stray keypress on screens
+  without the affordance, in a flow that has already succeeded. (#260)
 - **Login rejection detection widened**: the collapsed `Press Enter to retry`
   prompt now anchors `CodeRejected` as a fallback when the error wording
   doesn't contain `OAuth error` — live capture shows the renderer mangles

--- a/claude-codes/src/auth.rs
+++ b/claude-codes/src/auth.rs
@@ -426,7 +426,21 @@ impl LoginFlow {
 
             // Credentials write = accepted, even with nothing on screen.
             if creds_updated {
+                let first_detection = creds_seen_at.is_none();
                 let seen = *creds_seen_at.get_or_insert_with(Instant::now);
+                if first_detection {
+                    // Success is confirmed, so nudge the TUI's copy
+                    // affordance ("c to copy") once: if the success screen
+                    // supports it, the CLI emits the token over OSC 52 —
+                    // exact bytes — before the grace window closes. Best
+                    // effort: on screens without the affordance this is a
+                    // stray keypress in an already-succeeded flow.
+                    use std::io::Write;
+                    let _ = self
+                        .writer
+                        .write_all(b"c")
+                        .and_then(|()| self.writer.flush());
+                }
                 if seen.elapsed() >= CREDS_TOKEN_GRACE {
                     return Ok(LoginOutcome {
                         token: None,


### PR DESCRIPTION
Follow-up to #259, answering agentive-inversion's question of whether OSC 52 token capture can be made more reliable (their fallback mode — cli-persisted credentials in an ephemeral container HOME — costs a re-login on every redeploy).

When the credentials store updates but no token is observable on screen or OSC 52 yet, the flow now presses `c` once — the TUI's "c to copy" affordance — at the start of the 3s grace window. If the success screen supports copy (confirmed for the URL screen; unknown for the token screen), the CLI emits the token over OSC 52 in exact bytes and the existing ladder picks it up. If not, it's a single stray keypress in a flow that has already succeeded, and the `token: None` outcome stands unchanged.

Verified: full auth test suite green, clippy clean, live rejection probe unaffected (~235 ms; the nudge only fires after a credentials write).