### PR TITLE
Document that submit delay is redundant on purpose

### DIFF
--- a/claude-codes/src/auth.rs
+++ b/claude-codes/src/auth.rs
@@ -375,9 +375,13 @@ impl LoginFlow {
         use std::io::Write;
         self.writer.write_all(&prepare_code_paste(code)?)?;
         self.writer.flush()?;
-        // Let the TUI consume the paste before Enter arrives; also keeps the
-        // CR temporally separate from the burst (the second independently
-        // verified fix for the 64-byte swallow).
+        // REDUNDANT ON PURPOSE — do not "optimise away". The framing alone
+        // is sufficient (verified in-container: framed burst + CR in the
+        // SAME write submits at 92 bytes), and the delayed lone CR is
+        // sufficient alone too. Keeping both means a future change must
+        // break two independent mechanisms to reintroduce the 64-byte
+        // swallow, and either can quietly save us if the CLI's paste
+        // handling shifts.
         std::thread::sleep(SUBMIT_ENTER_DELAY);
         self.writer.write_all(b"\r")?;
         self.writer.flush()?;


### PR DESCRIPTION
Comment-only. Infra's in-container verification of #263 produced one robustness datum worth recording at the write site: bracketed-paste framing alone is sufficient (framed burst + CR in the same write submits at 92 bytes), so the 150 ms Enter delay is deliberately redundant — two independent mechanisms, either sufficient alone. The comment now says so explicitly, so the delay doesn't get optimised away as cargo cult by someone who doesn't know it's a second line of defense.