### PR TITLE
Stamp bracketed-paste mode at submit into channel lines

### DIFF
--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Bracketed-paste-mode telemetry**: channel lines now stamp
+  `paste-mode@submit=on|off|never-advertised` — the TUI's advertised
+  `?2004h/l` state at the moment the code was written, from the raw
+  stream. Directly tests the late-write hypothesis (a TUI that drops paste
+  mode while the user is off authorizing would receive a late frame as raw
+  ESC keypresses) in production, where the 19–22 s human submit latency
+  cannot be replicated by harnesses that write in milliseconds.
+  `SUBMIT_PATH` → `…+paste-probe/v6`. (#269)
+
 ### Fixed
 
 - **Login flows were structurally blind to child death.** `LoginFlow` held

--- a/claude-codes/src/auth.rs
+++ b/claude-codes/src/auth.rs
@@ -481,6 +481,13 @@ impl LoginFlow {
                 ),
             });
         }
+        // Snapshot the TUI's advertised bracketed-paste state at the moment
+        // of submission — the discriminator for the late-write hypothesis.
+        let paste_mode = {
+            let (lock, _) = &*self.buf;
+            let g = lock.lock().unwrap();
+            paste_mode_at(&g.0, offset)
+        };
         self.submit_code(code)?;
 
         let deadline = Instant::now() + timeout;
@@ -622,7 +629,7 @@ impl LoginFlow {
                 return Err(Error::LoginChildExited {
                     code,
                     transcript: format!(
-                        "[channels: screen=no-token osc52={:?} credentials=unchanged copy-nudge={} submit-path={SUBMIT_PATH} child=exited({code:?})]\n{tail}",
+                        "[channels: screen=no-token osc52={:?} credentials=unchanged copy-nudge={} submit-path={SUBMIT_PATH} paste-mode@submit={paste_mode} child=exited({code:?})]\n{tail}",
                         Osc52Status::from(&osc52),
                         if nudged { "sent" } else { "not-sent" },
                     ),
@@ -642,7 +649,7 @@ impl LoginFlow {
                 }
                 return Err(Error::LoginTimeout {
                     transcript: format!(
-                        "[channels: screen=no-token osc52={:?} credentials={} copy-nudge={} submit-path={SUBMIT_PATH} child=alive]\n{}",
+                        "[channels: screen=no-token osc52={:?} credentials={} copy-nudge={} submit-path={SUBMIT_PATH} paste-mode@submit={paste_mode} child=alive]\n{}",
                         Osc52Status::from(&osc52),
                         if creds_updated {
                             "updated"
@@ -853,11 +860,26 @@ fn extract_osc52_token(raw: &[u8]) -> Osc52Scan {
 /// builds inline the frame bytes into immediates, so byte-grepping a binary
 /// for `ESC[200~` proves nothing in either direction.
 pub const SUBMIT_PATH: &str =
-    "bracketed-paste+lone-cr-150ms+term-forced+env-scrubbed+exit-aware/v5";
+    "bracketed-paste+lone-cr-150ms+term-forced+env-scrubbed+exit-aware+paste-probe/v6";
 
 /// Pause between the paste frame and the Enter keypress in
 /// [`LoginFlow::submit_code`].
 const SUBMIT_ENTER_DELAY: Duration = Duration::from_millis(150);
+
+/// Bracketed-paste mode advertised by the TUI at a given point in the raw
+/// stream: the last `ESC[?2004h` (enable) or `ESC[?2004l` (disable) before
+/// `upto` wins. Telemetry for the late-write hypothesis — if the TUI drops
+/// paste mode while a user is off authorizing in a browser, a frame written
+/// on return would arrive as raw ESC keypresses.
+fn paste_mode_at(raw: &[u8], upto: usize) -> &'static str {
+    let hay = String::from_utf8_lossy(&raw[..upto.min(raw.len())]);
+    match (hay.rfind("\x1b[?2004h"), hay.rfind("\x1b[?2004l")) {
+        (Some(h), Some(l)) if l > h => "off",
+        (Some(_), _) => "on",
+        (None, Some(_)) => "off",
+        (None, None) => "never-advertised",
+    }
+}
 
 /// Best-effort exit-code reap after EOF: the child's death is imminent or
 /// already happened, but `wait()` could block forever if a grandchild holds


### PR DESCRIPTION
Implements agentive-inversion's (3d7334b1) telemetry ask for the late-write hypothesis: every human attempt submitted 19–22 s after URL extraction while every harness success writes in milliseconds — if the TUI drops bracketed-paste mode (`?2004l`) during that window, a late frame arrives as raw ESC keypresses, and ESC plausibly quits Ink.

- `paste_mode_at()` reads the last `?2004h`/`?2004l` advertisement in the raw stream before the submission offset; channel lines (both `LoginTimeout` and `LoginChildExited`) now stamp `paste-mode@submit=on|off|never-advertised`. `SUBMIT_PATH` → `…+paste-probe/v6`.
- **Local test of the hypothesis itself came back negative**: URL → 22 s idle → framed 92-char write submits fine (CodeRejected in 350 ms), and `paste-mode@submit=on` locally. But local hasn't reproduced prod on any axis yet — the stamp makes attempt five test it where it matters.

Live-verified rendering:
`[channels: … submit-path=…+paste-probe/v6 paste-mode@submit=on child=alive]`