### PR TITLE
Follow the CLI's real retry state machine after code rejection

### DIFF
--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Rejected-code retry now follows the CLI's real state machine** —
+  recovered from the 2.1.220 binary: the error screen renders **no input
+  component**, and its only affordance (Enter) restarts the OAuth flow with
+  a **new PKCE challenge**. There is no same-challenge retry; a corrected
+  code pasted after a rejection lands nowhere, silently. Accordingly:
+  `submit_code` after a `CodeRejected` now returns `InvalidState` instead
+  of writing into the void, and the new
+  **`LoginFlow::retry_new_url(timeout)`** presses Enter, waits for
+  `waiting_for_login` to re-render, and returns the **new** authorize URL
+  to show the user (the old URL's code is dead). Live-verified end to end:
+  reject → refused re-paste → new URL with rotated challenge in ~1 s →
+  fresh input field accepts the next submission. (#270)
+
 ### Added
 
 - **Bracketed-paste-mode telemetry**: channel lines now stamp

--- a/claude-codes/src/auth.rs
+++ b/claude-codes/src/auth.rs
@@ -200,6 +200,12 @@ pub struct LoginFlow {
     buf: OutBuf,
     mode: LoginMode,
     finished: bool,
+    /// Set when a submission was rejected: the TUI's error screen has NO
+    /// input component, so further writes land nowhere until
+    /// [`retry_new_url`](Self::retry_new_url) walks the CLI's actual retry
+    /// state machine (error → Enter → about_to_retry → waiting_for_login
+    /// with a NEW PKCE challenge).
+    rejected: bool,
     /// Credentials store path + its state when the flow started, so
     /// create-or-update after submission is detectable as a success signal.
     creds: CredsWatch,
@@ -352,6 +358,7 @@ impl LoginFlow {
             buf,
             mode,
             finished: false,
+            rejected: false,
             creds,
         })
     }
@@ -363,11 +370,47 @@ impl LoginFlow {
     /// wraps it. Show it to your user; they sign in there and receive a code
     /// to bring back to [`submit_code`](Self::submit_code).
     pub fn auth_url(&mut self, timeout: Duration) -> Result<String> {
+        self.auth_url_after(0, timeout)
+    }
+
+    /// Restart the OAuth flow after a [`Error::CodeRejected`] and return the
+    /// NEW authorize URL.
+    ///
+    /// The CLI's retry state machine (recovered from the 2.1.220 binary) is
+    /// `error → (Enter) → about_to_retry → waiting_for_login`, and the
+    /// error screen renders **no input component** — a corrected code
+    /// written there lands nowhere, silently. Re-entering
+    /// `waiting_for_login` starts a fresh OAuth flow with a **new PKCE
+    /// challenge**, so the previous URL's code is dead: show the returned
+    /// URL to the user and have them authorize again. There is no
+    /// same-challenge retry; the CLI does not support one.
+    pub fn retry_new_url(&mut self, timeout: Duration) -> Result<String> {
+        use std::io::Write;
+        if !self.rejected {
+            return Err(Error::InvalidState(
+                "retry_new_url is only valid after a CodeRejected outcome".to_string(),
+            ));
+        }
+        let offset = {
+            let (lock, _) = &*self.buf;
+            lock.lock().unwrap().0.len()
+        };
+        // Enter on the error screen → about_to_retry → waiting_for_login.
+        self.writer.write_all(b"\r")?;
+        self.writer.flush()?;
+        let url = self.auth_url_after(offset, timeout)?;
+        self.rejected = false;
+        Ok(url)
+    }
+
+    /// [`auth_url`](Self::auth_url), scanning only output produced after
+    /// `offset` — so a retry finds the NEW URL, not the first one.
+    fn auth_url_after(&mut self, offset: usize, timeout: Duration) -> Result<String> {
         let deadline = Instant::now() + timeout;
         let (lock, cv) = &*self.buf;
         let mut guard = lock.lock().unwrap();
         loop {
-            if let Some(url) = extract_auth_url(&guard.0) {
+            if let Some(url) = extract_auth_url(&guard.0[offset.min(guard.0.len())..]) {
                 return Ok(url);
             }
             if guard.1 {
@@ -412,6 +455,16 @@ impl LoginFlow {
     /// on an empty field produces no detectable outcome, only a silent hang.
     pub fn submit_code(&mut self, code: &str) -> Result<()> {
         use std::io::Write;
+        if self.rejected {
+            // Binary-verified: the error screen renders no input component,
+            // so this write would land on a screen with nothing to type
+            // into — the silent-doom mode of production attempts.
+            return Err(Error::InvalidState(
+                "previous code was rejected; call retry_new_url() to restart the CLI's \
+                 OAuth flow (the old URL's PKCE challenge is dead), then submit the NEW code"
+                    .to_string(),
+            ));
+        }
         self.writer.write_all(&prepare_code_paste(code)?)?;
         self.writer.flush()?;
         // REDUNDANT ON PURPOSE — do not "optimise away". The framing alone
@@ -451,9 +504,11 @@ impl LoginFlow {
     ///   `token: None`, `credentials_updated: true`.
     /// - Rejection printed after this submission (`OAuth error`, or the
     ///   stable `Press Enter to retry` prompt under any wording) →
-    ///   [`Error::CodeRejected`]. The flow stays **alive** — the same session
-    ///   (and its PKCE verifier) accepts a corrected code via another
-    ///   `submit_code_and_wait` call.
+    ///   [`Error::CodeRejected`]. The flow stays **alive**, but the error
+    ///   screen has no input field and the old URL's PKCE challenge is dead:
+    ///   call [`retry_new_url`](Self::retry_new_url) to restart the OAuth
+    ///   flow and get the NEW URL for the user (binary-verified state
+    ///   machine — there is no same-challenge retry).
     /// - Child exit → outcome from the transcript, as [`finish`](Self::finish).
     /// - Timeout → [`Error::LoginTimeout`] carrying a per-channel status line
     ///   and the post-submission screen content, so a silent failure names
@@ -554,6 +609,7 @@ impl LoginFlow {
             // a previous attempt's error text must not fail a retry.
             let tail = strip_ansi(&guard.0[offset.min(guard.0.len())..]);
             if let Some(message) = detect_oauth_error(&tail) {
+                self.rejected = true;
                 return Err(Error::CodeRejected { message });
             }
 

--- a/claude-codes/tests/integration_tests.rs
+++ b/claude-codes/tests/integration_tests.rs
@@ -2524,3 +2524,39 @@ fn test_production_length_code_submission_is_acknowledged_live() {
         );
     }
 }
+
+/// The CLI's retry state machine (binary-verified): the error screen has NO
+/// input component and re-entering the flow rotates the PKCE challenge. A
+/// rejected flow must refuse further submissions until retry_new_url walks
+/// error -> Enter -> waiting_for_login and yields a DIFFERENT URL.
+#[cfg(feature = "auth")]
+#[test]
+fn test_rejected_flow_retries_with_new_url_live() {
+    use claude_codes::auth::{LoginFlow, LoginMode};
+    use claude_codes::Error;
+    use std::time::Duration;
+
+    let code: String = "aB3".repeat(40)[..86].to_string() + "#state";
+    let mut flow = LoginFlow::start(LoginMode::SetupToken).expect("flow starts");
+    let url1 = flow.auth_url(Duration::from_secs(30)).expect("first url");
+
+    match flow.submit_code_and_wait(&code, Duration::from_secs(20)) {
+        Err(Error::CodeRejected { .. }) => {}
+        other => panic!("expected CodeRejected, got {other:?}"),
+    }
+    assert!(
+        matches!(flow.submit_code(&code), Err(Error::InvalidState(_))),
+        "post-rejection paste must be refused, not silently dropped"
+    );
+
+    let url2 = flow
+        .retry_new_url(Duration::from_secs(20))
+        .expect("retry yields new url");
+    assert!(url2.contains("oauth/authorize"));
+    assert_ne!(url1, url2, "PKCE challenge must rotate on retry");
+
+    match flow.submit_code_and_wait(&code, Duration::from_secs(20)) {
+        Err(Error::CodeRejected { .. }) => {}
+        other => panic!("round 2 should reach a live input field, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Implements infra's (72f72c15) decisive binary-source finding: the CLI's oauth state machine is `idle → waiting_for_login → creating_api_key → success | error`, the **error screen renders no input component**, and its only affordance (Enter) walks `error → about_to_retry → waiting_for_login` — a fresh OAuth flow with a **new PKCE challenge**. The crate's documented "flow stays alive, resubmit against the same verifier" affordance does not exist in the CLI; Matt's second pastes were doomed by design, not by any write bug.

- `submit_code` after `CodeRejected` → `InvalidState` with instructions, instead of silently writing into a field-less screen.
- New `LoginFlow::retry_new_url(timeout)`: sends Enter, scans only post-Enter output, returns the NEW authorize URL (old code is dead).
- Docs corrected everywhere the same-PKCE claim appeared.

**Live-verified end to end** (and added as a live integration test): reject → re-paste refused at API → new URL in 1.02 s with rotated challenge/state → round-two submission reaches a live input field.

Also noted from the same source recovery, no code change needed: the minted token IS rendered in plain text on the setup-token success screen (only the input field is masked — the asterisks were the echoed paste), so the screen channel of the success ladder is first-class, with OSC 52 and the credentials watch as backup for the "shown once, never again" property.