### PR TITLE
Document auth tooling across READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ opencode release train by version but ships no runtime version-divergence check.
 | `types` | Core message types and protocol structs only | Yes |
 | `sync-client` | Synchronous client with blocking I/O | No |
 | `async-client` | Asynchronous client using tokio | No |
+| `auth` | PTY-driven login tooling (`LoginFlow`, `auth_status`) | No |
 
-All features are enabled by default. For WASM or type-sharing use cases:
+`types`, `sync-client`, and `async-client` are enabled by default (`auth` is
+opt-in). For WASM or type-sharing use cases:
 
 ```toml
 [dependencies]
@@ -94,6 +96,22 @@ opencode-codes = { version = "1.18", default-features = false, features = ["type
 [dependencies]
 muse-codes = { version = "0.1", default-features = false, features = ["types"] }
 ```
+
+## Login & Auth Tooling
+
+Each crate ships helpers for authenticating its CLI programmatically — the
+mechanisms differ with each vendor's surface:
+
+| | claude-codes (`auth` feature) | codex-codes | muse-codes |
+|---|---|---|---|
+| Status read | `auth_status()` (typed `claude auth status --json`: email, org, plan) | `account_read` (protocol) or `auth_local::auth_status_local()` (cheap file read: email + plan, best-effort) | `auth::credentials_present()` + typed `AuthFile` (presence + provider only) |
+| Login flow | `LoginFlow` drives the Ink TUI under a PTY: `auth_url()` → user pastes code → `submit_code_and_wait()`; rejected codes retry via `retry_new_url()` (new PKCE) | Protocol-native: `account_login_start` (api-key / browser URL / device code), completion via the `account/login/completed` notification | `DeviceLoginFlow` wraps the plain-stdout device-code flow; `auth_set()` saves an API key over stdin |
+| Cancellation | Drop kills the PTY child | `account_login_cancel` | `cancel()` / drop |
+
+All presentables and outcomes are serde-shaped for relay surfaces, flows are
+parkable handles across round-trips, and waits take caller-supplied
+timeouts. opencode needs no CLI auth for the server endpoints this workspace
+wraps.
 
 ## Session Forking
 

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -156,6 +156,29 @@ let serialized = Protocol::serialize(&output)?;
 
 ## Compatibility
 
+## Login tooling (`auth` feature)
+
+The CLI's login flows are interactive Ink TUIs (they hang on a pipe), so the
+`auth` module drives them under a pseudo-terminal:
+
+```rust,ignore
+use claude_codes::auth::{auth_status, LoginFlow, LoginMode};
+
+let mut flow = LoginFlow::start(LoginMode::SetupToken)?;
+let url = flow.auth_url(Duration::from_secs(30))?;   // show to the user
+// … user authorizes in a browser, brings back a code …
+let outcome = flow.submit_code_and_wait(&code, Duration::from_secs(90))?;
+// outcome.token = Some("sk-ant-oat01-…") — recovered via screen text,
+// OSC 52 clipboard escapes, or the credentials-file watch.
+```
+
+Rejected codes keep the flow alive: call `retry_new_url()` for a fresh
+authorize URL (the CLI rotates the PKCE challenge; the old code is dead).
+Every failure self-describes — timeouts and child exits carry a channel
+line naming what each detection source saw. `auth_status()` types
+`claude auth status --json` (email, org, plan). Enable with
+`features = ["auth"]`.
+
 **Tested against:** Claude CLI 2.1.222
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:

--- a/codex-codes/README.md
+++ b/codex-codes/README.md
@@ -242,3 +242,23 @@ Override the schema with `CODEX_SCHEMA_PATH=/path/to/fresh/schemas.json` to vali
 ## License
 
 Apache-2.0. See [LICENSE](../LICENSE).
+
+## Account & auth helpers
+
+Codex login is drivable through the app-server protocol itself — no process
+scraping:
+
+- `account_read` — current account (plan, email, auth mode)
+- `account_login_start` — three modes: `apiKey` (completes inline),
+  `chatgpt` (returns a browser auth URL), `chatgptDeviceCode` (returns a
+  user code + verification URL); browser/device completion arrives as the
+  `account/login/completed` notification on the same connection
+- `account_login_cancel`, `account_logout`, `account_rate_limits_read`,
+  `account_usage_read`
+
+For cheap status probes without an app-server connection,
+`auth_local::auth_status_local()` reads `$CODEX_HOME/auth.json` and decodes
+display-only email/plan labels from the stored id_token — best-effort by
+design (the file is codex-internal; the crate owns that risk with fixture
+and live tests). `logged_in` there means *stored*, not *live* — use
+`account_read` or `codex login status` for liveness.


### PR DESCRIPTION
Doc-only. The auth capability that shipped across claude-codes (`auth` feature), codex-codes (`account_*` + `auth_local`), and muse-codes (`auth` module) was nearly invisible in the READMEs — the root feature table for claude-codes still listed three features, and neither the claude nor codex crate README mentioned their login tooling at all (muse's already did).

- Root README: `auth` row in the claude feature table + a cross-crate **Login & Auth Tooling** section (status read / login flow / cancellation per crate — same shape as the Session Forking section), with the relay-contract properties (serde presentables, parkable handles, caller timeouts) stated once.
- claude-codes README: `auth`-feature walkthrough, including the load-bearing rule that rejected codes must go through `retry_new_url()` (PKCE rotates; the old URL's code is dead).
- codex-codes README: account/* helper list + `auth_status_local()` with the stored-vs-live distinction spelled out.

Versions were already current everywhere (verified before writing).