### PR TITLE
Force TERM on login child, stamp write path in channel line

### DIFF
--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Write-path provenance**: `auth::SUBMIT_PATH` identifies the compiled
+  code-submission mechanism and is stamped into the `LoginTimeout` channel
+  line (`submit-path=bracketed-paste+lone-cr-150ms+term-forced/v3`) — which
+  deployed binary is running becomes readable from one log line. Necessary
+  because release builds inline the paste-frame bytes into immediates, so
+  byte-grepping a binary for `ESC[200~` proves nothing in either
+  direction. (#265)
+
+### Changed
+
+- **Login flows now force `TERM=xterm-256color` on the spawned CLI.** The
+  crate is the terminal on the other side of the PTY (it parses OSC 8/52
+  and speaks bracketed paste), so it advertises a deterministic capability
+  surface instead of inheriting the host process's TERM (server processes
+  often have none). Measured on CLI 2.1.220, submission works under
+  `TERM=dumb` and TERM-unset too — this eliminates an environment axis
+  rather than fixing a reproduced failure. (#265)
+
 ### Fixed
 
 - **Login code submission failed silently for every production-length

--- a/claude-codes/src/auth.rs
+++ b/claude-codes/src/auth.rs
@@ -267,6 +267,14 @@ impl LoginFlow {
 
         let mut cmd = CommandBuilder::new(binary);
         cmd.args(mode.args());
+        // The crate IS the terminal on the other side of this PTY (it parses
+        // OSC 8/52, strips ANSI, and speaks bracketed paste), so advertise a
+        // deterministic capability surface instead of inheriting whatever
+        // TERM the host process happens to have (server processes often have
+        // none). Measured on CLI 2.1.220: submission works under TERM=dumb
+        // and TERM-unset too — this is eliminating an environment axis, not
+        // fixing a reproduced failure.
+        cmd.env("TERM", "xterm-256color");
         if let Ok(cwd) = std::env::current_dir() {
             cmd.cwd(cwd);
         }
@@ -556,7 +564,7 @@ impl LoginFlow {
                 }
                 return Err(Error::LoginTimeout {
                     transcript: format!(
-                        "[channels: screen=no-token osc52={:?} credentials={} copy-nudge={}]\n{}",
+                        "[channels: screen=no-token osc52={:?} credentials={} copy-nudge={} submit-path={SUBMIT_PATH}]\n{}",
                         Osc52Status::from(&osc52),
                         if creds_updated {
                             "updated"
@@ -750,6 +758,14 @@ fn extract_osc52_token(raw: &[u8]) -> Osc52Scan {
     }
     best
 }
+
+/// Identifies the code-submission write path compiled into this build.
+/// Recorded in the [`Error::LoginTimeout`] channel line (and available to
+/// downstream logs), so "which write path is actually deployed" is readable
+/// from a single log line instead of requiring binary forensics — release
+/// builds inline the frame bytes into immediates, so byte-grepping a binary
+/// for `ESC[200~` proves nothing in either direction.
+pub const SUBMIT_PATH: &str = "bracketed-paste+lone-cr-150ms+term-forced/v3";
 
 /// Pause between the paste frame and the Enter keypress in
 /// [`LoginFlow::submit_code`].


### PR DESCRIPTION
Response to the attempt-four post-mortem (agentive 3d7334b1 / infra 72f72c15).

**TERM hypothesis tested locally and weakened**: portable-pty injects no default TERM (only `SHELL`), and 92-char framed submission against CLI 2.1.220 succeeds under both `TERM=dumb` (which every prior local pass unknowingly used) and fully-unset TERM. Forcing `TERM=xterm-256color` anyway — the crate IS the terminal here, and this deletes the whole env axis from future diagnosis. My entire passing matrix having run under `TERM=dumb` also directly contradicts capability-gated framing on this CLI version.

**The counter-hypothesis this PR arms against**: "no `ESC[200~` bytes in the deployed binary" is the expected signature of BOTH the broken and fixed release builds (LLVM inlines the 6-byte literals) — that check is circular and cannot establish the deployed rev. `auth::SUBMIT_PATH` (`bracketed-paste+lone-cr-150ms+term-forced/v3`) is now stamped into every `LoginTimeout` channel line, so provenance is a log line, not binary forensics.

Verified live: 92-char TERM-unset submission → `CodeRejected` in ~400 ms; forced timeout renders `submit-path=…/v3` in the channel line. Full auth suite + clippy clean.