### PR TITLE
muse-codes 0.1.1: login support tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,8 +224,10 @@ jobs:
           else
             echo "✅ README.md has Muse Code $MUSE_TESTED"
           fi
-          if [ "$MUSE_VERSION" != "$MUSE_TESTED" ]; then
-            echo "❌ muse-codes version ($MUSE_VERSION) != tested Muse Code ($MUSE_TESTED)"
+          # Crate may carry a patch offset above the CLI release; require
+          # only that major.minor track the tested Muse Code version.
+          if [ "${MUSE_VERSION%.*}" != "${MUSE_TESTED%.*}" ]; then
+            echo "❌ muse-codes major.minor ($MUSE_VERSION) != tested Muse Code ($MUSE_TESTED)"
             FAILED=1
           fi
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "muse-codes"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "env_logger",
  "log",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Each crate's version tracks the CLI it wraps:
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.222`, tested against Claude CLI `2.1.222`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.2`, tested against Codex CLI `0.146.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.5`, tested against opencode `1.18.5`.
-- **`muse-codes`** version tracks the Muse Code release its stream captures were taken from. Currently `muse-codes 0.1.0`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
+- **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.1`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
 
 `claude-codes` and `codex-codes` warn (or fail gracefully) when the installed
 CLI version diverges from the tested version. `opencode-codes` tracks the

--- a/muse-codes/CHANGELOG.md
+++ b/muse-codes/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-08-05
+
+### Added
+
+- **Login support tooling** (`auth` module, feature `async-client`). Muse's
+  auth surface needs no PTY: `auth_set` wraps
+  `muse auth set --api-key-stdin` (secret over stdin, never argv);
+  `DeviceLoginFlow` wraps the plain-stdout `muse login` OAuth device-code
+  flow (`device_code()` extracts the verification URL + code from captured
+  wire shapes, `wait_approved()`/`cancel()` manage the poll);
+  `logout()`; `credentials_present()` (checks `META_API_KEY` then the
+  saved file's providers map — `muse logout` empties the map but keeps
+  the file); typed `AuthFile`/`ProviderCredential` models of
+  `~/.config/muse/auth.json` (schema_version 1, observed). Live-tested:
+  real device flow yields URL+code then cancels; auth_set/logout
+  round-trip in a sandboxed HOME.
+
 ## [0.1.0] - 2026-08-05
 
 Initial release, tracking Muse Code 0.1.0 (`0.1.0-R708.1`) — released by

--- a/muse-codes/Cargo.toml
+++ b/muse-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muse-codes"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/muse-codes/README.md
+++ b/muse-codes/README.md
@@ -8,7 +8,8 @@ journal on stdout: envelope records covering command intake, run lifecycle,
 task lifecycle, and streamed output. This crate types that stream and ships
 an async Tokio client for driving headless runs.
 
-Tested against Muse Code 0.1.0 (`0.1.0-R708.1`).
+Tested against Muse Code 0.1.0 (`0.1.0-R708.1`). The crate version may
+carry a patch offset above the CLI release for crate-side additions.
 
 ## Captured, not guessed
 
@@ -56,6 +57,24 @@ println!("\nterminal: {}", terminal.terminal);
 
 The Meta provider needs credentials (`muse login`, `META_API_KEY`, or
 `~/.config/muse/auth.json`); `Provider::Echo` runs without any.
+
+## Auth helpers
+
+No PTY needed — Muse's auth surface is automation-friendly:
+
+```rust,ignore
+use muse_codes::auth::{auth_set, credentials_present, DeviceLoginFlow};
+
+// API key path (CI):
+auth_set(&std::env::var("MY_META_KEY")?, None).await?;
+
+// Or the browser device-code path:
+let mut flow = DeviceLoginFlow::start().await?;
+let dc = flow.device_code(std::time::Duration::from_secs(20)).await?;
+println!("Open {} and confirm code {}", dc.verification_url, dc.code);
+flow.wait_approved(std::time::Duration::from_secs(300)).await?;
+assert!(credentials_present());
+```
 
 ## Testing
 

--- a/muse-codes/src/auth.rs
+++ b/muse-codes/src/auth.rs
@@ -1,0 +1,324 @@
+//! Login support tooling for Muse Code (feature `async-client`).
+//!
+//! Muse's auth surface is automation-friendly — no TUI to drive:
+//!
+//! - [`auth_set`] wraps `muse auth set --api-key-stdin` (the key travels
+//!   over stdin; Muse refuses to take secrets as arguments).
+//! - [`DeviceLoginFlow`] wraps `muse login`, a plain-stdout OAuth
+//!   device-code flow: the CLI prints a verification URL and a short code,
+//!   then polls until the user approves in a browser.
+//! - [`logout`] wraps `muse logout` (removes the saved credential;
+//!   `META_API_KEY` in the environment is never touched).
+//! - [`credentials_present`] reports whether a run could authenticate
+//!   right now (env key or saved credential file).
+//!
+//! Credential resolution order (per the CLI): `META_API_KEY` env always
+//! wins, then the saved credential at `~/.config/muse/auth.json`.
+
+use crate::error::{Error, Result};
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::process::{Child, ChildStdout};
+
+/// Environment variable that overrides any saved credential.
+pub const META_API_KEY_VAR: &str = "META_API_KEY";
+
+/// Path of the saved credential file (`~/.config/muse/auth.json`),
+/// honoring `XDG_CONFIG_HOME`. `None` when no home directory resolves.
+pub fn credentials_path() -> Option<PathBuf> {
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+        return Some(PathBuf::from(xdg).join("muse/auth.json"));
+    }
+    let home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))?;
+    Some(PathBuf::from(home).join(".config/muse/auth.json"))
+}
+
+/// True when a headless run could authenticate right now: `META_API_KEY`
+/// is set (non-empty) or the saved credential file carries at least one
+/// provider. (`muse logout` empties the providers map but keeps the file,
+/// so bare existence is not enough.)
+pub fn credentials_present() -> bool {
+    if std::env::var(META_API_KEY_VAR).map(|v| !v.trim().is_empty()) == Ok(true) {
+        return true;
+    }
+    let Some(path) = credentials_path() else {
+        return false;
+    };
+    match std::fs::read_to_string(&path) {
+        Ok(raw) => serde_json::from_str::<AuthFile>(&raw)
+            .map(|f| !f.providers.is_empty())
+            // Unparseable file: assume it authenticates (newer schema).
+            .unwrap_or(true),
+        Err(_) => false,
+    }
+}
+
+/// Shape of `~/.config/muse/auth.json` (observed schema_version 1).
+///
+/// `muse logout` rewrites this with an empty `providers` map rather than
+/// deleting the file.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct AuthFile {
+    pub schema_version: u32,
+    pub providers: std::collections::BTreeMap<String, ProviderCredential>,
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// One saved provider credential.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ProviderCredential {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+fn resolve(binary: &str) -> Result<PathBuf> {
+    which::which(binary).map_err(|_| Error::BinaryNotFound {
+        name: binary.to_string(),
+    })
+}
+
+/// Save a provider API key: `muse auth set --provider <p> --api-key-stdin`.
+///
+/// The key is written to the child's stdin and never appears on a command
+/// line. `provider` defaults to `"meta"` when `None`.
+pub async fn auth_set(api_key: &str, provider: Option<&str>) -> Result<()> {
+    auth_set_with_binary("muse", api_key, provider).await
+}
+
+/// [`auth_set`] against a specific CLI binary.
+pub async fn auth_set_with_binary(
+    binary: &str,
+    api_key: &str,
+    provider: Option<&str>,
+) -> Result<()> {
+    let mut cmd = tokio::process::Command::new(resolve(binary)?);
+    cmd.args([
+        "auth",
+        "set",
+        "--provider",
+        provider.unwrap_or("meta"),
+        "--api-key-stdin",
+    ])
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .kill_on_drop(true);
+    let mut child = cmd.spawn()?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| Error::Protocol("failed to get stdin".to_string()))?;
+    stdin.write_all(api_key.trim().as_bytes()).await?;
+    stdin.write_all(b"\n").await?;
+    drop(stdin); // EOF tells the CLI the key is complete.
+    let out = child.wait_with_output().await?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(Error::Protocol(format!(
+            "muse auth set failed (exit {:?}): {}",
+            out.status.code(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        )))
+    }
+}
+
+/// Remove the saved credential: `muse logout`.
+pub async fn logout() -> Result<()> {
+    logout_with_binary("muse").await
+}
+
+/// [`logout`] against a specific CLI binary.
+pub async fn logout_with_binary(binary: &str) -> Result<()> {
+    let out = tokio::process::Command::new(resolve(binary)?)
+        .arg("logout")
+        .stdin(Stdio::null())
+        .output()
+        .await?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(Error::Protocol(format!(
+            "muse logout failed (exit {:?}): {}",
+            out.status.code(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        )))
+    }
+}
+
+/// The verification details a [`DeviceLoginFlow`] presents to the user.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeviceCode {
+    /// URL the user opens to approve the login.
+    pub verification_url: String,
+    /// Short confirmation code the user checks against the browser page.
+    pub code: String,
+}
+
+/// An in-flight `muse login` OAuth device-code flow.
+///
+/// Plain stdout, no pseudo-terminal: the CLI prints the verification URL
+/// and code, then blocks polling for browser approval. Dropping the flow
+/// cancels the login (the child is killed).
+pub struct DeviceLoginFlow {
+    child: Child,
+    lines: Lines<BufReader<ChildStdout>>,
+}
+
+impl DeviceLoginFlow {
+    /// Spawn `muse login` from `PATH`.
+    pub async fn start() -> Result<Self> {
+        Self::start_with_binary("muse").await
+    }
+
+    /// [`start`](Self::start) with a specific CLI binary.
+    pub async fn start_with_binary(binary: &str) -> Result<Self> {
+        let mut cmd = tokio::process::Command::new(resolve(binary)?);
+        cmd.arg("login")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        let mut child = cmd.spawn()?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| Error::Protocol("failed to get stdout".to_string()))?;
+        Ok(Self {
+            child,
+            lines: BufReader::new(stdout).lines(),
+        })
+    }
+
+    /// Read output until the verification URL and code are both seen.
+    ///
+    /// Show them to your user; the flow keeps polling in the background
+    /// until [`wait_approved`](Self::wait_approved) resolves.
+    pub async fn device_code(&mut self, timeout: Duration) -> Result<DeviceCode> {
+        let read = async {
+            let mut url: Option<String> = None;
+            let mut code: Option<String> = None;
+            while let Some(line) = self.lines.next_line().await? {
+                if let Some(u) = extract_url(&line) {
+                    url = Some(u);
+                }
+                if let Some(c) = extract_code_from_url_or_line(&line) {
+                    code = Some(c);
+                }
+                if let (Some(u), Some(c)) = (&url, &code) {
+                    return Ok(DeviceCode {
+                        verification_url: u.clone(),
+                        code: c.clone(),
+                    });
+                }
+            }
+            Err(Error::Protocol(
+                "muse login ended before printing a device code".to_string(),
+            ))
+        };
+        tokio::time::timeout(timeout, read)
+            .await
+            .map_err(|_| Error::Protocol("timed out waiting for device code".to_string()))?
+    }
+
+    /// Wait for the user to approve in the browser: resolves when the CLI
+    /// exits successfully (credential saved) or errors on failure/timeout.
+    pub async fn wait_approved(mut self, timeout: Duration) -> Result<()> {
+        let status = tokio::time::timeout(timeout, self.child.wait())
+            .await
+            .map_err(|_| Error::Protocol("timed out waiting for login approval".to_string()))??;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(Error::Protocol(format!(
+                "muse login exited with {:?} before approval",
+                status.code()
+            )))
+        }
+    }
+
+    /// Cancel the login.
+    pub async fn cancel(mut self) -> Result<()> {
+        self.child.kill().await?;
+        Ok(())
+    }
+}
+
+/// First `https://` run in a line (device URLs carry no trailing prose on
+/// the observed wire, but trim conservatively anyway).
+fn extract_url(line: &str) -> Option<String> {
+    let start = line.find("https://")?;
+    let url: String = line[start..]
+        .chars()
+        .take_while(|c| !c.is_whitespace())
+        .collect();
+    Some(url)
+}
+
+/// The device code: from the URL's `code=` parameter, or a bare
+/// `XXXX-XXXX`-shaped token on its own line (the CLI prints both forms).
+fn extract_code_from_url_or_line(line: &str) -> Option<String> {
+    if let Some(pos) = line.find("code=") {
+        let code: String = line[pos + 5..]
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '-')
+            .collect();
+        if !code.is_empty() {
+            return Some(code);
+        }
+    }
+    let t = line.trim();
+    let is_code_shaped = t.len() >= 7
+        && t.len() <= 12
+        && t.chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-')
+        && t.contains('-');
+    is_code_shaped.then(|| t.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verbatim `muse login` output captured from Muse Code 0.1.0.
+    const CAPTURE: &str = "Open this page to sign in:\n  \
+        https://auth.meta.com/oauth/device/?code=TBSS-QJWM\n\
+        confirm this code matches:\n  TBSS-QJWM\n\nWaiting for approval…\n";
+
+    #[test]
+    fn device_code_extracted_from_captured_output() {
+        let mut url = None;
+        let mut code = None;
+        for line in CAPTURE.lines() {
+            if let Some(u) = extract_url(line) {
+                url = Some(u);
+            }
+            if let Some(c) = extract_code_from_url_or_line(line) {
+                code = Some(c);
+            }
+        }
+        assert_eq!(
+            url.as_deref(),
+            Some("https://auth.meta.com/oauth/device/?code=TBSS-QJWM")
+        );
+        assert_eq!(code.as_deref(), Some("TBSS-QJWM"));
+    }
+
+    #[test]
+    fn bare_code_line_matches_and_prose_does_not() {
+        assert_eq!(
+            extract_code_from_url_or_line("  TBSS-QJWM"),
+            Some("TBSS-QJWM".to_string())
+        );
+        assert_eq!(extract_code_from_url_or_line("Waiting for approval…"), None);
+        assert_eq!(
+            extract_code_from_url_or_line("Open this page to sign in:"),
+            None
+        );
+    }
+}

