### PR TITLE
Fix 64-byte paste swallow: bracketed framing plus separate CR

### DIFF
--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Login code submission failed silently for every production-length
+  code.** The TUI classifies any single PTY write of **≥ 64 bytes** as a
+  paste and swallows a trailing CR into the paste payload instead of
+  treating it as Enter (measured on CLI 2.1.220: 62-char code + CR submits;
+  63-char + CR sits at the prompt forever). Real authorization codes are
+  ~90+ chars, so no unframed single-chunk write could ever submit — this is
+  what produced the silent 30s/90s timeouts in production, undetected
+  because every test fixture happened to be under 64 bytes. `submit_code`
+  now writes the code wrapped in **bracketed-paste framing**
+  (`ESC[200~…ESC[201~` — the paste path the CLI explicitly enables via
+  `ESC[?2004h`), then sends CR as its own write 150 ms later. Live-verified
+  across a 36–120 byte matrix including both previously-silent boundary
+  lengths; unit fixtures moved to production lengths (64/92/108/120) and a
+  live integration test now submits 92- and 108-char codes, both of which
+  any sub-64-byte fixture is structurally incapable of covering. (#263)
+
 ### Added
 
 - **Three-source success detection for login flows**, driven by the prod

--- a/claude-codes/src/auth.rs
+++ b/claude-codes/src/auth.rs
@@ -353,14 +353,33 @@ impl LoginFlow {
 
     /// Paste the authorization code back into the flow.
     ///
-    /// The code is trimmed and terminated with a single carriage return
-    /// (`0x0D` — the Enter keycode the raw-mode TUI expects; LF does not
-    /// submit), written as one chunk. A code that is empty after trimming is
-    /// rejected here: pressing Enter on an empty field produces no
-    /// detectable outcome, only a silent hang.
+    /// The code is written wrapped in **bracketed-paste framing**
+    /// (`ESC[200~ … ESC[201~`), then — after a short beat — a single
+    /// carriage return (`0x0D`, the Enter keycode; LF does not submit) as
+    /// its own write.
+    ///
+    /// Both parts are load-bearing. The TUI classifies any single write of
+    /// **≥ 64 bytes** as a paste and absorbs a trailing CR into the paste
+    /// payload instead of treating it as Enter — measured live on CLI
+    /// 2.1.220: a 62-char code + CR (63 bytes) submits, a 63-char code + CR
+    /// (64 bytes) sits silently at the prompt forever. Every real
+    /// authorization code (~90+ chars) is over the threshold, so an unframed
+    /// single-chunk write can never submit in production. The CLI enables
+    /// bracketed paste (`ESC[?2004h`), so explicit framing is the paste path
+    /// it is actually expecting; the separated, delayed CR then lands
+    /// outside the paste boundary as a genuine keypress.
+    ///
+    /// A code that is empty after trimming is rejected here: pressing Enter
+    /// on an empty field produces no detectable outcome, only a silent hang.
     pub fn submit_code(&mut self, code: &str) -> Result<()> {
         use std::io::Write;
-        self.writer.write_all(&prepare_code_bytes(code)?)?;
+        self.writer.write_all(&prepare_code_paste(code)?)?;
+        self.writer.flush()?;
+        // Let the TUI consume the paste before Enter arrives; also keeps the
+        // CR temporally separate from the burst (the second independently
+        // verified fix for the 64-byte swallow).
+        std::thread::sleep(SUBMIT_ENTER_DELAY);
+        self.writer.write_all(b"\r")?;
         self.writer.flush()?;
         Ok(())
     }
@@ -728,21 +747,29 @@ fn extract_osc52_token(raw: &[u8]) -> Osc52Scan {
     best
 }
 
-/// The exact bytes a code submission writes to the PTY: the trimmed code
-/// followed by a single carriage return, as ONE chunk. CR (`0x0D`) is the
-/// Enter keycode the raw-mode TUI expects — LF lands in the input buffer and
-/// never submits. An empty-after-trim code is refused: pressing Enter on an
-/// empty field produces no detectable outcome, only a silent hang.
-fn prepare_code_bytes(code: &str) -> Result<Vec<u8>> {
+/// Pause between the paste frame and the Enter keypress in
+/// [`LoginFlow::submit_code`].
+const SUBMIT_ENTER_DELAY: Duration = Duration::from_millis(150);
+
+/// The paste frame a code submission writes to the PTY: the trimmed code
+/// wrapped in bracketed-paste markers (`ESC[200~ … ESC[201~`), NO trailing
+/// CR — Enter is sent separately after [`SUBMIT_ENTER_DELAY`]. See
+/// [`LoginFlow::submit_code`] for why: single writes of ≥ 64 bytes are
+/// classified as pastes and a trailing CR inside the burst is swallowed, so
+/// the frame declares the paste explicitly and the keypress travels alone.
+/// An empty-after-trim code is refused: pressing Enter on an empty field
+/// produces no detectable outcome, only a silent hang.
+fn prepare_code_paste(code: &str) -> Result<Vec<u8>> {
     let code = code.trim();
     if code.is_empty() {
         return Err(Error::Protocol(
             "authorization code is empty after trimming; refusing to submit".to_string(),
         ));
     }
-    let mut buf = Vec::with_capacity(code.len() + 1);
+    let mut buf = Vec::with_capacity(code.len() + 12);
+    buf.extend_from_slice(b"\x1b[200~");
     buf.extend_from_slice(code.as_bytes());
-    buf.push(b'\r');
+    buf.extend_from_slice(b"\x1b[201~");
     Ok(buf)
 }
 
@@ -1049,15 +1076,29 @@ mod tests {
     }
 
     #[test]
-    fn code_bytes_are_trimmed_cr_terminated_single_chunk() {
-        // Browser pastes carry trailing newlines; exactly one CR must follow
-        // the code, with the caller's LF/CR stripped, in one write chunk.
-        assert_eq!(prepare_code_bytes("abc#def\n").unwrap(), b"abc#def\r");
-        assert_eq!(prepare_code_bytes(" abc \r\n").unwrap(), b"abc\r");
-        assert_eq!(prepare_code_bytes("abc").unwrap(), b"abc\r");
+    fn code_paste_is_bracketed_trimmed_and_cr_free() {
+        // Fixtures at PRODUCTION lengths. The 64-byte paste-classification
+        // bug was invisible to every sub-64-byte fixture; codes under 64
+        // bytes are a different input class from real ones (~92 observed,
+        // 108 = credentials-token length).
+        for len in [64usize, 92, 108, 120] {
+            let code: String = "x".repeat(len - 6) + "#state";
+            let frame = prepare_code_paste(&format!("{code}\n")).unwrap();
+            let mut expected = b"\x1b[200~".to_vec();
+            expected.extend_from_slice(code.as_bytes());
+            expected.extend_from_slice(b"\x1b[201~");
+            assert_eq!(frame, expected, "len {len}");
+            // The frame itself must never carry the Enter keypress: a CR
+            // inside a ≥64-byte burst is swallowed as paste payload.
+            assert!(!frame.contains(&b'\r'), "len {len}: CR must travel alone");
+        }
+        assert_eq!(
+            prepare_code_paste(" abc \r\n").unwrap(),
+            b"\x1b[200~abc\x1b[201~"
+        );
         for empty in ["", "  ", "\n", "\r\n", "\t"] {
             assert!(
-                prepare_code_bytes(empty).is_err(),
+                prepare_code_paste(empty).is_err(),
                 "empty guard must fire for {empty:?}"
             );
         }

--- a/claude-codes/tests/integration_tests.rs
+++ b/claude-codes/tests/integration_tests.rs
@@ -2489,3 +2489,38 @@ fn test_login_flow_yields_auth_url_live() {
     );
     // Dropping the flow cancels the login and kills the CLI.
 }
+
+/// Regression net for the 64-byte paste-classification bug: submission of a
+/// PRODUCTION-LENGTH code must produce a definitive rejection, not silence.
+/// Single-chunk writes of >= 64 bytes are classified as pastes by the TUI
+/// and a trailing CR is swallowed (62-char code + CR submits, 63-char + CR
+/// hangs forever, measured on CLI 2.1.220) — every fixture below 64 bytes
+/// is structurally incapable of catching this class of bug.
+#[cfg(feature = "auth")]
+#[test]
+fn test_production_length_code_submission_is_acknowledged_live() {
+    use claude_codes::auth::{LoginFlow, LoginMode};
+    use claude_codes::Error;
+    use std::time::{Duration, Instant};
+
+    for len in [92usize, 108] {
+        let code: String = "aB3".repeat(40)[..len - 6].to_string() + "#state";
+        assert!(code.len() >= 64, "fixture must exceed the paste threshold");
+
+        let mut flow = LoginFlow::start(LoginMode::SetupToken).expect("flow starts");
+        flow.auth_url(Duration::from_secs(30)).expect("url appears");
+        let t0 = Instant::now();
+        let err = flow
+            .submit_code_and_wait(&code, Duration::from_secs(20))
+            .expect_err("bogus code must be rejected");
+        match err {
+            Error::CodeRejected { .. } => {}
+            other => panic!("len {len}: expected CodeRejected, got: {other}"),
+        }
+        assert!(
+            t0.elapsed() < Duration::from_secs(15),
+            "len {len}: rejection took {:?} — submission may not have registered",
+            t0.elapsed()
+        );
+    }
+}


### PR DESCRIPTION
Fixes the actual root cause of the production login failure — found by infra's (72f72c15) length-matrix measurement after Matt's fully-instrumented third attempt returned `[channels: screen=no-token osc52=Absent credentials=unchanged]`, proving the code was never accepted.

**The bug**: the TUI classifies any single PTY write of **≥ 64 bytes** as a paste and swallows a trailing CR into the paste payload. Boundary measured independently in the prod container and locally, agreeing exactly: 62-char code + CR (63 bytes) submits; 63-char code + CR (64 bytes) sits at the prompt forever. Every real authorization code (~92 chars observed) is over the threshold — **no unframed single-chunk write could ever have submitted in production**. Attempt two's back-to-back split writes coalesced in the kernel PTY buffer, so they were equally broken; the write count was never the variable, burst size was.

**Why every test missed it**: all fixtures (17, 36 chars, `bogus-code-xyz`) sat under 64 bytes by coincidence. Sub-64-byte codes are a different input class from production ones.

**The fix** (both mechanisms infra verified at 92 bytes, combined): `submit_code` wraps the code in **bracketed-paste framing** (`ESC[200~…ESC[201~`) — the CLI enables bracketed paste via `ESC[?2004h`, so this is the paste path it is actually expecting — then sends CR as its own write 150 ms later, landing outside the paste boundary as a genuine keypress.

**Regression nets**: unit fixtures at 64/92/108/120 bytes asserting the frame is CR-free; live integration test submits 92- and 108-char codes and requires `CodeRejected` within 15s (silence = fail). Live matrix verified locally: 36/62/63/64/70/92/108/120 all submit in ~400 ms.

The 64-byte constant and mechanism are documented at the write site.