### PR TITLE
Serde on login presentables for relay surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "claude-codes"
-version = "2.1.222"
+version = "2.1.223"
 dependencies = [
  "anyhow",
  "base64",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "muse-codes"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "env_logger",
  "log",

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ This workspace provides independent crates for interacting with [Claude Code](ht
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.222`, tested against Claude CLI `2.1.222`.
+- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.223`, tested against Claude CLI `2.1.222`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.3`, tested against Codex CLI `0.146.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.5`, tested against opencode `1.18.5`.
-- **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.2`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
+- **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.3`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
 
 `claude-codes` and `codex-codes` warn (or fail gracefully) when the installed
 CLI version diverges from the tested version. `opencode-codes` tracks the

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.223] - 2026-08-05
+
+### Changed
+
+- **`LoginOutcome`, `TokenSource`, and `Osc52Status` now derive
+  Serialize/Deserialize** — login outcomes are relay-shaped for web/launcher
+  surfaces that ship them over the wire (requested by agent-portal's
+  login-automation assessment). No wire or behavior change.
+
 ## [2.1.222] - 2026-08-04
 
 Catches up to Claude CLI 2.1.222; snapshot baseline and `TESTED_VERSION`

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.222"
+version = "2.1.223"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/src/auth.rs
+++ b/claude-codes/src/auth.rs
@@ -116,7 +116,7 @@ impl LoginMode {
 }
 
 /// Which PTY channel a minted token was recovered from.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TokenSource {
     /// Rendered in the terminal's visible text.
     Screen,
@@ -129,7 +129,7 @@ pub enum TokenSource {
 /// success-path telemetry so a `token: None` outcome names the reason
 /// instead of leaving "no affordance" and "affordance fired with a non-token
 /// payload" indistinguishable.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Osc52Status {
     /// No OSC 52 sequence ever appeared (the screen may offer no copy
     /// affordance, or the nudge didn't trigger it).
@@ -146,7 +146,10 @@ pub enum Osc52Status {
 }
 
 /// Result of a completed [`LoginFlow`].
-#[derive(Debug, Clone)]
+///
+/// Serde-serializable so relay surfaces (web UIs, launchers) can ship the
+/// outcome over the wire as-is.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoginOutcome {
     /// The minted long-lived token (`SetupToken` mode only). Sourced from the
     /// CLI's screen output or its OSC 52 clipboard copy; `None` when the CLI

--- a/muse-codes/CHANGELOG.md
+++ b/muse-codes/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2026-08-05
+
+### Changed
+
+- **`DeviceCode` now derives Serialize/Deserialize** — the verification
+  URL + code presentable is relay-shaped for remote UIs. No behavior
+  change.
+
 ## [0.1.2] - 2026-08-05
 
 Extends the corpus and models with the **live-provider vocabulary**,

--- a/muse-codes/Cargo.toml
+++ b/muse-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muse-codes"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/muse-codes/src/auth.rs
+++ b/muse-codes/src/auth.rs
@@ -152,7 +152,8 @@ pub async fn logout_with_binary(binary: &str) -> Result<()> {
 }
 
 /// The verification details a [`DeviceLoginFlow`] presents to the user.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Serde-serializable for relay to remote UIs.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct DeviceCode {
     /// URL the user opens to approve the login.
     pub verification_url: String,


### PR DESCRIPTION
agent-portal's login-automation assessment identified that a relay architecture (browser ⇄ WS ⇄ launcher host) needs every presentable and outcome on the auth path to be a plain serializable struct — most already were; this closes the stragglers:

- claude-codes **2.1.223**: `LoginOutcome`, `TokenSource`, `Osc52Status` gain Serialize/Deserialize (`AuthStatus` already had them)
- muse-codes **0.1.3**: `DeviceCode` gains Serialize/Deserialize (`AuthFile`/`ProviderCredential` already had them; codex types are all generated-serde already)

No wire or behavior changes. Workspace tests + clippy clean.