### PR TITLE
Expose OSC 52 status and copy-nudge attribution on login outcomes

### DIFF
--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Success-path OSC 52 telemetry**: `LoginOutcome` gains
+  `osc52: Osc52Status` (`Absent` / `Unterminated` / `Undecodable` /
+  `PresentNoToken` / `TokenRecovered`) and `copy_nudge_sent: bool`, and the
+  `LoginTimeout` channel line gains `copy-nudge=sent|not-sent` — so a
+  `token: None` success distinguishes "screen offers no copy affordance"
+  from "affordance fired with a non-token payload", crate-side, where the
+  PTY bytes are actually observable. The copy nudge is also recorded so any
+  unexpected TUI consequence is attributable. (#261)
 - **Copy-affordance nudge on confirmed success**: when the credentials store
   updates but no token is yet observable, `submit_code_and_wait` presses `c`
   (the TUI's "c to copy" affordance) once, giving the OSC 52 channel a chance

--- a/claude-codes/src/auth.rs
+++ b/claude-codes/src/auth.rs
@@ -125,6 +125,26 @@ pub enum TokenSource {
     Osc52,
 }
 
+/// What the OSC 52 clipboard channel showed by the time the flow settled —
+/// success-path telemetry so a `token: None` outcome names the reason
+/// instead of leaving "no affordance" and "affordance fired with a non-token
+/// payload" indistinguishable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Osc52Status {
+    /// No OSC 52 sequence ever appeared (the screen may offer no copy
+    /// affordance, or the nudge didn't trigger it).
+    Absent,
+    /// A sequence started but never terminated before the flow settled.
+    Unterminated,
+    /// Terminated sequence(s) whose payload wasn't valid base64.
+    Undecodable,
+    /// Valid payload(s) seen, none containing a token (e.g. the URL copy).
+    PresentNoToken,
+    /// The token was recovered from this channel
+    /// ([`LoginOutcome::token_source`] is [`TokenSource::Osc52`]).
+    TokenRecovered,
+}
+
 /// Result of a completed [`LoginFlow`].
 #[derive(Debug, Clone)]
 pub struct LoginOutcome {
@@ -140,9 +160,27 @@ pub struct LoginOutcome {
     /// code submission — the authoritative success signal, independent of
     /// anything rendered on screen.
     pub credentials_updated: bool,
+    /// State of the OSC 52 clipboard channel when the flow settled.
+    pub osc52: Osc52Status,
+    /// True when the flow pressed the TUI's `c` copy affordance after
+    /// success was confirmed — so any unexpected TUI consequence is
+    /// attributable rather than mysterious.
+    pub copy_nudge_sent: bool,
     /// The flow's full terminal output with ANSI escapes stripped — for
     /// surfacing the CLI's own error text when something goes wrong.
     pub transcript: String,
+}
+
+impl From<&Osc52Scan> for Osc52Status {
+    fn from(scan: &Osc52Scan) -> Self {
+        match scan {
+            Osc52Scan::Absent => Osc52Status::Absent,
+            Osc52Scan::Unterminated => Osc52Status::Unterminated,
+            Osc52Scan::Undecodable => Osc52Status::Undecodable,
+            Osc52Scan::NoTokenInPayload => Osc52Status::PresentNoToken,
+            Osc52Scan::Token(_) => Osc52Status::TokenRecovered,
+        }
+    }
 }
 
 /// Shared PTY output buffer: bytes so far + whether the reader hit EOF.
@@ -371,6 +409,7 @@ impl LoginFlow {
         // extraction gets this long afterwards to surface before we accept
         // success-without-token.
         let mut creds_seen_at: Option<Instant> = None;
+        let mut nudged = false;
         const CREDS_TOKEN_GRACE: Duration = Duration::from_secs(3);
 
         let (lock, cv) = &*self.buf;
@@ -390,6 +429,8 @@ impl LoginFlow {
                             token: Some(token),
                             token_source: Some(TokenSource::Osc52),
                             credentials_updated: creds_updated,
+                            osc52: Osc52Status::TokenRecovered,
+                            copy_nudge_sent: nudged,
                             transcript: stripped,
                         });
                     }
@@ -404,6 +445,8 @@ impl LoginFlow {
                     token: Some(token),
                     token_source: Some(TokenSource::Screen),
                     credentials_updated: creds_updated,
+                    osc52: Osc52Status::from(&osc52),
+                    copy_nudge_sent: nudged,
                     transcript: stripped,
                 });
             }