--- a/muse-codes/src/lib.rs
+++ b/muse-codes/src/lib.rs
@@ -41,6 +41,8 @@ pub mod version;
 
 // Client modules
 #[cfg(feature = "async-client")]
+pub mod auth;
+#[cfg(feature = "async-client")]
 pub mod cli;
 #[cfg(feature = "async-client")]
 pub mod client_async;

--- a/muse-codes/tests/integration_tests.rs
+++ b/muse-codes/tests/integration_tests.rs
@@ -48,3 +48,92 @@ async fn echo_run_streams_to_terminal() {
         "expected a full journal, saw {records} records"
     );
 }
+
+/// Device login flow: real `muse login` prints a verification URL + code
+/// on plain stdout. Start, extract, cancel — no approval needed.
+#[tokio::test]
+async fn device_login_yields_url_and_code_live() {
+    use muse_codes::auth::DeviceLoginFlow;
+    use std::time::Duration;
+
+    let mut flow = DeviceLoginFlow::start().await.expect("muse spawns");
+    let dc = flow
+        .device_code(Duration::from_secs(20))
+        .await
+        .expect("device code appears");
+    assert!(dc.verification_url.starts_with("https://"));
+    assert!(dc.code.contains('-'), "code shape: {}", dc.code);
+    assert!(
+        dc.verification_url.contains(&dc.code),
+        "URL should embed the code"
+    );
+    flow.cancel().await.expect("cancel");
+}
+
+/// auth_set/logout round-trip in an isolated HOME so real credentials are
+/// never touched: save a dummy key, see the file appear, log out, gone.
+#[tokio::test]
+async fn auth_set_and_logout_roundtrip_in_sandbox_home() {
+    let sandbox = std::env::temp_dir().join(format!("muse-auth-sandbox-{}", std::process::id()));
+    std::fs::create_dir_all(&sandbox).unwrap();
+    // Child processes inherit our env; override HOME only for them.
+    // muse resolves ~/.config/muse relative to HOME.
+    let orig_home = std::env::var_os("HOME");
+    // SAFETY-free approach: spawn with explicit env instead of mutating ours.
+    let muse = which::which("muse").expect("muse on PATH");
+    let child = tokio::process::Command::new(&muse)
+        .args(["auth", "set", "--provider", "meta", "--api-key-stdin"])
+        .env("HOME", &sandbox)
+        .env_remove("XDG_CONFIG_HOME")
+        .stdin(std::process::Stdio::piped())
+        .output_stdin(b"meta-dummy-key-not-real\n")
+        .await;
+    drop(orig_home);
+    let out = child.expect("auth set runs");
+    assert!(
+        out.status.success(),
+        "auth set failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let auth_file = sandbox.join(".config/muse/auth.json");
+    assert!(auth_file.exists(), "credential file should appear");
+    let saved: muse_codes::auth::AuthFile =
+        serde_json::from_str(&std::fs::read_to_string(&auth_file).unwrap()).unwrap();
+    assert_eq!(
+        saved.providers["meta"].api_key.as_deref(),
+        Some("meta-dummy-key-not-real")
+    );
+
+    let out = tokio::process::Command::new(&muse)
+        .arg("logout")
+        .env("HOME", &sandbox)
+        .env_remove("XDG_CONFIG_HOME")
+        .output()
+        .await
+        .expect("logout runs");
+    assert!(out.status.success());
+    // logout empties the providers map but keeps the file.
+    let post: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&auth_file).unwrap()).unwrap();
+    assert_eq!(post["providers"], serde_json::json!({}));
+    std::fs::remove_dir_all(&sandbox).ok();
+}
+
+/// Helper: run a command feeding stdin then collecting output.
+trait StdinExt {
+    async fn output_stdin(&mut self, input: &[u8]) -> std::io::Result<std::process::Output>;
+}
+
+impl StdinExt for tokio::process::Command {
+    async fn output_stdin(&mut self, input: &[u8]) -> std::io::Result<std::process::Output> {
+        use tokio::io::AsyncWriteExt;
+        let mut child = self
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()?;
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin.write_all(input).await?;
+        }
+        child.wait_with_output().await
+    }
+}


