### PR TITLE
codex-codes 0.146.3: account auth helpers, fix schema drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.146.2"
+version = "0.146.3"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This workspace provides independent crates for interacting with [Claude Code](ht
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.222`, tested against Claude CLI `2.1.222`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.2`, tested against Codex CLI `0.146.0`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.3`, tested against Codex CLI `0.146.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.5`, tested against opencode `1.18.5`.
 - **`muse-codes`** version tracks the Muse Code release its stream captures were taken from. Currently `muse-codes 0.1.0`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
 

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.146.3] - 2026-08-05
+
+Re-snapshots the app-server schema from `openai/codex@main` (fixes #275)
+and ships typed account/auth client helpers.
+
+### Added
+
+- **Account/auth client helpers** on `AsyncClient`: `account_read`,
+  `account_login_start` (api-key / browser `chatgpt` / `chatgptDeviceCode`
+  modes — browser and device flows complete via the
+  `account/login/completed` notification), `account_login_cancel`,
+  `account_logout`, `account_rate_limits_read`, `account_usage_read`.
+  The protocol layer (method constants, params/response types,
+  notification samples) already existed; these make it reachable without
+  hand-rolling `request()` calls. Live-tested: `account/read` returns the
+  active account; rate-limit/usage reads verified wire-correct (this
+  environment's token is rejected by the usage backend — the typed
+  JSON-RPC error path is exercised instead).
+
+### Changed
+
+- **`InitializeCapabilities`** gains `extensions` (v2) per the upstream
+  schema refresh; v1 snapshot picks up `modelSpecialty` on its
+  counterpart. (#275)
+
 ## [0.146.2] - 2026-08-03
 
 Re-snapshots the app-server schema from `openai/codex@main`, fixing the

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.146.2"
+version = "0.146.3"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/src/client_async.rs
+++ b/codex-codes/src/client_async.rs
@@ -54,6 +54,11 @@ use crate::protocol::{
     ThreadResumeParams, ThreadResumeResponse, ThreadStartParams, ThreadStartResponse,
     TurnInterruptParams, TurnInterruptResponse, TurnStartParams, TurnStartResponse,
 };
+use crate::protocol_generated::types::{
+    CancelLoginAccountParams, CancelLoginAccountResponse, GetAccountParams,
+    GetAccountRateLimitsResponse, GetAccountResponse, GetAccountTokenUsageResponse,
+    LoginAccountParams, LoginAccountResponse, LogoutAccountResponse,
+};
 use log::{debug, error, warn};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -426,6 +431,65 @@ impl AsyncClient {
     /// Get the process ID.
     pub fn pid(&self) -> Option<u32> {
         self.child.id()
+    }
+
+    // ── Account / auth methods ─────────────────────────────────────────
+
+    /// `account/read` — the active account (plan, email, auth mode), or
+    /// `account: null` when logged out.
+    pub async fn account_read(&mut self, params: &GetAccountParams) -> Result<GetAccountResponse> {
+        self.request(crate::protocol::methods::ACCOUNT_READ, params)
+            .await
+    }
+
+    /// `account/login/start` — begin a login. The params select the mode
+    /// (`apiKey` completes immediately; `chatgpt` returns an auth URL to
+    /// open; `chatgptDeviceCode` returns a user code + verification URL).
+    /// Browser/device modes complete asynchronously: watch for the
+    /// `account/login/completed` notification, or cancel with
+    /// [`account_login_cancel`](Self::account_login_cancel).
+    pub async fn account_login_start(
+        &mut self,
+        params: &LoginAccountParams,
+    ) -> Result<LoginAccountResponse> {
+        self.request(crate::protocol::methods::ACCOUNT_LOGIN_START, params)
+            .await
+    }
+
+    /// `account/login/cancel` — abort an in-flight browser/device login.
+    pub async fn account_login_cancel(
+        &mut self,
+        params: &CancelLoginAccountParams,
+    ) -> Result<CancelLoginAccountResponse> {
+        self.request(crate::protocol::methods::ACCOUNT_LOGIN_CANCEL, params)
+            .await
+    }
+
+    /// `account/logout` — remove the stored credential.
+    pub async fn account_logout(&mut self) -> Result<LogoutAccountResponse> {
+        self.request(
+            crate::protocol::methods::ACCOUNT_LOGOUT,
+            &serde_json::json!({}),
+        )
+        .await
+    }
+
+    /// `account/rateLimits/read` — current rate-limit windows.
+    pub async fn account_rate_limits_read(&mut self) -> Result<GetAccountRateLimitsResponse> {
+        self.request(
+            crate::protocol::methods::ACCOUNT_RATELIMITS_READ,
+            &serde_json::json!({}),
+        )
+        .await
+    }
+
+    /// `account/usage/read` — token-usage summary for the account.
+    pub async fn account_usage_read(&mut self) -> Result<GetAccountTokenUsageResponse> {
+        self.request(
+            crate::protocol::methods::ACCOUNT_USAGE_READ,
+            &serde_json::json!({}),
+        )
+        .await
     }
 
     /// Check if the child process is still running.

--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -2991,6 +2991,8 @@ pub struct InitializeCapabilities {
         skip_serializing_if = "Option::is_none"
     )]
     pub experimental_api: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<Value>,
     #[serde(
         rename = "mcpServerOpenaiFormElicitation",
         default,
@@ -4038,6 +4040,12 @@ pub struct Model {
     pub is_default: bool,
     #[serde(default)]
     pub model: String,
+    #[serde(
+        rename = "modelSpecialty",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub model_specialty: Option<String>,
     #[serde(
         rename = "serviceTiers",
         default,

--- a/codex-codes/tests/live_client_tests.rs
+++ b/codex-codes/tests/live_client_tests.rs
@@ -204,6 +204,7 @@ async fn test_async_client_custom_initialize() {
             },
             capabilities: Some(InitializeCapabilities {
                 experimental_api: Some(false),
+                extensions: None,
                 mcp_server_openai_form_elicitation: None,
                 opt_out_notification_methods: None,
                 request_attestation: None,
@@ -842,4 +843,45 @@ async fn test_async_client_writes_compilable_quicksort() {
     );
 
     let _ = std::fs::remove_dir_all(&scratch);
+}
+
+/// Account read-side helpers against the live app-server: `account/read`,
+/// `account/rateLimits/read`, `account/usage/read`. Read-only — never
+/// mutates the stored credential.
+#[tokio::test]
+async fn test_account_read_family() {
+    let mut client = AsyncClient::start()
+        .await
+        .expect("Failed to start app-server");
+
+    let account = client
+        .account_read(&codex_codes::protocol_generated::types::GetAccountParams::default())
+        .await
+        .expect("account/read");
+    // This environment is logged in via ChatGPT; a logged-out env would
+    // carry account: None and that's a legitimate wire answer too.
+    let _ = account;
+
+    // Rate-limit/usage reads proxy to the ChatGPT usage backend, which can
+    // reject a locally-valid session token (observed: 401 "Could not parse
+    // your authentication token" while model turns work fine). The wiring
+    // assertion is "typed request goes out, typed response OR a well-formed
+    // JSON-RPC error comes back" — not that this box's token can fetch
+    // usage.
+    match client.account_rate_limits_read().await {
+        Ok(_) => {}
+        Err(codex_codes::Error::JsonRpc { code, .. }) => {
+            assert_eq!(code, -32603, "unexpected rpc error class");
+        }
+        Err(other) => panic!("account/rateLimits/read transport failure: {other}"),
+    }
+    match client.account_usage_read().await {
+        Ok(_) => {}
+        Err(codex_codes::Error::JsonRpc { code, .. }) => {
+            assert_eq!(code, -32603, "unexpected rpc error class");
+        }
+        Err(other) => panic!("account/usage/read transport failure: {other}"),
+    }
+
+    client.shutdown().await.expect("shutdown");
 }

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -3115,8 +3115,16 @@
           "description": "Opt into receiving experimental API methods and fields.",
           "type": "boolean"
         },
+        "extensions": {
+          "additionalProperties": true,
+          "description": "MCP extension settings declared by the app-server client.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
         "mcpServerOpenaiFormElicitation": {
-          "description": "Allow downstream MCP servers to request OpenAI extended form elicitations.",
+          "description": "Legacy opt-in for the `openai/form` MCP extension.\n\nNew clients should declare `openai/form` in [`Self::extensions`].",
           "type": "boolean"
         },
         "optOutNotificationMethods": {
@@ -13531,6 +13539,13 @@
           },
           "model": {
             "type": "string"
+          },
+          "modelSpecialty": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "serviceTiers": {
             "default": [],

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -8326,8 +8326,16 @@
           "description": "Opt into receiving experimental API methods and fields.",
           "type": "boolean"
         },
+        "extensions": {
+          "additionalProperties": true,
+          "description": "MCP extension settings declared by the app-server client.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
         "mcpServerOpenaiFormElicitation": {
-          "description": "Allow downstream MCP servers to request OpenAI extended form elicitations.",
+          "description": "Legacy opt-in for the `openai/form` MCP extension.\n\nNew clients should declare `openai/form` in [`Self::extensions`].",
           "type": "boolean"
         },
         "optOutNotificationMethods": {
@@ -9868,6 +9876,13 @@
         },
         "model": {
           "type": "string"
+        },
+        "modelSpecialty": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "serviceTiers": {
           "default": [],


### PR DESCRIPTION
Second leg of the login-helper parity pass, plus the outstanding drift issue.

**Account/auth helpers** (closing the gap found during the original login survey): typed `AsyncClient` methods over the already-modeled `account/*` protocol family — `account_read`, `account_login_start` (three modes: `apiKey` completes inline; `chatgpt` returns a browser auth URL; `chatgptDeviceCode` returns user code + verification URL — async completion via the `account/login/completed` notification), `account_login_cancel`, `account_logout`, `account_rate_limits_read`, `account_usage_read`. Unlike claude's PTY scraping, codex login is drivable **through the protocol itself**.

**Drift (fixes #275)**: re-snapshots both schema files from `openai/codex@main` — `InitializeCapabilities.extensions` (v2) and `modelSpecialty` (v1). One live-test struct literal updated for the new field.

**Live verification**: `account/read` returns the active account under this environment's ChatGPT login. The rate-limit/usage reads surfaced a genuine finding: the upstream usage backend rejects this box's session token (401) even though model turns work — so those two legs assert the typed JSON-RPC error path instead, with the rationale documented in the test. Workspace tests + clippy clean; coverage stays 175/175.