### PR TITLE
muse-codes 0.1.5: full muse exec flag parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "muse-codes"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "env_logger",
  "log",

--- a/muse-codes/CHANGELOG.md
+++ b/muse-codes/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2026-08-06
+
+### Added
+
+- **Full `muse exec` flag parity** — `MuseExecBuilder` now covers the
+  entire flag surface of Muse Code 0.1.0, verified flag-by-flag against
+  the real binary: `prompt_file`, `api_key_stdin`, `parallel_tool_calls`,
+  `agents`, `image` (repeatable), `workspace`, `worktree` (typed
+  `WorktreeMode`) with `worktree_base`/`worktree_existing`, the context
+  compaction trio, `max_model_steps`, `max_tool_output_bytes`,
+  `allow_workspace_switch`, `user_input_auto_resolve`,
+  `subagent_worktree_isolation`, `disable_web_tools`,
+  `no_foreign_personal_context`, `no_session_log`, and the safety group
+  (`yolo`, `trust_workspace`, `disable_approval`, `disable_sandbox`,
+  `sandbox_network`, `disable_write`, `disable_shell`,
+  `enable_shell_tool`).
+- **Measured CLI constraints documented on the methods and pinned by live
+  tests**: `--parallel-tool-calls`/`--api-key-stdin`/`--image` are
+  meta-provider-only (echo rejects at startup);
+  `--allow-workspace-switch` requires `--session-id`; `--no-session-log`
+  conflicts with `--session-id` ("a session id needs retained logging") —
+  so multi-turn continuity requires the session log. `--agents` is
+  accepted by `exec` despite appearing only in the top-level help.
+
+### Changed
+
+- `MuseExecBuilder` implements `Default` (binary `muse` from `PATH`,
+  empty prompt); `--api-key-stdin` pipes the child's stdin so the caller
+  can write the key.
+
 ## [0.1.4] - 2026-08-06
 
 ### Added

--- a/muse-codes/Cargo.toml
+++ b/muse-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muse-codes"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/muse-codes/README.md
+++ b/muse-codes/README.md
@@ -59,6 +59,12 @@ println!("\nterminal: {}", terminal.terminal);
 The Meta provider needs credentials (`muse login`, `META_API_KEY`, or
 `~/.config/muse/auth.json`); `Provider::Echo` runs without any.
 
+`MuseExecBuilder` covers the full `muse exec` flag surface (worktrees,
+sandbox/safety toggles, context compaction, image attachments, prompt
+files, step/output caps — see the builder docs), with each flag verified
+against the real binary and the CLI's cross-flag constraints noted on the
+corresponding method.
+
 ## Auth helpers
 
 No PTY needed — Muse's auth surface is automation-friendly:

--- a/muse-codes/src/cli.rs
+++ b/muse-codes/src/cli.rs
@@ -24,34 +24,129 @@ impl Provider {
     }
 }
 
+/// Session git-worktree mode (`--worktree`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorktreeMode {
+    Off,
+    /// Create a fresh worktree (base ref via
+    /// [`MuseExecBuilder::worktree_base`], default `HEAD`).
+    Create,
+    /// Use an existing worktree (path via
+    /// [`MuseExecBuilder::worktree_existing`]).
+    Existing,
+}
+
+impl WorktreeMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            WorktreeMode::Off => "off",
+            WorktreeMode::Create => "create",
+            WorktreeMode::Existing => "existing",
+        }
+    }
+}
+
 /// Builder for one `muse exec --json` invocation.