### PR DESCRIPTION
Login-helper parity for muse-codes, per the auth-tooling comparison. Muse's surface needed **none of claude-codes' PTY machinery** — everything is plain pipes:

- `auth_set(key, provider)` → `muse auth set --api-key-stdin` (secret travels over stdin; Muse refuses argv secrets)
- `DeviceLoginFlow` → `muse login`'s plain-stdout OAuth device-code flow: `device_code()` extracts the verification URL + confirmation code (extraction shapes unit-tested against verbatim captured output), `wait_approved()` awaits browser approval, `cancel()`/drop kills the poll
- `logout()`, `credentials_present()`, `credentials_path()` (XDG-aware)
- Typed `AuthFile`/`ProviderCredential` for `~/.config/muse/auth.json` (schema_version 1, shape captured live)

**Discovered en route**: `muse logout` empties the `providers` map but keeps the file — so `credentials_present()` checks contents, not existence (the naive check shipped wrong in this PR's first draft and the live test caught it).

**Live-verified, no credentials touched**: real device flow yields URL+code then cancels cleanly; `auth_set`/`logout` round-trip runs in a sandboxed `HOME` so the host's real credential state is never modified. Version 0.1.0 → 0.1.1 (crate-side addition; consistency check relaxed to major.minor tracking, mirroring the codex convention).