### PR TITLE
Scrub session and credential env vars from login spawn

### DIFF
--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Login flows scrub session/credential env vars from the spawned CLI**
+  (`CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_CHILD_SESSION`,
+  `CLAUDE_CODE_SESSION_ID`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`,
+  `ANTHROPIC_AUTH_TOKEN`), aligning with the session spawn path's
+  `CLAUDECODE` scrubbing in `cli.rs` — a login child's purpose is minting
+  fresh credentials, so it must not inherit the host's. Measured on 2.1.220
+  that none of these break submission when present; this removes the axis,
+  not a reproduced failure. `SUBMIT_PATH` bumps to
+  `…+env-scrubbed/v4`. (#266)
 - **Login flows now force `TERM=xterm-256color` on the spawned CLI.** The
   crate is the terminal on the other side of the PTY (it parses OSC 8/52
   and speaks bracketed paste), so it advertises a deterministic capability

--- a/claude-codes/src/auth.rs
+++ b/claude-codes/src/auth.rs
@@ -275,6 +275,23 @@ impl LoginFlow {
         // and TERM-unset too — this is eliminating an environment axis, not
         // fixing a reproduced failure.
         cmd.env("TERM", "xterm-256color");
+        // Same move for nested-session and credential detection: the session
+        // spawn path (cli.rs) deliberately scrubs CLAUDECODE; a login flow
+        // additionally must not inherit the host's Anthropic credentials —
+        // its entire purpose is to mint fresh ones. Measured on 2.1.220 that
+        // none of these break submission when present, but a login child has
+        // no legitimate use for any of them, so remove the axis outright.
+        for var in [
+            "CLAUDECODE",
+            "CLAUDE_CODE_ENTRYPOINT",
+            "CLAUDE_CODE_CHILD_SESSION",
+            "CLAUDE_CODE_SESSION_ID",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_AUTH_TOKEN",
+        ] {
+            cmd.env_remove(var);
+        }
         if let Ok(cwd) = std::env::current_dir() {
             cmd.cwd(cwd);
         }
@@ -765,7 +782,7 @@ fn extract_osc52_token(raw: &[u8]) -> Osc52Scan {
 /// from a single log line instead of requiring binary forensics — release
 /// builds inline the frame bytes into immediates, so byte-grepping a binary
 /// for `ESC[200~` proves nothing in either direction.
-pub const SUBMIT_PATH: &str = "bracketed-paste+lone-cr-150ms+term-forced/v3";
+pub const SUBMIT_PATH: &str = "bracketed-paste+lone-cr-150ms+term-forced+env-scrubbed/v4";
 
 /// Pause between the paste frame and the Enter keypress in
 /// [`LoginFlow::submit_code`].


### PR DESCRIPTION
Closes the spawn-path asymmetry agentive-inversion (3d7334b1) found: `cli.rs` session spawns deliberately `env_remove("CLAUDECODE")` at three sites, while the `auth.rs` login spawn inherited the host's complete environment untouched.

**Local reproduction attempts all negative first** — measured on CLI 2.1.220 with 92-char framed submissions: `CLAUDECODE=1` (present in every green run this box ever produced, natively), dummy `ANTHROPIC_API_KEY`, dummy `CLAUDE_CODE_OAUTH_TOKEN`, and both together — all submit fine. So this is axis-removal hygiene, not a reproduced fix, and the changelog says so honestly.

The scrub list: `CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_CHILD_SESSION`, `CLAUDE_CODE_SESSION_ID`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`. Proxy/CA/XDG vars are deliberately NOT touched — container egress depends on them. A login child's entire purpose is minting fresh credentials; it has no legitimate use for inherited ones.

`SUBMIT_PATH` bumps to `bracketed-paste+lone-cr-150ms+term-forced+env-scrubbed/v4`, so attempt five's channel line names the full posture. Auth suite + clippy clean; live 92-char probe unaffected (~384 ms).