+///
+/// Covers the full `muse exec` flag surface (Muse Code 0.1.0), verified
+/// flag-by-flag against the real binary. Constraints the CLI enforces are
+/// noted on each method (several flags are Meta-provider-only; the echo
+/// provider rejects them at startup with a usage error).
 #[derive(Debug, Clone)]
 pub struct MuseExecBuilder {
     binary: String,
     prompt: String,
+    prompt_file: Option<PathBuf>,
+    api_key_stdin: bool,
     provider: Option<Provider>,
     preset: Option<String>,
     model: Option<String>,
     session_id: Option<String>,
     reasoning_effort: Option<String>,
+    parallel_tool_calls: Option<bool>,
     base_url: Option<String>,
+    agents: Option<String>,
+    images: Vec<PathBuf>,
+    workspace: Option<PathBuf>,
+    worktree: Option<WorktreeMode>,
+    worktree_base: Option<String>,
+    worktree_existing: Option<PathBuf>,
+    context_compaction_strategy: Option<String>,
+    context_compaction_soft_threshold: Option<f64>,
+    context_compaction_hard_threshold: Option<f64>,
+    max_model_steps: Option<u64>,
+    max_tool_output_bytes: Option<u64>,
+    allow_workspace_switch: bool,
+    user_input_auto_resolve: bool,
+    subagent_worktree_isolation: bool,
+    disable_web_tools: bool,
+    no_foreign_personal_context: bool,
+    no_session_log: bool,
+    yolo: bool,
+    trust_workspace: bool,
+    disable_approval: bool,
+    disable_sandbox: bool,
+    sandbox_network: Option<String>,
+    disable_write: bool,
+    disable_shell: bool,
+    enable_shell_tool: bool,
     working_directory: Option<PathBuf>,
     envs: Vec<(String, String)>,
 }
 
