### PR TITLE
Document the tool.result task_id gap and other wire limits

### DIFF
--- a/muse-codes/README.md
+++ b/muse-codes/README.md
@@ -94,6 +94,22 @@ across sessions). `stream.id` is the only cross-session-unique handle;
 supply your own via [`MuseExecBuilder::session_id`] and it is adopted
 verbatim.
 
+## Known wire gaps (Muse Code 0.1.0)
+
+Things the stream does *not* carry, which consumers must work around:
+
+- **`tool.result` has no `task_id`.** Tool outcomes cannot be attributed to
+  the task that issued them from the record alone. A consumer building a
+  task tree must guess — attaching the result to the most recently started
+  non-terminal task works for every capture in `test_cases/`, but would
+  mis-attribute under genuinely concurrent tasks. The `call_id` it does
+  carry is a provider call id, not a task handle. Fixing this properly
+  requires the field upstream; don't grow a smarter heuristic to compensate.
+- **No usage/token accounting** appears anywhere in the observed stream.
+- **No approval round-trip**: policy decisions are journaled after the fact
+  (`side_effect_intent.policy_decision`), never asked, so headless runs
+  cannot be gated interactively.
+
 ## Testing
 
 - **Corpus tests**: every committed capture line must parse, lift into a

--- a/muse-codes/src/io/mod.rs
+++ b/muse-codes/src/io/mod.rs
@@ -219,6 +219,12 @@ pub struct ModelConfigured {
 }
 
 /// `tool.result` — outcome of one tool invocation (live providers only).
+///
+/// **No `task_id`**: the record cannot be attributed to the task that
+/// issued it. `call_id` is the provider's call id, not a task handle. A
+/// consumer correlating tools to tasks has to guess (e.g. the most
+/// recently started non-terminal task), which is wrong under genuinely
+/// concurrent tasks — see the README's known-wire-gaps section.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolResult {
     pub kind: String,


### PR DESCRIPTION
Surfaced by the agent-portal task-tree build: `tool.result` carries no `task_id`, so tool outcomes cannot be attributed to the task that issued them from the record alone. The consumer there has to attach results to the most recently started non-terminal task — correct for every committed capture, but wrong under genuinely concurrent tasks.

Documenting rather than papering over it: the fix belongs upstream (Meta carrying the field), and a consumer shouldn't grow a smarter heuristic to compensate for a missing wire field.

Adds a **known wire gaps** README section covering that plus two others the integration confirmed: no usage/token accounting anywhere in the observed stream, and no approval round-trip (policy decisions are journaled after the fact, never asked), so headless runs can't be gated interactively.