### PR TITLE
codex-codes 0.146.4: best-effort local auth snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "codex-codes"
-version = "0.146.3"
+version = "0.146.4"
 dependencies = [
  "env_logger",
  "jsonschema",

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This workspace provides independent crates for interacting with [Claude Code](ht
 Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.223`, tested against Claude CLI `2.1.222`.
-- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.3`, tested against Codex CLI `0.146.0`.
+- **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.4`, tested against Codex CLI `0.146.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.5`, tested against opencode `1.18.5`.
 - **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.3`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
 

--- a/codex-codes/CHANGELOG.md
+++ b/codex-codes/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.146.4] - 2026-08-05
+
+### Added
+
+- **`auth_local::auth_status_local()`** — best-effort, serde-shaped local
+  auth snapshot from `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`):
+  `logged_in`, `auth_mode`, display-only `email` and `plan_type` decoded
+  (unverified, by design) from the stored id_token's claims, `account_id`,
+  `last_refresh`. Exists so status dashboards don't need an app-server
+  connection just to render a label — and so the **private-contract risk
+  lives in this crate**: the file layout is codex-internal, documented
+  loudly as such, unit-tested against a captured fixture, and watched by a
+  live integration test that parses the real file (a codex layout change
+  becomes a crate patch, not a silent consumer break). Requested by
+  agent-portal's login-matrix build; missing file = `Ok(logged_in: false)`;
+  garbage JWT degrades to no-label, never an error.
+
 ## [0.146.3] - 2026-08-05
 
 Re-snapshots the app-server schema from `openai/codex@main` (fixes #275)

--- a/codex-codes/Cargo.toml
+++ b/codex-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-codes"
-version = "0.146.3"
+version = "0.146.4"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/codex-codes/src/auth_local.rs
+++ b/codex-codes/src/auth_local.rs
@@ -1,0 +1,269 @@
+//! Best-effort local auth status read — **private-contract territory**.
+//!
+//! The sanctioned way to read account state is protocol-native
+//! ([`AsyncClient::account_read`](crate::client_async::AsyncClient::account_read)),
+//! which requires standing up an app-server connection. For cheap status
+//! probes (dashboards, launcher matrices) this module reads what the codex
+//! CLI itself persists at `$CODEX_HOME/auth.json` (default
+//! `~/.codex/auth.json`) and decodes the display-only identity claims from
+//! the stored `id_token`.
+//!
+//! **Caveats, deliberately loud:**
+//!
+//! - `auth.json` is codex's internal storage, not a published interface.
+//!   Its layout can change in any CLI release. This crate owns that risk so
+//!   consumers don't have to: the shape is unit-tested against a captured
+//!   fixture and exercised against the real file by the live integration
+//!   suite, so a layout change becomes a crate patch, not a silent
+//!   downstream break.
+//! - The JWT payload is base64-decoded **without signature verification** —
+//!   the values come from a file the user's own CLI wrote, and they are fit
+//!   for display labels only. Never use them for authorization decisions.
+//! - A `logged_in: true` here means "credentials are stored", not "they
+//!   still work" — tokens expire and get refreshed by the CLI. For a
+//!   liveness answer use `account_read` or `codex login status`.
+
+use crate::error::{Error, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::PathBuf;
+
+/// Serde-shaped local auth snapshot, fit for relaying to UIs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalAuthStatus {
+    /// Credentials are present on disk (see module docs: stored ≠ live).
+    pub logged_in: bool,
+    /// `auth_mode` as stored, e.g. `"chatgpt"` or `"apikey"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_mode: Option<String>,
+    /// `email` claim from the stored id_token (display only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    /// `chatgpt_plan_type` from the id_token's OpenAI auth claim
+    /// (display only), e.g. `"plus"`, `"pro"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan_type: Option<String>,
+    /// `tokens.account_id` as stored.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
+    /// `last_refresh` timestamp string as stored.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_refresh: Option<String>,
+}
+
+/// `$CODEX_HOME/auth.json`, defaulting to `~/.codex/auth.json`.
+pub fn auth_json_path() -> Option<PathBuf> {
+    if let Some(home) = std::env::var_os("CODEX_HOME") {
+        return Some(PathBuf::from(home).join("auth.json"));
+    }
+    let home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))?;
+    Some(PathBuf::from(home).join(".codex/auth.json"))
+}
+
+/// Read the local auth snapshot from the default location.
+///
+/// A missing file is `Ok` with `logged_in: false` (that's what logged-out
+/// looks like); an unreadable or unparseable file is an error.
+pub fn auth_status_local() -> Result<LocalAuthStatus> {
+    let Some(path) = auth_json_path() else {
+        return Err(Error::Protocol(
+            "no home directory to resolve auth.json against".to_string(),
+        ));
+    };
+    if !path.exists() {
+        return Ok(LocalAuthStatus {
+            logged_in: false,
+            auth_mode: None,
+            email: None,
+            plan_type: None,
+            account_id: None,
+            last_refresh: None,
+        });
+    }
+    auth_status_from_json(&std::fs::read_to_string(&path)?)
+}
+
+/// Parse a snapshot out of `auth.json` contents.
+pub fn auth_status_from_json(raw: &str) -> Result<LocalAuthStatus> {
+    let v: Value = serde_json::from_str(raw)?;
+    let auth_mode = v
+        .get("auth_mode")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let api_key_present = v
+        .get("OPENAI_API_KEY")
+        .and_then(Value::as_str)
+        .is_some_and(|k| !k.trim().is_empty());
+    let tokens = v.get("tokens").filter(|t| t.is_object());
+    let account_id = tokens
+        .and_then(|t| t.get("account_id"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let last_refresh = v
+        .get("last_refresh")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+
+    let mut email = None;
+    let mut plan_type = None;
+    if let Some(id_token) = tokens
+        .and_then(|t| t.get("id_token"))
+        .and_then(Value::as_str)
+    {
+        if let Some(claims) = decode_jwt_claims(id_token) {
+            email = claims
+                .get("email")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            plan_type = claims
+                .get("https://api.openai.com/auth")
+                .and_then(|a| a.get("chatgpt_plan_type"))
+                .and_then(Value::as_str)
+                .map(str::to_string);
+        }
+    }
+
+    Ok(LocalAuthStatus {
+        logged_in: tokens.is_some() || api_key_present,
+        auth_mode,
+        email,
+        plan_type,
+        account_id,
+        last_refresh,
+    })
+}
+
+/// Decode a JWT's payload segment (base64url, unverified) into JSON.
+fn decode_jwt_claims(jwt: &str) -> Option<Value> {
+    let payload = jwt.split('.').nth(1)?;
+    let bytes = base64url_decode(payload)?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Minimal base64url (no padding) decoder — display-only path, so a tiny
+/// hand-rolled table beats a dependency.
+fn base64url_decode(s: &str) -> Option<Vec<u8>> {
+    fn val(c: u8) -> Option<u32> {
+        match c {
+            b'A'..=b'Z' => Some((c - b'A') as u32),
+            b'a'..=b'z' => Some((c - b'a' + 26) as u32),
+            b'0'..=b'9' => Some((c - b'0' + 52) as u32),
+            b'-' => Some(62),
+            b'_' => Some(63),
+            _ => None,
+        }
+    }
+    let s = s.trim_end_matches('=');
+    let mut out = Vec::with_capacity(s.len() * 3 / 4);
+    let mut buf: u32 = 0;
+    let mut bits = 0;
+    for &c in s.as_bytes() {
+        buf = (buf << 6) | val(c)?;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((buf >> bits) as u8);
+        }
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn fake_jwt(claims: Value) -> String {
+        fn enc(v: &Value) -> String {
+            // Std base64url without padding via the reverse of our decoder.
+            const TBL: &[u8; 64] =
+                b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+            let bytes = serde_json::to_vec(v).unwrap();
+            let mut out = String::new();
+            for chunk in bytes.chunks(3) {
+                let b = [
+                    chunk[0],
+                    *chunk.get(1).unwrap_or(&0),
+                    *chunk.get(2).unwrap_or(&0),
+                ];
+                let n = ((b[0] as u32) << 16) | ((b[1] as u32) << 8) | b[2] as u32;
+                out.push(TBL[(n >> 18) as usize & 63] as char);
+                out.push(TBL[(n >> 12) as usize & 63] as char);
+                if chunk.len() > 1 {
+                    out.push(TBL[(n >> 6) as usize & 63] as char);
+                }
+                if chunk.len() > 2 {
+                    out.push(TBL[n as usize & 63] as char);
+                }
+            }
+            out
+        }
+        format!("{}.{}.sig", enc(&json!({"alg": "RS256"})), enc(&claims))
+    }
+
+    /// Fixture mirrors the real ~/.codex/auth.json layout (captured shape:
+    /// auth_mode / OPENAI_API_KEY / tokens{id_token,access_token,
+    /// refresh_token,account_id} / last_refresh).
+    #[test]
+    fn chatgpt_mode_snapshot_carries_email_and_plan() {
+        let jwt = fake_jwt(json!({
+            "email": "matt@example.com",
+            "email_verified": true,
+            "https://api.openai.com/auth": {
+                "chatgpt_plan_type": "pro",
+                "chatgpt_account_id": "acct_1"
+            }
+        }));
+        let raw = json!({
+            "auth_mode": "chatgpt",
+            "OPENAI_API_KEY": null,
+            "tokens": {
+                "id_token": jwt,
+                "access_token": "at",
+                "refresh_token": "rt",
+                "account_id": "acct_1"
+            },
+            "last_refresh": "2026-08-05T12:00:00Z"
+        });
+        let s = auth_status_from_json(&raw.to_string()).unwrap();
+        assert!(s.logged_in);
+        assert_eq!(s.auth_mode.as_deref(), Some("chatgpt"));
+        assert_eq!(s.email.as_deref(), Some("matt@example.com"));
+        assert_eq!(s.plan_type.as_deref(), Some("pro"));
+        assert_eq!(s.account_id.as_deref(), Some("acct_1"));
+    }
+
+    #[test]
+    fn api_key_mode_has_no_identity() {
+        let raw = json!({
+            "auth_mode": "apikey",
+            "OPENAI_API_KEY": "sk-test",
+            "tokens": null,
+            "last_refresh": null
+        });
+        let s = auth_status_from_json(&raw.to_string()).unwrap();
+        assert!(s.logged_in);
+        assert_eq!(s.auth_mode.as_deref(), Some("apikey"));
+        assert_eq!(s.email, None);
+        assert_eq!(s.plan_type, None);
+    }
+
+    #[test]
+    fn garbage_jwt_degrades_to_no_label_not_error() {
+        let raw = json!({
+            "auth_mode": "chatgpt",
+            "tokens": {"id_token": "not-a-jwt", "account_id": "a"},
+        });
+        let s = auth_status_from_json(&raw.to_string()).unwrap();
+        assert!(s.logged_in);
+        assert_eq!(s.email, None);
+        assert_eq!(s.account_id.as_deref(), Some("a"));
+    }
+
+    #[test]
+    fn base64url_roundtrips_jwt_segments() {
+        assert_eq!(base64url_decode("aGVsbG8").unwrap(), b"hello");
+        assert_eq!(base64url_decode("aGVsbG8=").unwrap(), b"hello");
+        assert!(base64url_decode("!!bad!!").is_none());
+    }
+}

--- a/codex-codes/src/lib.rs
+++ b/codex-codes/src/lib.rs
@@ -114,6 +114,8 @@ pub mod protocol;
 pub mod protocol_generated;
 
 #[cfg(any(feature = "sync-client", feature = "async-client"))]
+pub mod auth_local;
+#[cfg(any(feature = "sync-client", feature = "async-client"))]
 pub mod cli;
 
 #[cfg(any(feature = "sync-client", feature = "async-client"))]

--- a/codex-codes/tests/live_client_tests.rs
+++ b/codex-codes/tests/live_client_tests.rs
@@ -885,3 +885,26 @@ async fn test_account_read_family() {
 
     client.shutdown().await.expect("shutdown");
 }
+
+/// Local auth snapshot parses the REAL ~/.codex/auth.json on this box —
+/// the private-contract shape watchdog. If codex changes the file layout,
+/// this fails here (a crate patch) instead of silently downstream.
+#[test]
+fn test_auth_status_local_parses_real_file() {
+    let path = codex_codes::auth_local::auth_json_path().expect("home resolves");
+    if !path.exists() {
+        eprintln!("skipping: no auth.json on this host");
+        return;
+    }
+    let s = codex_codes::auth_local::auth_status_local().expect("real auth.json parses");
+    assert!(s.logged_in, "file exists but parsed as logged out");
+    // This box is chatgpt-mode; a fresh api-key box would legitimately
+    // carry no identity claims.
+    if s.auth_mode.as_deref() == Some("chatgpt") {
+        assert!(
+            s.email.is_some(),
+            "chatgpt mode should yield an email label"
+        );
+        assert!(s.account_id.is_some());
+    }
+}


### PR DESCRIPTION
agent-portal's login-matrix build wants a codex status label without standing up an app-server connection per probe. Their CLAUDE.md principle (and ours): don't decode private file formats downstream — push it into the typed layer that's watched. So:

`auth_local::auth_status_local()` → serde `LocalAuthStatus { logged_in, auth_mode, email, plan_type, account_id, last_refresh }`, reading `$CODEX_HOME/auth.json` and base64url-decoding the stored id_token's claims (**unverified, display-only** — documented loudly; hand-rolled decoder, zero new deps; the `chatgpt_plan_type` claim means the label matches `account_read`'s email+plan cell shape exactly).

**Risk ownership is the point**: the file layout is codex-internal and unpublished. It's unit-tested against a captured fixture, and a live integration test parses the REAL file on a logged-in box — a codex layout change fails here as a crate patch instead of breaking consumers silently. Missing file = `Ok(logged_in: false)`; garbage JWT degrades to no-label.

Sanctioned path (`account_read`) remains the liveness answer; the module docs draw that line explicitly (stored ≠ live). Workspace tests + clippy clean; live test green against this box's real file.