-impl MuseExecBuilder {
-    pub fn new(prompt: impl Into<String>) -> Self {
+impl Default for MuseExecBuilder {
+    /// An empty-prompt builder resolving `muse` from `PATH`; use
+    /// [`MuseExecBuilder::new`] (or [`MuseExecBuilder::prompt_file`]) to
+    /// supply the prompt.
+    fn default() -> Self {
         Self {
             binary: "muse".to_string(),
-            prompt: prompt.into(),
+            prompt: String::new(),
+            prompt_file: None,
+            api_key_stdin: false,
             provider: None,
             preset: None,
             model: None,
             session_id: None,
             reasoning_effort: None,
+            parallel_tool_calls: None,
             base_url: None,
+            agents: None,
+            images: Vec::new(),
+            workspace: None,
+            worktree: None,
+            worktree_base: None,
+            worktree_existing: None,
+            context_compaction_strategy: None,
+            context_compaction_soft_threshold: None,
+            context_compaction_hard_threshold: None,
+            max_model_steps: None,
+            max_tool_output_bytes: None,
+            allow_workspace_switch: false,
+            user_input_auto_resolve: false,
+            subagent_worktree_isolation: false,
+            disable_web_tools: false,
+            no_foreign_personal_context: false,
+            no_session_log: false,
+            yolo: false,
+            trust_workspace: false,
+            disable_approval: false,
+            disable_sandbox: false,
+            sandbox_network: None,
+            disable_write: false,
+            disable_shell: false,
+            enable_shell_tool: false,
             working_directory: None,
             envs: Vec::new(),
+        }
+    }
+}
+
+impl MuseExecBuilder {
+    pub fn new(prompt: impl Into<String>) -> Self {
+        Self {
+            prompt: prompt.into(),
+            ..Self::default()
         }
     }
 
@@ -106,6 +201,203 @@ impl MuseExecBuilder {
         self
     }
 
+    /// Read the prompt from a file (`--prompt-file`) instead of passing it
+    /// as an argument; the positional prompt is omitted when set.
+    pub fn prompt_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.prompt_file = Some(path.into());
+        self
+    }
+
+    /// Read the provider API key from stdin (`--api-key-stdin`).
+    /// Meta-provider-only (the echo provider rejects it at startup). When
+    /// set, the child's stdin is piped instead of null — the caller writes
+    /// the key (newline-terminated) and closes it.
+    pub fn api_key_stdin(mut self, enabled: bool) -> Self {
+        self.api_key_stdin = enabled;
+        self
+    }
+
+    /// Meta API parallel tool calls: `true` → `--parallel-tool-calls`,
+    /// `false` → `--no-parallel-tool-calls`. Meta-provider-only (the echo
+    /// provider rejects both at startup).
+    pub fn parallel_tool_calls(mut self, enabled: bool) -> Self {
+        self.parallel_tool_calls = Some(enabled);
+        self
+    }
+
+    /// One ephemeral agent-definition overlay as JSON (`--agents`).
+    /// Accepted by `exec` even though only the top-level help lists it
+    /// (verified against the binary).
+    pub fn agents(mut self, json: impl Into<String>) -> Self {
+        self.agents = Some(json.into());
+        self
+    }
+
+    /// Attach a local image file (`--image`, repeatable). Requires an
+    /// image-capable provider — the echo provider rejects it at startup.
+    pub fn image(mut self, path: impl Into<PathBuf>) -> Self {
+        self.images.push(path.into());
+        self
+    }
+
+    /// Root policy-gated workspace tools at this path (`--workspace`).
+    pub fn workspace(mut self, path: impl Into<PathBuf>) -> Self {
+        self.workspace = Some(path.into());
+        self
+    }
+
+    /// Session git worktree mode (`--worktree off|create|existing`).
+    pub fn worktree(mut self, mode: WorktreeMode) -> Self {
+        self.worktree = Some(mode);
+        self
+    }
+
+    /// Base ref for [`WorktreeMode::Create`] (`--worktree-base`, default
+    /// `HEAD`).
+    pub fn worktree_base(mut self, git_ref: impl Into<String>) -> Self {
+        self.worktree_base = Some(git_ref.into());
+        self
+    }
+
+    /// Existing worktree path for [`WorktreeMode::Existing`]
+    /// (`--worktree-existing`).
+    pub fn worktree_existing(mut self, path: impl Into<PathBuf>) -> Self {
+        self.worktree_existing = Some(path.into());
+        self
+    }
+
+    /// Context compaction strategy id (`--context-compaction-strategy`,
+    /// e.g. `summary-preserved-suffix/v1`). Kept as a string: the ids are
+    /// versioned and the set will drift.
+    pub fn context_compaction_strategy(mut self, id: impl Into<String>) -> Self {
+        self.context_compaction_strategy = Some(id.into());
+        self
+    }
+
+    /// Soft compaction threshold fraction
+    /// (`--context-compaction-soft-threshold`).
+    pub fn context_compaction_soft_threshold(mut self, fraction: f64) -> Self {
+        self.context_compaction_soft_threshold = Some(fraction);
+        self
+    }
+
+    /// Hard compaction threshold fraction
+    /// (`--context-compaction-hard-threshold`).
+    pub fn context_compaction_hard_threshold(mut self, fraction: f64) -> Self {
+        self.context_compaction_hard_threshold = Some(fraction);
+        self
+    }
+
+    /// Cap the number of model steps (`--max-model-steps`).
+    pub fn max_model_steps(mut self, steps: u64) -> Self {
+        self.max_model_steps = Some(steps);
+        self
+    }
+
+    /// Cap tool output bytes fed back to the model
+    /// (`--max-tool-output-bytes`).
+    pub fn max_tool_output_bytes(mut self, bytes: u64) -> Self {
+        self.max_tool_output_bytes = Some(bytes);
+        self
+    }
+
+    /// Allow switching the workspace mid-run (`--allow-workspace-switch`).
+    /// The CLI requires [`MuseExecBuilder::session_id`] alongside it
+    /// (verified: rejected at startup otherwise).
+    pub fn allow_workspace_switch(mut self, enabled: bool) -> Self {
+        self.allow_workspace_switch = enabled;
+        self
+    }
+
+    /// Offer `request_user_input` and auto-cancel prompts in headless runs
+    /// (`--user-input-auto-resolve`).
+    pub fn user_input_auto_resolve(mut self, enabled: bool) -> Self {
+        self.user_input_auto_resolve = enabled;
+        self
+    }
+
+    /// Compatibility flag for subagent worktree isolation
+    /// (`--subagent-worktree-isolation`); the capability defaults on.
+    pub fn subagent_worktree_isolation(mut self, enabled: bool) -> Self {
+        self.subagent_worktree_isolation = enabled;
+        self
+    }
+
+    /// Disable web tools for this run (`--disable-web-tools`).
+    pub fn disable_web_tools(mut self, disabled: bool) -> Self {
+        self.disable_web_tools = disabled;
+        self
+    }
+
+    /// Exclude foreign personal rules and skills
+    /// (`--no-foreign-personal-context`).
+    pub fn no_foreign_personal_context(mut self, excluded: bool) -> Self {
+        self.no_foreign_personal_context = excluded;
+        self
+    }
+
+    /// Do not persist session event logs to disk (`--no-session-log`).
+    /// Conflicts with [`MuseExecBuilder::session_id`]: the CLI rejects the
+    /// pair at startup ("a session id needs retained logging" — verified),
+    /// which also means multi-turn continuity requires the log.
+    pub fn no_session_log(mut self, disabled: bool) -> Self {
+        self.no_session_log = disabled;
+        self
+    }
+
+    /// Disable approval and sandbox and trust this workspace for the run
+    /// (`--yolo`).
+    pub fn yolo(mut self, enabled: bool) -> Self {
+        self.yolo = enabled;
+        self
+    }
+
+    /// Load this workspace's skills and rules for the run
+    /// (`--trust-workspace`).
+    pub fn trust_workspace(mut self, trusted: bool) -> Self {
+        self.trust_workspace = trusted;
+        self
+    }
+
+    /// Disable tool approval prompts for the run (`--disable-approval`).
+    pub fn disable_approval(mut self, disabled: bool) -> Self {
+        self.disable_approval = disabled;
+        self
+    }
+
+    /// Disable shell filesystem/network sandboxing for the run
+    /// (`--disable-sandbox`).
+    pub fn disable_sandbox(mut self, disabled: bool) -> Self {
+        self.disable_sandbox = disabled;
+        self
+    }
+
+    /// Sandbox network mode (`--sandbox-network`, default `proxy-only`).
+    /// Kept as a string: the help names no closed set of modes.
+    pub fn sandbox_network(mut self, mode: impl Into<String>) -> Self {
+        self.sandbox_network = Some(mode.into());
+        self
+    }
+
+    /// Disable non-shell workspace filesystem writes (`--disable-write`).
+    pub fn disable_write(mut self, disabled: bool) -> Self {
+        self.disable_write = disabled;
+        self
+    }
+
+    /// Disable workspace shell execution (`--disable-shell`).
+    pub fn disable_shell(mut self, disabled: bool) -> Self {
+        self.disable_shell = disabled;
+        self
+    }
+
+    /// Use the legacy shell tool instead of managed bash
+    /// (`--enable-shell-tool`).
+    pub fn enable_shell_tool(mut self, enabled: bool) -> Self {
+        self.enable_shell_tool = enabled;
+        self
+    }
+
     pub fn working_directory(mut self, dir: impl Into<PathBuf>) -> Self {
         self.working_directory = Some(dir.into());
         self
@@ -138,14 +430,110 @@ impl MuseExecBuilder {
         if let Some(e) = &self.reasoning_effort {
             cmd.args(["--reasoning-effort", e]);
         }
+        if let Some(enabled) = self.parallel_tool_calls {
+            cmd.arg(if enabled {
+                "--parallel-tool-calls"
+            } else {
+                "--no-parallel-tool-calls"
+            });
+        }
         if let Some(u) = &self.base_url {
             cmd.args(["--base-url", u]);
         }
-        cmd.arg(&self.prompt)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true);
+        if let Some(a) = &self.agents {
+            cmd.args(["--agents", a]);
+        }
+        for image in &self.images {
+            cmd.arg("--image").arg(image);
+        }
+        if let Some(w) = &self.workspace {
+            cmd.arg("--workspace").arg(w);
+        }
+        if let Some(mode) = self.worktree {
+            cmd.args(["--worktree", mode.as_str()]);
+        }
+        if let Some(base) = &self.worktree_base {
+            cmd.args(["--worktree-base", base]);
+        }
+        if let Some(path) = &self.worktree_existing {
+            cmd.arg("--worktree-existing").arg(path);
+        }
+        if let Some(s) = &self.context_compaction_strategy {
+            cmd.args(["--context-compaction-strategy", s]);
+        }
+        if let Some(f) = self.context_compaction_soft_threshold {
+            cmd.args(["--context-compaction-soft-threshold", &f.to_string()]);
+        }
+        if let Some(f) = self.context_compaction_hard_threshold {
+            cmd.args(["--context-compaction-hard-threshold", &f.to_string()]);
+        }
+        if let Some(n) = self.max_model_steps {
+            cmd.args(["--max-model-steps", &n.to_string()]);
+        }
+        if let Some(n) = self.max_tool_output_bytes {
+            cmd.args(["--max-tool-output-bytes", &n.to_string()]);
+        }
+        if self.api_key_stdin {
+            cmd.arg("--api-key-stdin");
+        }
+        if self.allow_workspace_switch {
+            cmd.arg("--allow-workspace-switch");
+        }
+        if self.user_input_auto_resolve {
+            cmd.arg("--user-input-auto-resolve");
+        }
+        if self.subagent_worktree_isolation {
+            cmd.arg("--subagent-worktree-isolation");
+        }
+        if self.disable_web_tools {
+            cmd.arg("--disable-web-tools");
+        }
+        if self.no_foreign_personal_context {
+            cmd.arg("--no-foreign-personal-context");
+        }
+        if self.no_session_log {
+            cmd.arg("--no-session-log");
+        }
+        if self.yolo {
+            cmd.arg("--yolo");
+        }
+        if self.trust_workspace {
+            cmd.arg("--trust-workspace");
+        }
+        if self.disable_approval {
+            cmd.arg("--disable-approval");
+        }
+        if self.disable_sandbox {
+            cmd.arg("--disable-sandbox");
+        }
+        if let Some(mode) = &self.sandbox_network {
+            cmd.args(["--sandbox-network", mode]);
+        }
+        if self.disable_write {
+            cmd.arg("--disable-write");
+        }
+        if self.disable_shell {
+            cmd.arg("--disable-shell");
+        }
+        if self.enable_shell_tool {
+            cmd.arg("--enable-shell-tool");
+        }
+        // `--prompt-file` replaces the positional prompt.
+        if let Some(file) = &self.prompt_file {
+            cmd.arg("--prompt-file").arg(file);
+        } else {
+            cmd.arg(&self.prompt);
+        }
+        // `--api-key-stdin` needs a writable stdin; the caller writes the
+        // key and closes it. Otherwise stdin stays null.
+        cmd.stdin(if self.api_key_stdin {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
         if let Some(dir) = &self.working_directory {
             cmd.current_dir(dir);
         }
@@ -158,5 +546,145 @@ impl MuseExecBuilder {
     /// Spawn the run.
     pub async fn spawn(&self) -> Result<tokio::process::Child> {
         Ok(self.build_command()?.spawn()?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(builder: &MuseExecBuilder) -> Vec<String> {
+        let cmd = builder.build_command().expect("muse on PATH");
+        cmd.as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    /// Every flag lands on the command line exactly as the CLI spells it —
+    /// the full `muse exec` surface, so a missing arm here is a missing
+    /// flag.
+    #[test]
+    fn full_flag_surface_assembles() {
+        let b = MuseExecBuilder::new("do the thing")
+            .provider(Provider::Meta)
+            .preset("native-basic")
+            .model("m-1")
+            .session_id("s-1")
+            .reasoning_effort("high")
+            .parallel_tool_calls(true)
+            .base_url("http://localhost:1")
+            .agents("{}")
+            .image("/tmp/a.png")
+            .image("/tmp/b.png")
+            .workspace("/ws")
+            .worktree(WorktreeMode::Create)
+            .worktree_base("main")
+            .worktree_existing("/wt")
+            .context_compaction_strategy("summary-preserved-suffix/v1")
+            .context_compaction_soft_threshold(0.7)
+            .context_compaction_hard_threshold(0.9)
+            .max_model_steps(5)
+            .max_tool_output_bytes(1000)
+            .api_key_stdin(true)
+            .allow_workspace_switch(true)
+            .user_input_auto_resolve(true)
+            .subagent_worktree_isolation(true)
+            .disable_web_tools(true)
+            .no_foreign_personal_context(true)
+            .no_session_log(true)
+            .yolo(true)
+            .trust_workspace(true)
+            .disable_approval(true)
+            .disable_sandbox(true)
+            .sandbox_network("proxy-only")
+            .disable_write(true)
+            .disable_shell(true)
+            .enable_shell_tool(true);
+        let got = args(&b);
+        let want: Vec<&str> = vec![
+            "exec",
+            "--json",
+            "--provider",
+            "meta",
+            "--preset",
+            "native-basic",
+            "--model",
+            "m-1",
+            "--session-id",
+            "s-1",
+            "--reasoning-effort",
+            "high",
+            "--parallel-tool-calls",
+            "--base-url",
+            "http://localhost:1",
+            "--agents",
+            "{}",
+            "--image",
+            "/tmp/a.png",
+            "--image",
+            "/tmp/b.png",
+            "--workspace",
+            "/ws",
+            "--worktree",
+            "create",
+            "--worktree-base",
+            "main",
+            "--worktree-existing",
+            "/wt",
+            "--context-compaction-strategy",
+            "summary-preserved-suffix/v1",
+            "--context-compaction-soft-threshold",
+            "0.7",
+            "--context-compaction-hard-threshold",
+            "0.9",
+            "--max-model-steps",
+            "5",
+            "--max-tool-output-bytes",
+            "1000",
+            "--api-key-stdin",
+            "--allow-workspace-switch",
+            "--user-input-auto-resolve",
+            "--subagent-worktree-isolation",
+            "--disable-web-tools",
+            "--no-foreign-personal-context",
+            "--no-session-log",
+            "--yolo",
+            "--trust-workspace",
+            "--disable-approval",
+            "--disable-sandbox",
+            "--sandbox-network",
+            "proxy-only",
+            "--disable-write",
+            "--disable-shell",
+            "--enable-shell-tool",
+            "do the thing",
+        ];
+        assert_eq!(got, want);
+    }
+
+    /// `--no-parallel-tool-calls` is the false arm of one knob, not a
+    /// separate builder method.
+    #[test]
+    fn parallel_tool_calls_false_emits_the_no_flag() {
+        let got = args(&MuseExecBuilder::new("p").parallel_tool_calls(false));
+        assert!(got.contains(&"--no-parallel-tool-calls".to_string()));
+        assert!(!got.contains(&"--parallel-tool-calls".to_string()));
+    }
+
+    /// `--prompt-file` replaces the positional prompt entirely.
+    #[test]
+    fn prompt_file_replaces_the_positional_prompt() {
+        let got = args(&MuseExecBuilder::new("ignored").prompt_file("/tmp/p.txt"));
+        assert_eq!(got.last().map(String::as_str), Some("/tmp/p.txt"));
+        assert!(got.contains(&"--prompt-file".to_string()));
+        assert!(!got.contains(&"ignored".to_string()));
+    }
+
+    /// Nothing optional leaks into a minimal invocation.
+    #[test]
+    fn minimal_invocation_stays_minimal() {
+        let got = args(&MuseExecBuilder::new("hi"));
+        assert_eq!(got, ["exec", "--json", "hi"]);
     }
 }

--- a/muse-codes/src/lib.rs
+++ b/muse-codes/src/lib.rs
@@ -55,6 +55,6 @@ pub use io::{
 };
 
 #[cfg(feature = "async-client")]
-pub use cli::{MuseExecBuilder, Provider};
+pub use cli::{MuseExecBuilder, Provider, WorktreeMode};
 #[cfg(feature = "async-client")]
 pub use client_async::ExecRun;

--- a/muse-codes/tests/integration_tests.rs
+++ b/muse-codes/tests/integration_tests.rs
@@ -286,3 +286,94 @@ fn uuid_v4_like() -> String {
         (n & 0xffff_ffff_ffff) as u64
     )
 }
+
+/// Every echo-compatible flag in the builder is accepted by the real CLI
+/// and the run still reaches its terminal record. Meta-only flags
+/// (`--api-key-stdin`, `--parallel-tool-calls`, `--image`) and
+/// `--allow-workspace-switch` (requires a session id) are exercised for
+/// *rejection* below, so the acceptance list and the constraint notes on
+/// the builder can't silently drift apart.
+#[tokio::test]
+async fn full_echo_flag_surface_is_accepted_live() {
+    let dir = std::env::temp_dir().join(format!("muse-flags-{}", uuid_v4_like()));
+    std::fs::create_dir_all(&dir).expect("tempdir");
+    let prompt_path = dir.join("prompt.txt");
+    std::fs::write(&prompt_path, "hello from a prompt file").expect("write prompt");
+
+    let builder = muse_codes::MuseExecBuilder::new("")
+        .prompt_file(&prompt_path)
+        .provider(muse_codes::Provider::Echo)
+        .session_id(uuid_v4_like())
+        .workspace(&dir)
+        .context_compaction_strategy("summary-preserved-suffix/v1")
+        .context_compaction_soft_threshold(0.7)
+        .context_compaction_hard_threshold(0.9)
+        .max_model_steps(5)
+        .max_tool_output_bytes(10_000)
+        .allow_workspace_switch(true)
+        .user_input_auto_resolve(true)
+        .subagent_worktree_isolation(true)
+        .disable_web_tools(true)
+        .no_foreign_personal_context(true)
+        .trust_workspace(true)
+        .disable_approval(true)
+        .disable_sandbox(true)
+        .sandbox_network("proxy-only")
+        .disable_write(true)
+        .disable_shell(true)
+        .working_directory(&dir);
+
+    let run = muse_codes::ExecRun::spawn(&builder).await.expect("spawn");
+    let terminal = tokio::time::timeout(
+        std::time::Duration::from_secs(60),
+        run.wait_terminal(|_| {}),
+    )
+    .await
+    .expect("echo run should finish inside a minute")
+    .expect("run reaches terminal despite the full flag surface");
+    assert_eq!(terminal.terminal, "completed");
+
+    // `--no-session-log` conflicts with `--session-id` ("a session id
+    // needs retained logging" — measured), so it gets its own run.
+    let run = muse_codes::ExecRun::spawn(
+        &muse_codes::MuseExecBuilder::new("hi")
+            .provider(muse_codes::Provider::Echo)
+            .no_session_log(true)
+            .working_directory(&dir),
+    )
+    .await
+    .expect("spawn");
+    let terminal = tokio::time::timeout(
+        std::time::Duration::from_secs(60),
+        run.wait_terminal(|_| {}),
+    )
+    .await
+    .expect("echo run should finish inside a minute")
+    .expect("--no-session-log run reaches terminal");
+    assert_eq!(terminal.terminal, "completed");
+}
+
+/// The constraints documented on the builder are the CLI's real behavior:
+/// meta-only flags fail fast on the echo provider with a usage error
+/// rather than starting a run. Pins the constraint notes to the binary.
+#[tokio::test]
+async fn meta_only_flags_are_rejected_by_the_echo_provider_live() {
+    for build in [
+        muse_codes::MuseExecBuilder::new("hi")
+            .provider(muse_codes::Provider::Echo)
+            .parallel_tool_calls(true),
+        muse_codes::MuseExecBuilder::new("hi")
+            .provider(muse_codes::Provider::Echo)
+            .api_key_stdin(true),
+    ] {
+        let mut child = build.spawn().await.expect("spawn");
+        let status = tokio::time::timeout(std::time::Duration::from_secs(20), child.wait())
+            .await
+            .expect("usage errors fail fast")
+            .expect("wait");
+        assert!(
+            !status.success(),
+            "a meta-only flag must be rejected under the echo provider"
+        );
+    }
+}


### PR DESCRIPTION
`MuseExecBuilder` previously exposed 6 of ~30 `muse exec` flags; it now covers the full surface of Muse Code 0.1.0, bringing the muse wrapper to parity with claude-codes' approach (explicit-bool setters, typed enums for closed sets, strings for open/versioned ones).

## Verified, not transcribed

Every flag was probed against the real binary (echo provider, tmp git repo) before being exposed. That surfaced **three cross-flag constraints the help text doesn't state**, now documented on the corresponding builder methods and pinned by live tests:

- `--parallel-tool-calls` / `--api-key-stdin` / `--image` are **meta-provider-only** — echo rejects each at startup with a usage error
- `--allow-workspace-switch` **requires `--session-id`**
- `--no-session-log` **conflicts with `--session-id`** ("a session id needs retained logging") — which also means multi-turn continuity requires the session log
- Bonus: `--agents` (the ephemeral agent-overlay JSON) is accepted by `exec` despite appearing only in the top-level help — verified and exposed

## Surface added

`prompt_file` (replaces the positional prompt), `api_key_stdin` (pipes child stdin for the key), `parallel_tool_calls` (one knob, `false` emits `--no-parallel-tool-calls`), `agents`, `image` (repeatable), `workspace`, `worktree` (typed `WorktreeMode: Off|Create|Existing`) + `worktree_base`/`worktree_existing`, `context_compaction_strategy`/`_soft_threshold`/`_hard_threshold`, `max_model_steps`, `max_tool_output_bytes`, `allow_workspace_switch`, `user_input_auto_resolve`, `subagent_worktree_isolation`, `disable_web_tools`, `no_foreign_personal_context`, `no_session_log`, and the safety group: `yolo`, `trust_workspace`, `disable_approval`, `disable_sandbox`, `sandbox_network`, `disable_write`, `disable_shell`, `enable_shell_tool`.

## Tests

- 4 unit tests pin exact argv assembly (the full-surface test is order-exact, so a missing arm is a missing flag), the `--no-` false arm, prompt-file replacement, and that a minimal invocation stays `exec --json <prompt>`
- 2 live tests (`--features integration-tests`): the echo-safe surface reaches `run.terminal.completed`, and the meta-only flags fail fast under echo — so the constraint notes can't drift from the binary silently

0.1.4 → 0.1.5, CHANGELOG updated.