@@ -413,6 +456,8 @@ impl LoginFlow {
                     token: Some(token.clone()),
                     token_source: Some(TokenSource::Osc52),
                     credentials_updated: creds_updated,
+                    osc52: Osc52Status::TokenRecovered,
+                    copy_nudge_sent: nudged,
                     transcript: stripped,
                 });
             }
@@ -434,18 +479,24 @@ impl LoginFlow {
                     // supports it, the CLI emits the token over OSC 52 —
                     // exact bytes — before the grace window closes. Best
                     // effort: on screens without the affordance this is a
-                    // stray keypress in an already-succeeded flow.
+                    // stray keypress in an already-succeeded flow. Guarded:
+                    // reaching this branch means the post-submission tail
+                    // carried no rejection anchor this iteration (that check
+                    // returns above), so this is not a retry prompt.
                     use std::io::Write;
-                    let _ = self
+                    nudged = self
                         .writer
                         .write_all(b"c")
-                        .and_then(|()| self.writer.flush());
+                        .and_then(|()| self.writer.flush())
+                        .is_ok();
                 }
                 if seen.elapsed() >= CREDS_TOKEN_GRACE {
                     return Ok(LoginOutcome {
                         token: None,
                         token_source: None,
                         credentials_updated: true,
+                        osc52: Osc52Status::from(&osc52),
+                        copy_nudge_sent: nudged,
                         transcript: stripped,
                     });
                 }
@@ -463,6 +514,8 @@ impl LoginFlow {
                     token: None,
                     token_source: None,
                     credentials_updated: creds_updated,
+                    osc52: Osc52Status::from(&osc52),
+                    copy_nudge_sent: nudged,
                     transcript,
                 });
             }
@@ -480,12 +533,14 @@ impl LoginFlow {
                 }
                 return Err(Error::LoginTimeout {
                     transcript: format!(
-                        "[channels: screen=no-token osc52={osc52:?} credentials={}]\n{}",
+                        "[channels: screen=no-token osc52={:?} credentials={} copy-nudge={}]\n{}",
+                        Osc52Status::from(&osc52),
                         if creds_updated {
                             "updated"
                         } else {
                             "unchanged"
                         },
+                        if nudged { "sent" } else { "not-sent" },
                         &tail[start..]
                     ),
                 });
@@ -536,6 +591,7 @@ impl LoginFlow {
         drop(guard);
 
         let credentials_updated = self.creds.updated();
+        let osc52_status = Osc52Status::from(&osc52);
         let (token, token_source) = match (extract_token(&transcript), osc52) {
             (Some(t), _) => (Some(t), Some(TokenSource::Screen)),
             (None, Osc52Scan::Token(t)) => (Some(t), Some(TokenSource::Osc52)),
@@ -550,6 +606,8 @@ impl LoginFlow {
             token,
             token_source,
             credentials_updated,
+            osc52: osc52_status,
+            copy_nudge_sent: false,
             transcript,
         })
     }


### PR DESCRIPTION
Follow-up to #260, implementing infra's (72f72c15) observation that the PTY stream is only visible from inside the crate — so success-path channel telemetry must live here, not in external instrumentation.

- `LoginOutcome.osc52: Osc52Status` — `Absent` / `Unterminated` / `Undecodable` / `PresentNoToken` / `TokenRecovered`. A `token: None` success now distinguishes the three worlds: `token_source=Osc52` → nudge worked; `osc52=Absent` → token screen offers no copy affordance (durable fix moves downstream: volume for `~/.claude`); `osc52=PresentNoToken` → affordance fired but the payload wasn't the token.
- `LoginOutcome.copy_nudge_sent: bool` and `copy-nudge=sent|not-sent` on the `LoginTimeout` channel line — the nudge keypress is recorded so any unexpected TUI consequence is attributable rather than mysterious.
- Nudge guard made explicit: the ladder's ordering already guarantees the nudge can't fire on a screen showing rejection anchors (that branch returns earlier in the same iteration); now documented at the nudge site.

Additive only — no behavior change to detection. Live-verified: rejection ~240 ms unchanged; forced timeout renders `[channels: screen=no-token osc52=Absent credentials=unchanged copy-nudge=not-sent]`.