### PR TITLE
muse-codes 0.1.4: session_id, pid, and identity-trap tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "muse-codes"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "env_logger",
  "log",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Each crate's version tracks the CLI it wraps:
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.223`, tested against Claude CLI `2.1.222`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.4`, tested against Codex CLI `0.146.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.5`, tested against opencode `1.18.5`.
-- **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.3`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
+- **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.4`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
 
 `claude-codes` and `codex-codes` warn (or fail gracefully) when the installed
 CLI version diverges from the tested version. `opencode-codes` tracks the

--- a/muse-codes/CHANGELOG.md
+++ b/muse-codes/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-08-06
+
+### Added
+
+- **`MuseExecBuilder::session_id`** — run under a caller-supplied
+  `--session-id`, the basis of multi-turn continuity: each turn is its own
+  process, and reusing the id continues the session. The id is adopted
+  verbatim as `stream.id` on every record, which is also what makes the
+  `(stream.id, id)` identity composite trustworthy.
+- **`ExecRun::pid`** — the child's OS process id, for supervisors that
+  signal the process group directly.
+- **Live tests pinning two measured behaviors** that consumers must not get
+  wrong: `sequence` restarts per turn (never key across turns on it), record
+  ids do **not** repeat within a session but **do** repeat across sessions
+  (UUID-shaped counters — only `(stream.id, id)` is unique), and a run
+  SIGKILLed mid-flight leaves the session store usable for the next turn.
+
 ## [0.1.3] - 2026-08-05
 
 ### Changed

