### PR TITLE
claude-codes 2.1.222: model refusal-fallback scope, re-align version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.220"
+version = "2.1.222"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This workspace provides independent crates for interacting with [Claude Code](ht
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.220`, tested against Claude CLI `2.1.220`.
+- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.222`, tested against Claude CLI `2.1.222`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.2`, tested against Codex CLI `0.146.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.5`, tested against opencode `1.18.5`.
 - **`hermes-codes`** version tracks the hermes-agent release its schema snapshots were taken from. Currently `hermes-codes 0.20.0`, tested against hermes-agent `0.20.0` (ACP protocol version 1 via `agent-client-protocol==0.9.0` → zed schema `v0.11.2`).

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,7 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.1.222] - 2026-08-04
+
+Catches up to Claude CLI 2.1.222; snapshot baseline and `TESTED_VERSION`
+move to 2.1.222, and the full live suite passes against the installed
+binary. Also ships the complete login-tooling saga and session forking
+(below) that accumulated unreleased.
+
+### Added (2.1.222 drift)
+
+- **`ModelRefusalFallbackMessage.scope`** — new open enum
+  `RefusalFallbackScope` (`session` | `local` + `Unknown(String)`):
+  `session` means the main thread fell back and the session model is
+  swapped (also the meaning when the field is absent, i.e. every CLI
+  before 2.1.222); `local` means a subagent / side-question / background
+  fork fell back and only that response used the fallback model. (#272)
 
 ### Changed
 

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.220"
+version = "2.1.222"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -156,7 +156,7 @@ let serialized = Protocol::serialize(&output)?;
 
 ## Compatibility
 
-**Tested against:** Claude CLI 2.1.220
+**Tested against:** Claude CLI 2.1.222
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/io/message_types.rs
+++ b/claude-codes/src/io/message_types.rs
@@ -1209,6 +1209,13 @@ pub struct ControlRequestProgressMessage {
 pub struct ModelRefusalFallbackMessage {
     pub trigger: String,
     pub direction: String,
+    /// `"session"`: the main thread fell back and the session model is
+    /// swapped. `"local"`: a subagent / side-question (`/btw`) / background
+    /// fork fell back — only that response came from the fallback model and
+    /// the session model is unchanged. Absent from CLIs before 2.1.222
+    /// (treat as `"session"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<RefusalFallbackScope>,
     pub original_model: String,
     pub fallback_model: String,
     pub request_id: Option<String>,
@@ -1225,6 +1232,59 @@ pub struct ModelRefusalFallbackMessage {
     pub uuid: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
+}
+
+/// Scope of a refusal-fallback model swap, carried by
+/// [`ModelRefusalFallbackMessage::scope`]. Open — new scopes may ship on the
+/// wire ahead of schema updates.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum RefusalFallbackScope {
+    /// The main thread fell back; the session model is swapped.
+    Session,
+    /// A subagent / side-question / background fork fell back; only that
+    /// response used the fallback model, the session model is unchanged.
+    Local,
+    /// A scope not yet known to this version of the crate.
+    Unknown(String),
+}
+
+impl RefusalFallbackScope {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Session => "session",
+            Self::Local => "local",
+            Self::Unknown(s) => s.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for RefusalFallbackScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<&str> for RefusalFallbackScope {
+    fn from(s: &str) -> Self {
+        match s {
+            "session" => Self::Session,
+            "local" => Self::Local,
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+}
+
+impl Serialize for RefusalFallbackScope {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for RefusalFallbackScope {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self::from(s.as_str()))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -3156,5 +3216,41 @@ mod tests {
         let reserialized = serde_json::to_string(&output).unwrap();
         assert!(reserialized.contains("\"non_execution_kind\":\"user-rejected\""));
         assert!(!reserialized.contains("\"user_feedback\":null"));
+    }
+
+    /// CLI 2.1.222 added `scope` to `system/model_refusal_fallback`:
+    /// "session" (main-thread swap, also the meaning when absent on older
+    /// CLIs) vs "local" (subagent/side-question fallback only).
+    #[test]
+    fn model_refusal_fallback_scope_roundtrips_and_defaults() {
+        use super::{ModelRefusalFallbackMessage, RefusalFallbackScope};
+        let with_scope = serde_json::json!({
+            "trigger": "refusal",
+            "direction": "retry",
+            "scope": "local",
+            "original_model": "claude-fable-5",
+            "fallback_model": "claude-opus-5",
+            "request_id": null,
+            "content": "Refused; retried on fallback model.",
+            "uuid": "u1",
+            "session_id": "s1"
+        });
+        let msg: ModelRefusalFallbackMessage = serde_json::from_value(with_scope.clone()).unwrap();
+        assert_eq!(msg.scope, Some(RefusalFallbackScope::Local));
+        assert_eq!(serde_json::to_value(&msg).unwrap(), with_scope);
+
+        // Older CLIs omit scope — absent, not null, and treated as session
+        // by consumers per the wire docs.
+        let mut without = with_scope.clone();
+        without.as_object_mut().unwrap().remove("scope");
+        let msg: ModelRefusalFallbackMessage = serde_json::from_value(without.clone()).unwrap();
+        assert_eq!(msg.scope, None);
+        assert_eq!(serde_json::to_value(&msg).unwrap(), without);
+
+        // Open enum: unknown scopes pass through verbatim.
+        assert_eq!(
+            RefusalFallbackScope::from("workspace").as_str(),
+            "workspace"
+        );
     }
 }

--- a/claude-codes/src/lib.rs
+++ b/claude-codes/src/lib.rs
@@ -169,11 +169,11 @@ pub use io::{
     MemoryRecallItem, MemoryRecallMessage, MessageOrigin, MessageRole, MirrorErrorKey,
     MirrorErrorMessage, ModelRefusalFallbackMessage, ModelRefusalNoFallbackMessage,
     NotificationMessage, OutputStyle, PermissionDeniedMessage, PersistedFile, PluginDiagnostic,
-    PluginInfo, PluginInstallMessage, PreservedMessages, PreservedSegment, StatusMessage,
-    StatusMessageStatus, StopReason, SummarizeMetadata, SystemMessage, SystemSubtype,
-    TaskNotificationMessage, TaskPatch, TaskProgressMessage, TaskStartedMessage, TaskStatus,
-    TaskType, TaskUpdatedMessage, TaskUsage, ThinkingTokensMessage, ToolResultMeta, ToolUseMeta,
-    VcsMutationKind, VcsStateChangedMessage, WorkerShuttingDownMessage,
+    PluginInfo, PluginInstallMessage, PreservedMessages, PreservedSegment, RefusalFallbackScope,
+    StatusMessage, StatusMessageStatus, StopReason, SummarizeMetadata, SystemMessage,
+    SystemSubtype, TaskNotificationMessage, TaskPatch, TaskProgressMessage, TaskStartedMessage,
+    TaskStatus, TaskType, TaskUpdatedMessage, TaskUsage, ThinkingTokensMessage, ToolResultMeta,
+    ToolUseMeta, VcsMutationKind, VcsStateChangedMessage, WorkerShuttingDownMessage,
 };
 
 // Additional top-level output message wrappers

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.220";
+const TESTED_VERSION: &str = "2.1.222";
 
 /// Ensures version warning is only shown once per session
 static VERSION_CHECK: Once = Once::new();

--- a/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
+++ b/claude-codes/tests/schemas/claude_stream_json_snapshot.txt
@@ -30,7 +30,7 @@ system/init: agents, analytics_disabled, apiKeySource, betas, capabilities, clau
 system/local_command_output: content, session_id, subtype, type, uuid
 system/memory_recall: memories, mode, session_id, subtype, type, uuid
 system/mirror_error: error, key, session_id, subtype, type, uuid
-system/model_refusal_fallback: api_refusal_category, api_refusal_explanation, content, direction, fallback_model, original_model, refused_user_message_uuid, request_id, retracted_message_uuids, session_id, subtype, trigger, type, uuid
+system/model_refusal_fallback: api_refusal_category, api_refusal_explanation, content, direction, fallback_model, original_model, refused_user_message_uuid, request_id, retracted_message_uuids, scope, session_id, subtype, trigger, type, uuid
 system/model_refusal_no_fallback: api_refusal_category, api_refusal_explanation, content, original_model, refused_user_message_uuid, request_id, session_id, subtype, type, uuid
 system/notification: color, key, priority, session_id, subtype, text, timeout_ms, type, uuid
 system/permission_denied: agent_id, decision_reason, decision_reason_type, message, session_id, subtype, tool_name, tool_use_id, type, uuid


### PR DESCRIPTION
Fixes #272 (nightly drift check vs CLI 2.1.222, triggered after the local CLI update).

**The drift is one field**: `system/model_refusal_fallback` gains `scope`. Wire contract recovered from the 2.1.222 binary's Zod schema:
- `"session"` — the main thread fell back; the session model is swapped. Also the meaning when the field is **absent** (every CLI ≤ 2.1.220).
- `"local"` — a subagent / side-question (`/btw`) / background fork fell back; only that response used the fallback model, session model unchanged.

Modeled as the open enum `RefusalFallbackScope` (`Session` | `Local` | `Unknown(String)`) following the crate's open-enum convention, with absent-vs-null round-trip discipline unit-tested.

**Version re-alignment**: snapshot baseline + `TESTED_VERSION` + crate version all move to 2.1.222; the changelog cuts the 2.1.222 release, which also carries the accumulated `[Unreleased]` work (login support tooling #257–#270, session forking #253).

**Verification**: full live integration suite **30/30 in 90s** against the installed 2.1.222 binary — including the PTY login-flow tests, production-length code submission, retry protocol, and session forking. Unit suite + clippy clean; version-consistency strings updated in both READMEs.