### PR TITLE
Correct tool.result guidance: kind-match correlation exists

### DIFF
--- a/muse-codes/README.md
+++ b/muse-codes/README.md
@@ -98,13 +98,17 @@ verbatim.
 
 Things the stream does *not* carry, which consumers must work around:
 
-- **`tool.result` has no `task_id`.** Tool outcomes cannot be attributed to
-  the task that issued them from the record alone. A consumer building a
-  task tree must guess — attaching the result to the most recently started
-  non-terminal task works for every capture in `test_cases/`, but would
-  mis-attribute under genuinely concurrent tasks. The `call_id` it does
-  carry is a provider call id, not a task handle. Fixing this properly
-  requires the field upstream; don't grow a smarter heuristic to compensate.
+- **`tool.result` has no `task_id`** — but a correlation exists. The wire
+  models each tool call as its own task (`task_kind: tool.<tool_name>`),
+  and the result's `correlation_facts.tool_name` names it: in every
+  committed capture, each `tool.result` matches exactly one such task.
+  Match on that, latest-first. Do **not** use a recency-of-running-tasks
+  heuristic — measured against the captures it always mis-attributes,
+  because the issuing tool task has already completed by the time its
+  result record lands (only `reminder.*` scaffolding is still running).
+  The `call_id` is a provider call id, not a task handle; the residual
+  ambiguity (two same-name tool tasks genuinely concurrent) still needs
+  the field upstream.
 - **No usage/token accounting** appears anywhere in the observed stream.
 - **No approval round-trip**: policy decisions are journaled after the fact
   (`side_effect_intent.policy_decision`), never asked, so headless runs

--- a/muse-codes/src/io/mod.rs
+++ b/muse-codes/src/io/mod.rs
@@ -220,11 +220,12 @@ pub struct ModelConfigured {
 
 /// `tool.result` — outcome of one tool invocation (live providers only).
 ///
-/// **No `task_id`**: the record cannot be attributed to the task that
-/// issued it. `call_id` is the provider's call id, not a task handle. A
-/// consumer correlating tools to tasks has to guess (e.g. the most
-/// recently started non-terminal task), which is wrong under genuinely
-/// concurrent tasks — see the README's known-wire-gaps section.
+/// **No `task_id`**, but the wire models each tool call as its own task
+/// (`task_kind: tool.<tool_name>`) and `correlation_facts.tool_name`
+/// names it — match on that, latest-first. Recency-of-running-tasks
+/// heuristics mis-attribute: the issuing tool task has already completed
+/// when this record lands. `call_id` is the provider's call id, not a
+/// task handle — see the README's known-wire-gaps section.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolResult {
     pub kind: String,


### PR DESCRIPTION
Follow-up to #285, driven by a measured discovery in agent-portal's task-tree work: the "consumers must guess" guidance was doubly wrong.

1. The suggested heuristic (most recently started non-terminal task) doesn't just risk mis-attribution under concurrency — replayed against the committed captures it **always** mis-attributes, because the issuing tool task has already completed by the time its `tool.result` record lands; the only tasks still running are `reminder.*` scaffolding.
2. A real correlation exists that the gap note missed: the wire models each tool call as its own task (`task_kind: tool.<tool_name>`), and `correlation_facts.tool_name` names it. Every `tool.result` in every capture matches exactly one such task.

Updated the README known-wire-gaps entry and the `ToolResult` type docs to prescribe kind-matching (latest-first) and warn against recency scans. The residual ambiguity — two same-name tool tasks genuinely concurrent — still needs the `task_id` field upstream, so the gap remains real, just narrower.