--- a/muse-codes/Cargo.toml
+++ b/muse-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muse-codes"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/muse-codes/README.md
+++ b/muse-codes/README.md
@@ -77,6 +77,23 @@ flow.wait_approved(std::time::Duration::from_secs(300)).await?;
 assert!(credentials_present());
 ```
 
+## Record identity — read this before persisting or rendering
+
+Journal record `id`s are **UUID-shaped counters, not UUIDs**. They restart
+at the same value for every session, so two sessions emit byte-identical id
+lists; and `sequence` restarts on every turn. Neither is a safe handle
+alone.
+
+- Unique key: the composite **`(stream.id, id)`**
+- Turn grouping: `causation_id`
+- Ordering **within** a turn: `sequence`
+
+Treat `id` as stream-local *everywhere* — dedup, correlation maps, and
+frontend list keys included (a render key of `id` alone would alias rows
+across sessions). `stream.id` is the only cross-session-unique handle;
+supply your own via [`MuseExecBuilder::session_id`] and it is adopted
+verbatim.
+
 ## Testing
 
 - **Corpus tests**: every committed capture line must parse, lift into a

--- a/muse-codes/src/cli.rs
+++ b/muse-codes/src/cli.rs
@@ -32,6 +32,7 @@ pub struct MuseExecBuilder {
     provider: Option<Provider>,
     preset: Option<String>,
     model: Option<String>,
+    session_id: Option<String>,
     reasoning_effort: Option<String>,
     base_url: Option<String>,
     working_directory: Option<PathBuf>,
@@ -46,6 +47,7 @@ impl MuseExecBuilder {
             provider: None,
             preset: None,
             model: None,
+            session_id: None,
             reasoning_effort: None,
             base_url: None,
             working_directory: None,
@@ -72,6 +74,23 @@ impl MuseExecBuilder {
 
     pub fn model(mut self, model: impl Into<String>) -> Self {
         self.model = Some(model.into());
+        self
+    }
+
+    /// Run under a caller-supplied session id (`--session-id`), the basis of
+    /// multi-turn continuity: each turn is its own process, and passing the
+    /// same id makes the CLI continue that session rather than start a new
+    /// one. The id is adopted verbatim as the `stream.id` on every emitted
+    /// record.
+    ///
+    /// Supplying your own id is also what makes
+    /// [`MuseRecord`](crate::MuseRecord) identity safe to key on: record
+    /// `id`s are UUID-shaped counters that repeat across sessions, so the
+    /// only unique handle is the composite `(stream.id, id)` — and that is
+    /// trustworthy precisely because `stream.id` is yours. (When omitted,
+    /// the CLI mints a random v4 of its own.)
+    pub fn session_id(mut self, session_id: impl Into<String>) -> Self {
+        self.session_id = Some(session_id.into());
         self
     }
 
@@ -112,6 +131,9 @@ impl MuseExecBuilder {
         }
         if let Some(m) = &self.model {
             cmd.args(["--model", m]);
+        }
+        if let Some(s) = &self.session_id {
+            cmd.args(["--session-id", s]);
         }
         if let Some(e) = &self.reasoning_effort {
             cmd.args(["--reasoning-effort", e]);

--- a/muse-codes/src/client_async.rs
+++ b/muse-codes/src/client_async.rs
@@ -38,6 +38,14 @@ impl ExecRun {
         })
     }
 
+    /// OS process id of the running child, when the platform exposes one.
+    ///
+    /// Useful for supervisors that signal the process group directly rather
+    /// than relying on `kill_on_drop`.
+    pub fn pid(&self) -> Option<u32> {
+        self.child.id()
+    }
+
     /// Next journal record, or `None` at end of stream.
     pub async fn next_record(&mut self) -> Result<Option<MuseRecord>> {
         loop {

--- a/muse-codes/tests/integration_tests.rs
+++ b/muse-codes/tests/integration_tests.rs
@@ -208,7 +208,7 @@ async fn record_ids_repeat_across_sessions() {
         let run = ExecRun::spawn(
             &MuseExecBuilder::new("same prompt, different session")
                 .provider(Provider::Echo)
-                .session_id(&uuid_v4_like())
+                .session_id(uuid_v4_like())
                 .working_directory(std::env::temp_dir()),
         )
         .await

--- a/muse-codes/tests/integration_tests.rs
+++ b/muse-codes/tests/integration_tests.rs
@@ -137,3 +137,152 @@ impl StdinExt for tokio::process::Command {
         child.wait_with_output().await
     }
 }
+
+/// Multi-turn continuity: two turns under one caller-supplied session id.
+/// The id is adopted verbatim as `stream.id`, and — the trap this test
+/// exists to pin — `sequence` RESTARTS rather than continuing, so it must
+/// never be used as a cross-turn key.
+#[tokio::test]
+async fn session_id_continuity_and_sequence_reuse() {
+    use muse_codes::{ExecRun, MuseExecBuilder, Provider};
+    use std::time::Duration;
+
+    let session = uuid_v4_like();
+    let mut streams = Vec::new();
+    let mut first_seqs = Vec::new();
+    let mut ids = Vec::new();
+
+    for turn in ["first turn", "second turn"] {
+        let run = ExecRun::spawn(
+            &MuseExecBuilder::new(turn)
+                .provider(Provider::Echo)
+                .session_id(&session)
+                .working_directory(std::env::temp_dir()),
+        )
+        .await
+        .expect("spawn");
+        let mut seqs = Vec::new();
+        let mut turn_ids = Vec::new();
+        let terminal = run
+            .wait_terminal(|r| {
+                seqs.push(r.sequence);
+                turn_ids.push(r.id.clone());
+                streams.push(r.stream.id.clone());
+            })
+            .await
+            .expect("terminal");
+        assert_eq!(terminal.terminal, "completed");
+        first_seqs.push(*seqs.first().expect("records"));
+        ids.push(turn_ids);
+    }
+
+    assert!(
+        streams.iter().all(|s| *s == session),
+        "the caller-supplied session id must be adopted verbatim as stream.id"
+    );
+    // Both turns start near sequence 1 rather than the second continuing
+    // from the first — the collision this test pins.
+    assert!(
+        first_seqs[1] <= 3,
+        "sequence restarts per turn (got {first_seqs:?}); never key across turns on it"
+    );
+    // Within one session, ids keep incrementing — no repeats across turns.
+    let within_session_overlap = ids[0].iter().filter(|i| ids[1].contains(i)).count();
+    assert_eq!(
+        within_session_overlap, 0,
+        "record ids should not repeat across turns of the SAME session"
+    );
+    let _ = Duration::from_secs(0);
+}
+
+/// The identity trap, pinned: record ids are UUID-*shaped counters* that
+/// restart per session, so two DIFFERENT sessions emit the same ids. Keying
+/// on `id` alone would collide across every session; only the composite
+/// `(stream.id, id)` is safe.
+#[tokio::test]
+async fn record_ids_repeat_across_sessions() {
+    use muse_codes::{ExecRun, MuseExecBuilder, Provider};
+
+    let mut runs: Vec<Vec<String>> = Vec::new();
+    for _ in 0..2 {
+        let run = ExecRun::spawn(
+            &MuseExecBuilder::new("same prompt, different session")
+                .provider(Provider::Echo)
+                .session_id(&uuid_v4_like())
+                .working_directory(std::env::temp_dir()),
+        )
+        .await
+        .expect("spawn");
+        let mut ids = Vec::new();
+        run.wait_terminal(|r| ids.push(r.id.clone()))
+            .await
+            .expect("terminal");
+        runs.push(ids);
+    }
+    let overlap = runs[0].iter().filter(|i| runs[1].contains(i)).count();
+    assert!(
+        overlap > 0,
+        "record ids are expected to REPEAT across sessions (UUID-shaped counters). \
+         If this ever fails they may have become globally unique — re-check before \
+         relaxing any (stream_id, id) composite key."
+    );
+    assert!(
+        runs[0][0].starts_with("018f0000-"),
+        "the counter shape is load-bearing context for the composite-key rule: {}",
+        runs[0][0]
+    );
+}
+
+/// Interrupt-as-kill: SIGKILL a run before it emits anything, then run the
+/// same session id again. The store must survive. Kept at a pre-first-line
+/// window on purpose — a later kill would pass vacuously because an echo
+/// run completes in ~250ms.
+#[tokio::test]
+async fn kill_midflight_then_resume_same_session() {
+    use muse_codes::{ExecRun, MuseExecBuilder, Provider};
+    use std::time::Duration;
+
+    let session = uuid_v4_like();
+    let mut victim = ExecRun::spawn(
+        &MuseExecBuilder::new("this run gets killed")
+            .provider(Provider::Echo)
+            .session_id(&session)
+            .working_directory(std::env::temp_dir()),
+    )
+    .await
+    .expect("spawn victim");
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    victim.kill().await.expect("kill");
+    drop(victim);
+
+    let run = ExecRun::spawn(
+        &MuseExecBuilder::new("this run must still work")
+            .provider(Provider::Echo)
+            .session_id(&session)
+            .working_directory(std::env::temp_dir()),
+    )
+    .await
+    .expect("spawn after kill");
+    let terminal = run
+        .wait_terminal(|_| {})
+        .await
+        .expect("session store survives a mid-flight kill");
+    assert_eq!(terminal.terminal, "completed");
+}
+
+/// Cheap v4-shaped id without pulling in the uuid crate for tests.
+fn uuid_v4_like() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let n = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    format!(
+        "{:08x}-{:04x}-4{:03x}-8{:03x}-{:012x}",
+        (n & 0xffff_ffff) as u32,
+        ((n >> 32) & 0xffff) as u16,
+        ((n >> 48) & 0xfff) as u16,
+        ((n >> 60) & 0xfff) as u16,
+        (n & 0xffff_ffff_ffff) as u64
+    )
+}


### PR DESCRIPTION
Surfaced by the agent-portal integration build (plan-PR-2): the crate could not express multi-turn continuity at all.

- **`MuseExecBuilder::session_id`** — `--session-id`, the basis of multi-turn continuity (each turn is its own process; reusing the id continues the session). The id is adopted verbatim as `stream.id`, which is precisely what makes the `(stream.id, id)` identity composite trustworthy.
- **`ExecRun::pid`** — child pid for supervisors that signal the process group directly.
- **Live tests pinning the identity traps**, all measured against the real CLI: `sequence` restarts per turn; record ids do **not** repeat within a session but **do** repeat across sessions (UUID-shaped counters — `018f0000-…c350` in every session); and a run SIGKILLed mid-flight leaves the session store usable for the next turn.

One of those tests caught an error in my own first draft: I'd asserted ids repeat across *turns*, when the real property is that they repeat across *sessions*. The corrected test now pins the actual trap, including the counter prefix, with a message telling a future reader to re-verify before relaxing any composite key.

README gains an identity section so consumers don't key on `id` alone — including the frontend-render-key case, where aliasing would drop DOM rows across sessions.