### PR TITLE
Attribute Drop-kills in logs, document exit-code forensics

### DIFF
--- a/claude-codes/src/auth.rs
+++ b/claude-codes/src/auth.rs
@@ -725,6 +725,15 @@ impl LoginFlow {
 impl Drop for LoginFlow {
     fn drop(&mut self) {
         if !self.finished {
+            // Make a self-inflicted kill visible: if a host application
+            // drops the flow mid-submission (moved-out state not put back,
+            // early return, TTL reaper), the child's death must be
+            // attributable to THIS line rather than presenting as a
+            // mysterious CLI crash. portable-pty's kill sends SIGTERM, so
+            // the child reports exit code 143 — same as an external
+            // SIGTERM; this log line is the disambiguator.
+            #[cfg(feature = "log")]
+            log::warn!("LoginFlow dropped while unfinished — killing login child (SIGTERM)");
             let _ = self.killer.kill();
         }
     }

--- a/claude-codes/src/error.rs
+++ b/claude-codes/src/error.rs
@@ -31,6 +31,17 @@ pub enum Error {
     )]
     LoginTimeout { transcript: String },
 
+    /// The login CLI process exited without producing a login outcome.
+    ///
+    /// Reading `code` (signal deaths surface as `128 + signo`):
+    /// - `0` / small integers — the CLI exited on its own (its error text,
+    ///   if any, is in `transcript`).
+    /// - `143` (SIGTERM) — terminated externally, OR the host application
+    ///   dropped the `LoginFlow` mid-flight (the crate's `Drop` kills with
+    ///   SIGTERM and, with the `log` feature, warns
+    ///   "LoginFlow dropped while unfinished" — check logs to attribute).
+    /// - `137` (SIGKILL) — killed externally (OOM killer, `kill -9`); the
+    ///   crate never sends SIGKILL.
     #[error("Login CLI exited (code {code:?}) without a login outcome; output:\n{transcript}")]
     LoginChildExited {
         code: Option<u32>,


### PR DESCRIPTION
Companion to #267 for infra's parent-kills-child hypothesis: a host application that drops the `LoginFlow` mid-submission (moved-out state not put back, early return, TTL reaper) kills the child via the crate's `Drop` — which was previously indistinguishable from a CLI crash or an external SIGTERM.

- `Drop` now logs `LoginFlow dropped while unfinished — killing login child (SIGTERM)` (behind the `log` feature), so a self-inflicted kill names itself in the host's own logs at the exact timestamp.
- `Error::LoginChildExited` rustdoc gains the forensics table: small codes = CLI self-exit; `143` = SIGTERM (external or crate Drop — the log line disambiguates); `137` = SIGKILL (external only; the crate never sends it).

With #267's `child=exited(code)` channel stamp, attempt five's failure mode — if any — is attributable from logs alone: exit code says who could have done it, the Drop warning says whether it was us.