### PR TITLE
Add wirecheck: login portal plus live wire-format checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +730,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +749,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -990,6 +1049,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1122,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1797,6 +1871,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,6 +1902,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1956,6 +2050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2034,6 +2137,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2072,8 +2176,21 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2083,6 +2200,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2181,6 +2324,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -2643,6 +2792,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wirecheck"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "claude-codes",
+ "codex-codes",
+ "muse-codes",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,7 +1226,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opencode-codes"
-version = "1.18.5"
+version = "1.18.14"
 dependencies = [
  "futures-core",
  "jsonschema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "muse-codes"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "env_logger",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2802,11 +2802,13 @@ dependencies = [
  "claude-codes",
  "codex-codes",
  "muse-codes",
+ "opencode-codes",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["claude-codes", "codex-codes", "muse-codes", "opencode-codes"]
+members = ["claude-codes", "codex-codes", "muse-codes", "opencode-codes", "wirecheck"]
 resolver = "2"
 
 # Dependencies shared by two or more workspace crates. Members reference these

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.223`, tested against Claude CLI `2.1.222`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.4`, tested against Codex CLI `0.146.0`.
-- **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.5`, tested against opencode `1.18.5`.
-- **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.4`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
+- **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.14`, tested against opencode `1.18.14`.
+- **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.5`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
 
 `claude-codes` and `codex-codes` warn (or fail gracefully) when the installed
 CLI version diverges from the tested version. `opencode-codes` tracks the

--- a/claude-codes/tests/integration_tests.rs
+++ b/claude-codes/tests/integration_tests.rs
@@ -201,7 +201,7 @@ async fn test_fork_session_carries_history_under_new_id() {
             break;
         }
     }
-    drop(stream);
+    let _ = stream; // release the &mut client borrow (ResponseStream has no Drop)
     client.shutdown().await.expect("Failed to shutdown source");
 
     // Fork it and ask the fork to recall the fact.
@@ -239,7 +239,7 @@ async fn test_fork_session_carries_history_under_new_id() {
             _ => {}
         }
     }
-    drop(stream);
+    let _ = stream; // release the &mut fork borrow (ResponseStream has no Drop)
     fork.shutdown().await.expect("Failed to shutdown fork");
 
     assert!(

--- a/muse-codes/CHANGELOG.md
+++ b/muse-codes/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2026-08-06
+
+### Added
+
+- **Full `muse exec` flag parity** — `MuseExecBuilder` now covers the
+  entire flag surface of Muse Code 0.1.0, verified flag-by-flag against
+  the real binary: `prompt_file`, `api_key_stdin`, `parallel_tool_calls`,
+  `agents`, `image` (repeatable), `workspace`, `worktree` (typed
+  `WorktreeMode`) with `worktree_base`/`worktree_existing`, the context
+  compaction trio, `max_model_steps`, `max_tool_output_bytes`,
+  `allow_workspace_switch`, `user_input_auto_resolve`,
+  `subagent_worktree_isolation`, `disable_web_tools`,
+  `no_foreign_personal_context`, `no_session_log`, and the safety group
+  (`yolo`, `trust_workspace`, `disable_approval`, `disable_sandbox`,
+  `sandbox_network`, `disable_write`, `disable_shell`,
+  `enable_shell_tool`).
+- **Measured CLI constraints documented on the methods and pinned by live
+  tests**: `--parallel-tool-calls`/`--api-key-stdin`/`--image` are
+  meta-provider-only (echo rejects at startup);
+  `--allow-workspace-switch` requires `--session-id`; `--no-session-log`
+  conflicts with `--session-id` ("a session id needs retained logging") —
+  so multi-turn continuity requires the session log. `--agents` is
+  accepted by `exec` despite appearing only in the top-level help.
+
+### Changed
+
+- `MuseExecBuilder` implements `Default` (binary `muse` from `PATH`,
+  empty prompt); `--api-key-stdin` pipes the child's stdin so the caller
+  can write the key.
+
 ## [0.1.4] - 2026-08-06
 
 ### Added

--- a/muse-codes/Cargo.toml
+++ b/muse-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muse-codes"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/muse-codes/README.md
+++ b/muse-codes/README.md
@@ -59,6 +59,12 @@ println!("\nterminal: {}", terminal.terminal);
 The Meta provider needs credentials (`muse login`, `META_API_KEY`, or
 `~/.config/muse/auth.json`); `Provider::Echo` runs without any.
 
+`MuseExecBuilder` covers the full `muse exec` flag surface (worktrees,
+sandbox/safety toggles, context compaction, image attachments, prompt
+files, step/output caps — see the builder docs), with each flag verified
+against the real binary and the CLI's cross-flag constraints noted on the
+corresponding method.
+
 ## Auth helpers
 
 No PTY needed — Muse's auth surface is automation-friendly:

--- a/muse-codes/src/cli.rs
+++ b/muse-codes/src/cli.rs
@@ -24,6 +24,28 @@ impl Provider {
     }
 }
 
+/// String-collecting stand-in for `Command::arg`/`args` so argv assembly
+/// is pure and testable without resolving the binary.
+#[derive(Default)]
+struct ArgSink(Vec<String>);
+
+impl ArgSink {
+    fn arg(&mut self, a: impl AsRef<std::ffi::OsStr>) -> &mut Self {
+        self.0.push(a.as_ref().to_string_lossy().into_owned());
+        self
+    }
+    fn args<I, S>(&mut self, items: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<std::ffi::OsStr>,
+    {
+        for a in items {
+            self.arg(a);
+        }
+        self
+    }
+}
+
 /// Session git-worktree mode (`--worktree`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WorktreeMode {
@@ -424,12 +446,11 @@ impl MuseExecBuilder {
         self
     }
 
-    /// Resolve the binary and assemble the command with piped stdio.
-    pub fn build_command(&self) -> Result<tokio::process::Command> {
-        let program = which::which(&self.binary).map_err(|_| Error::BinaryNotFound {
-            name: self.binary.clone(),
-        })?;
-        let mut cmd = tokio::process::Command::new(program);
+    /// The full argv after the binary name — assembly is separated from
+    /// binary resolution so it can be exercised (and unit-tested) on hosts
+    /// without a `muse` install.
+    fn assembled_args(&self) -> Vec<String> {
+        let mut cmd = ArgSink::default();
         cmd.arg("exec").arg("--json");
         if let Some(p) = self.provider {
             cmd.args(["--provider", p.as_str()]);
@@ -543,6 +564,16 @@ impl MuseExecBuilder {
         } else {
             cmd.arg(&self.prompt);
         }
+        cmd.0
+    }
+
+    /// Resolve the binary and assemble the command with piped stdio.
+    pub fn build_command(&self) -> Result<tokio::process::Command> {
+        let program = which::which(&self.binary).map_err(|_| Error::BinaryNotFound {
+            name: self.binary.clone(),
+        })?;
+        let mut cmd = tokio::process::Command::new(program);
+        cmd.args(self.assembled_args());
         // `--api-key-stdin` needs a writable stdin; the caller writes the
         // key and closes it. Otherwise stdin stays null.
         cmd.stdin(if self.api_key_stdin {
@@ -573,11 +604,9 @@ mod tests {
     use super::*;
 
     fn args(builder: &MuseExecBuilder) -> Vec<String> {
-        let cmd = builder.build_command().expect("muse on PATH");
-        cmd.as_std()
-            .get_args()
-            .map(|a| a.to_string_lossy().into_owned())
-            .collect()
+        // Pure assembly — no `muse` install needed, so these run on any CI
+        // host.
+        builder.assembled_args()
     }
 
     /// Every flag lands on the command line exactly as the CLI spells it —

--- a/muse-codes/src/cli.rs
+++ b/muse-codes/src/cli.rs
@@ -24,34 +24,129 @@ impl Provider {
     }
 }
 
+/// Session git-worktree mode (`--worktree`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorktreeMode {
+    Off,
+    /// Create a fresh worktree (base ref via
+    /// [`MuseExecBuilder::worktree_base`], default `HEAD`).
+    Create,
+    /// Use an existing worktree (path via
+    /// [`MuseExecBuilder::worktree_existing`]).
+    Existing,
+}
+
+impl WorktreeMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            WorktreeMode::Off => "off",
+            WorktreeMode::Create => "create",
+            WorktreeMode::Existing => "existing",
+        }
+    }
+}
+
 /// Builder for one `muse exec --json` invocation.
+///
+/// Covers the full `muse exec` flag surface (Muse Code 0.1.0), verified
+/// flag-by-flag against the real binary. Constraints the CLI enforces are
+/// noted on each method (several flags are Meta-provider-only; the echo
+/// provider rejects them at startup with a usage error).
 #[derive(Debug, Clone)]
 pub struct MuseExecBuilder {
     binary: String,
     prompt: String,
+    prompt_file: Option<PathBuf>,
+    api_key_stdin: bool,
     provider: Option<Provider>,
     preset: Option<String>,
     model: Option<String>,
     session_id: Option<String>,
     reasoning_effort: Option<String>,
+    parallel_tool_calls: Option<bool>,
     base_url: Option<String>,
+    agents: Option<String>,
+    images: Vec<PathBuf>,
+    workspace: Option<PathBuf>,
+    worktree: Option<WorktreeMode>,
+    worktree_base: Option<String>,
+    worktree_existing: Option<PathBuf>,
+    context_compaction_strategy: Option<String>,
+    context_compaction_soft_threshold: Option<f64>,
+    context_compaction_hard_threshold: Option<f64>,
+    max_model_steps: Option<u64>,
+    max_tool_output_bytes: Option<u64>,
+    allow_workspace_switch: bool,
+    user_input_auto_resolve: bool,
+    subagent_worktree_isolation: bool,
+    disable_web_tools: bool,
+    no_foreign_personal_context: bool,
+    no_session_log: bool,
+    yolo: bool,
+    trust_workspace: bool,
+    disable_approval: bool,
+    disable_sandbox: bool,
+    sandbox_network: Option<String>,
+    disable_write: bool,
+    disable_shell: bool,
+    enable_shell_tool: bool,
     working_directory: Option<PathBuf>,
     envs: Vec<(String, String)>,
 }
 
-impl MuseExecBuilder {
-    pub fn new(prompt: impl Into<String>) -> Self {
+impl Default for MuseExecBuilder {
+    /// An empty-prompt builder resolving `muse` from `PATH`; use
+    /// [`MuseExecBuilder::new`] (or [`MuseExecBuilder::prompt_file`]) to
+    /// supply the prompt.
+    fn default() -> Self {
         Self {
             binary: "muse".to_string(),
-            prompt: prompt.into(),
+            prompt: String::new(),
+            prompt_file: None,
+            api_key_stdin: false,
             provider: None,
             preset: None,
             model: None,
             session_id: None,
             reasoning_effort: None,
+            parallel_tool_calls: None,
             base_url: None,
+            agents: None,
+            images: Vec::new(),
+            workspace: None,
+            worktree: None,
+            worktree_base: None,
+            worktree_existing: None,
+            context_compaction_strategy: None,
+            context_compaction_soft_threshold: None,
+            context_compaction_hard_threshold: None,
+            max_model_steps: None,
+            max_tool_output_bytes: None,
+            allow_workspace_switch: false,
+            user_input_auto_resolve: false,
+            subagent_worktree_isolation: false,
+            disable_web_tools: false,
+            no_foreign_personal_context: false,
+            no_session_log: false,
+            yolo: false,
+            trust_workspace: false,
+            disable_approval: false,
+            disable_sandbox: false,
+            sandbox_network: None,
+            disable_write: false,
+            disable_shell: false,
+            enable_shell_tool: false,
             working_directory: None,
             envs: Vec::new(),
+        }
+    }
+}
+
+impl MuseExecBuilder {
+    pub fn new(prompt: impl Into<String>) -> Self {
+        Self {
+            prompt: prompt.into(),
+            ..Self::default()
         }
     }
 
@@ -106,6 +201,203 @@ impl MuseExecBuilder {
         self
     }
 
+    /// Read the prompt from a file (`--prompt-file`) instead of passing it
+    /// as an argument; the positional prompt is omitted when set.
+    pub fn prompt_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.prompt_file = Some(path.into());
+        self
+    }
+
+    /// Read the provider API key from stdin (`--api-key-stdin`).
+    /// Meta-provider-only (the echo provider rejects it at startup). When
+    /// set, the child's stdin is piped instead of null — the caller writes
+    /// the key (newline-terminated) and closes it.
+    pub fn api_key_stdin(mut self, enabled: bool) -> Self {
+        self.api_key_stdin = enabled;
+        self
+    }
+
+    /// Meta API parallel tool calls: `true` → `--parallel-tool-calls`,
+    /// `false` → `--no-parallel-tool-calls`. Meta-provider-only (the echo
+    /// provider rejects both at startup).
+    pub fn parallel_tool_calls(mut self, enabled: bool) -> Self {
+        self.parallel_tool_calls = Some(enabled);
+        self
+    }
+
+    /// One ephemeral agent-definition overlay as JSON (`--agents`).
+    /// Accepted by `exec` even though only the top-level help lists it
+    /// (verified against the binary).
+    pub fn agents(mut self, json: impl Into<String>) -> Self {
+        self.agents = Some(json.into());
+        self
+    }
+
+    /// Attach a local image file (`--image`, repeatable). Requires an
+    /// image-capable provider — the echo provider rejects it at startup.
+    pub fn image(mut self, path: impl Into<PathBuf>) -> Self {
+        self.images.push(path.into());
+        self
+    }
+
+    /// Root policy-gated workspace tools at this path (`--workspace`).
+    pub fn workspace(mut self, path: impl Into<PathBuf>) -> Self {
+        self.workspace = Some(path.into());
+        self
+    }
+
+    /// Session git worktree mode (`--worktree off|create|existing`).
+    pub fn worktree(mut self, mode: WorktreeMode) -> Self {
+        self.worktree = Some(mode);
+        self
+    }
+
+    /// Base ref for [`WorktreeMode::Create`] (`--worktree-base`, default
+    /// `HEAD`).
+    pub fn worktree_base(mut self, git_ref: impl Into<String>) -> Self {
+        self.worktree_base = Some(git_ref.into());
+        self
+    }
+
+    /// Existing worktree path for [`WorktreeMode::Existing`]
+    /// (`--worktree-existing`).
+    pub fn worktree_existing(mut self, path: impl Into<PathBuf>) -> Self {
+        self.worktree_existing = Some(path.into());
+        self
+    }
+
+    /// Context compaction strategy id (`--context-compaction-strategy`,
+    /// e.g. `summary-preserved-suffix/v1`). Kept as a string: the ids are
+    /// versioned and the set will drift.
+    pub fn context_compaction_strategy(mut self, id: impl Into<String>) -> Self {
+        self.context_compaction_strategy = Some(id.into());
+        self
+    }
+
+    /// Soft compaction threshold fraction
+    /// (`--context-compaction-soft-threshold`).
+    pub fn context_compaction_soft_threshold(mut self, fraction: f64) -> Self {
+        self.context_compaction_soft_threshold = Some(fraction);
+        self
+    }
+
+    /// Hard compaction threshold fraction
+    /// (`--context-compaction-hard-threshold`).
+    pub fn context_compaction_hard_threshold(mut self, fraction: f64) -> Self {
+        self.context_compaction_hard_threshold = Some(fraction);
+        self
+    }
+
+    /// Cap the number of model steps (`--max-model-steps`).
+    pub fn max_model_steps(mut self, steps: u64) -> Self {
+        self.max_model_steps = Some(steps);
+        self
+    }
+
+    /// Cap tool output bytes fed back to the model
+    /// (`--max-tool-output-bytes`).
+    pub fn max_tool_output_bytes(mut self, bytes: u64) -> Self {
+        self.max_tool_output_bytes = Some(bytes);
+        self
+    }
+
+    /// Allow switching the workspace mid-run (`--allow-workspace-switch`).
+    /// The CLI requires [`MuseExecBuilder::session_id`] alongside it
+    /// (verified: rejected at startup otherwise).
+    pub fn allow_workspace_switch(mut self, enabled: bool) -> Self {
+        self.allow_workspace_switch = enabled;
+        self
+    }
+
+    /// Offer `request_user_input` and auto-cancel prompts in headless runs
+    /// (`--user-input-auto-resolve`).
+    pub fn user_input_auto_resolve(mut self, enabled: bool) -> Self {
+        self.user_input_auto_resolve = enabled;
+        self
+    }
+
+    /// Compatibility flag for subagent worktree isolation
+    /// (`--subagent-worktree-isolation`); the capability defaults on.
+    pub fn subagent_worktree_isolation(mut self, enabled: bool) -> Self {
+        self.subagent_worktree_isolation = enabled;
+        self
+    }
+
+    /// Disable web tools for this run (`--disable-web-tools`).
+    pub fn disable_web_tools(mut self, disabled: bool) -> Self {
+        self.disable_web_tools = disabled;
+        self
+    }
+
+    /// Exclude foreign personal rules and skills
+    /// (`--no-foreign-personal-context`).
+    pub fn no_foreign_personal_context(mut self, excluded: bool) -> Self {
+        self.no_foreign_personal_context = excluded;
+        self
+    }
+
+    /// Do not persist session event logs to disk (`--no-session-log`).
+    /// Conflicts with [`MuseExecBuilder::session_id`]: the CLI rejects the
+    /// pair at startup ("a session id needs retained logging" — verified),
+    /// which also means multi-turn continuity requires the log.
+    pub fn no_session_log(mut self, disabled: bool) -> Self {
+        self.no_session_log = disabled;
+        self
+    }
+
+    /// Disable approval and sandbox and trust this workspace for the run
+    /// (`--yolo`).
+    pub fn yolo(mut self, enabled: bool) -> Self {
+        self.yolo = enabled;
+        self
+    }
+
+    /// Load this workspace's skills and rules for the run
+    /// (`--trust-workspace`).
+    pub fn trust_workspace(mut self, trusted: bool) -> Self {
+        self.trust_workspace = trusted;
+        self
+    }
+
+    /// Disable tool approval prompts for the run (`--disable-approval`).
+    pub fn disable_approval(mut self, disabled: bool) -> Self {
+        self.disable_approval = disabled;
+        self
+    }
+
+    /// Disable shell filesystem/network sandboxing for the run
+    /// (`--disable-sandbox`).
+    pub fn disable_sandbox(mut self, disabled: bool) -> Self {
+        self.disable_sandbox = disabled;
+        self
+    }
+
+    /// Sandbox network mode (`--sandbox-network`, default `proxy-only`).
+    /// Kept as a string: the help names no closed set of modes.
+    pub fn sandbox_network(mut self, mode: impl Into<String>) -> Self {
+        self.sandbox_network = Some(mode.into());
+        self
+    }
+
+    /// Disable non-shell workspace filesystem writes (`--disable-write`).
+    pub fn disable_write(mut self, disabled: bool) -> Self {
+        self.disable_write = disabled;
+        self
+    }
+
+    /// Disable workspace shell execution (`--disable-shell`).
+    pub fn disable_shell(mut self, disabled: bool) -> Self {
+        self.disable_shell = disabled;
+        self
+    }
+
+    /// Use the legacy shell tool instead of managed bash
+    /// (`--enable-shell-tool`).
+    pub fn enable_shell_tool(mut self, enabled: bool) -> Self {
+        self.enable_shell_tool = enabled;
+        self
+    }
+
     pub fn working_directory(mut self, dir: impl Into<PathBuf>) -> Self {
         self.working_directory = Some(dir.into());
         self
@@ -138,14 +430,110 @@ impl MuseExecBuilder {
         if let Some(e) = &self.reasoning_effort {
             cmd.args(["--reasoning-effort", e]);
         }
+        if let Some(enabled) = self.parallel_tool_calls {
+            cmd.arg(if enabled {
+                "--parallel-tool-calls"
+            } else {
+                "--no-parallel-tool-calls"
+            });
+        }
         if let Some(u) = &self.base_url {
             cmd.args(["--base-url", u]);
         }
-        cmd.arg(&self.prompt)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true);
+        if let Some(a) = &self.agents {
+            cmd.args(["--agents", a]);
+        }
+        for image in &self.images {
+            cmd.arg("--image").arg(image);
+        }
+        if let Some(w) = &self.workspace {
+            cmd.arg("--workspace").arg(w);
+        }
+        if let Some(mode) = self.worktree {
+            cmd.args(["--worktree", mode.as_str()]);
+        }
+        if let Some(base) = &self.worktree_base {
+            cmd.args(["--worktree-base", base]);
+        }
+        if let Some(path) = &self.worktree_existing {
+            cmd.arg("--worktree-existing").arg(path);
+        }
+        if let Some(s) = &self.context_compaction_strategy {
+            cmd.args(["--context-compaction-strategy", s]);
+        }
+        if let Some(f) = self.context_compaction_soft_threshold {
+            cmd.args(["--context-compaction-soft-threshold", &f.to_string()]);
+        }
+        if let Some(f) = self.context_compaction_hard_threshold {
+            cmd.args(["--context-compaction-hard-threshold", &f.to_string()]);
+        }
+        if let Some(n) = self.max_model_steps {
+            cmd.args(["--max-model-steps", &n.to_string()]);
+        }
+        if let Some(n) = self.max_tool_output_bytes {
+            cmd.args(["--max-tool-output-bytes", &n.to_string()]);
+        }
+        if self.api_key_stdin {
+            cmd.arg("--api-key-stdin");
+        }
+        if self.allow_workspace_switch {
+            cmd.arg("--allow-workspace-switch");
+        }
+        if self.user_input_auto_resolve {
+            cmd.arg("--user-input-auto-resolve");
+        }
+        if self.subagent_worktree_isolation {
+            cmd.arg("--subagent-worktree-isolation");
+        }
+        if self.disable_web_tools {
+            cmd.arg("--disable-web-tools");
+        }
+        if self.no_foreign_personal_context {
+            cmd.arg("--no-foreign-personal-context");
+        }
+        if self.no_session_log {
+            cmd.arg("--no-session-log");
+        }
+        if self.yolo {
+            cmd.arg("--yolo");
+        }
+        if self.trust_workspace {
+            cmd.arg("--trust-workspace");
+        }
+        if self.disable_approval {
+            cmd.arg("--disable-approval");
+        }
+        if self.disable_sandbox {
+            cmd.arg("--disable-sandbox");
+        }
+        if let Some(mode) = &self.sandbox_network {
+            cmd.args(["--sandbox-network", mode]);
+        }
+        if self.disable_write {
+            cmd.arg("--disable-write");
+        }
+        if self.disable_shell {
+            cmd.arg("--disable-shell");
+        }
+        if self.enable_shell_tool {
+            cmd.arg("--enable-shell-tool");
+        }
+        // `--prompt-file` replaces the positional prompt.
+        if let Some(file) = &self.prompt_file {
+            cmd.arg("--prompt-file").arg(file);
+        } else {
+            cmd.arg(&self.prompt);
+        }
+        // `--api-key-stdin` needs a writable stdin; the caller writes the
+        // key and closes it. Otherwise stdin stays null.
+        cmd.stdin(if self.api_key_stdin {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
         if let Some(dir) = &self.working_directory {
             cmd.current_dir(dir);
         }
@@ -158,5 +546,145 @@ impl MuseExecBuilder {
     /// Spawn the run.
     pub async fn spawn(&self) -> Result<tokio::process::Child> {
         Ok(self.build_command()?.spawn()?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(builder: &MuseExecBuilder) -> Vec<String> {
+        let cmd = builder.build_command().expect("muse on PATH");
+        cmd.as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    /// Every flag lands on the command line exactly as the CLI spells it —
+    /// the full `muse exec` surface, so a missing arm here is a missing
+    /// flag.
+    #[test]
+    fn full_flag_surface_assembles() {
+        let b = MuseExecBuilder::new("do the thing")
+            .provider(Provider::Meta)
+            .preset("native-basic")
+            .model("m-1")
+            .session_id("s-1")
+            .reasoning_effort("high")
+            .parallel_tool_calls(true)
+            .base_url("http://localhost:1")
+            .agents("{}")
+            .image("/tmp/a.png")
+            .image("/tmp/b.png")
+            .workspace("/ws")
+            .worktree(WorktreeMode::Create)
+            .worktree_base("main")
+            .worktree_existing("/wt")
+            .context_compaction_strategy("summary-preserved-suffix/v1")
+            .context_compaction_soft_threshold(0.7)
+            .context_compaction_hard_threshold(0.9)
+            .max_model_steps(5)
+            .max_tool_output_bytes(1000)
+            .api_key_stdin(true)
+            .allow_workspace_switch(true)
+            .user_input_auto_resolve(true)
+            .subagent_worktree_isolation(true)
+            .disable_web_tools(true)
+            .no_foreign_personal_context(true)
+            .no_session_log(true)
+            .yolo(true)
+            .trust_workspace(true)
+            .disable_approval(true)
+            .disable_sandbox(true)
+            .sandbox_network("proxy-only")
+            .disable_write(true)
+            .disable_shell(true)
+            .enable_shell_tool(true);
+        let got = args(&b);
+        let want: Vec<&str> = vec![
+            "exec",
+            "--json",
+            "--provider",
+            "meta",
+            "--preset",
+            "native-basic",
+            "--model",
+            "m-1",
+            "--session-id",
+            "s-1",
+            "--reasoning-effort",
+            "high",
+            "--parallel-tool-calls",
+            "--base-url",
+            "http://localhost:1",
+            "--agents",
+            "{}",
+            "--image",
+            "/tmp/a.png",
+            "--image",
+            "/tmp/b.png",
+            "--workspace",
+            "/ws",
+            "--worktree",
+            "create",
+            "--worktree-base",
+            "main",
+            "--worktree-existing",
+            "/wt",
+            "--context-compaction-strategy",
+            "summary-preserved-suffix/v1",
+            "--context-compaction-soft-threshold",
+            "0.7",
+            "--context-compaction-hard-threshold",
+            "0.9",
+            "--max-model-steps",
+            "5",
+            "--max-tool-output-bytes",
+            "1000",
+            "--api-key-stdin",
+            "--allow-workspace-switch",
+            "--user-input-auto-resolve",
+            "--subagent-worktree-isolation",
+            "--disable-web-tools",
+            "--no-foreign-personal-context",
+            "--no-session-log",
+            "--yolo",
+            "--trust-workspace",
+            "--disable-approval",
+            "--disable-sandbox",
+            "--sandbox-network",
+            "proxy-only",
+            "--disable-write",
+            "--disable-shell",
+            "--enable-shell-tool",
+            "do the thing",
+        ];
+        assert_eq!(got, want);
+    }
+
+    /// `--no-parallel-tool-calls` is the false arm of one knob, not a
+    /// separate builder method.
+    #[test]
+    fn parallel_tool_calls_false_emits_the_no_flag() {
+        let got = args(&MuseExecBuilder::new("p").parallel_tool_calls(false));
+        assert!(got.contains(&"--no-parallel-tool-calls".to_string()));
+        assert!(!got.contains(&"--parallel-tool-calls".to_string()));
+    }
+
+    /// `--prompt-file` replaces the positional prompt entirely.
+    #[test]
+    fn prompt_file_replaces_the_positional_prompt() {
+        let got = args(&MuseExecBuilder::new("ignored").prompt_file("/tmp/p.txt"));
+        assert_eq!(got.last().map(String::as_str), Some("/tmp/p.txt"));
+        assert!(got.contains(&"--prompt-file".to_string()));
+        assert!(!got.contains(&"ignored".to_string()));
+    }
+
+    /// Nothing optional leaks into a minimal invocation.
+    #[test]
+    fn minimal_invocation_stays_minimal() {
+        let got = args(&MuseExecBuilder::new("hi"));
+        assert_eq!(got, ["exec", "--json", "hi"]);
     }
 }

--- a/muse-codes/src/cli.rs
+++ b/muse-codes/src/cli.rs
@@ -90,6 +90,7 @@ pub struct MuseExecBuilder {
     disable_write: bool,
     disable_shell: bool,
     enable_shell_tool: bool,
+    extra_args: Vec<String>,
     working_directory: Option<PathBuf>,
     envs: Vec<(String, String)>,
 }
@@ -136,6 +137,7 @@ impl Default for MuseExecBuilder {
             disable_write: false,
             disable_shell: false,
             enable_shell_tool: false,
+            extra_args: Vec::new(),
             working_directory: None,
             envs: Vec::new(),
         }
@@ -398,6 +400,20 @@ impl MuseExecBuilder {
         self
     }
 
+    /// Raw argument passthrough for flags this builder does not model
+    /// (mirrors codex-codes). Appended AFTER every typed flag and BEFORE
+    /// the positional prompt, so callers relaying user-supplied tokens
+    /// (e.g. a launch dialog's extra-args box) need no flag parser of
+    /// their own. Prefer the typed setters when one exists.
+    pub fn extra_args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.extra_args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
     pub fn working_directory(mut self, dir: impl Into<PathBuf>) -> Self {
         self.working_directory = Some(dir.into());
         self
@@ -517,6 +533,9 @@ impl MuseExecBuilder {
         }
         if self.enable_shell_tool {
             cmd.arg("--enable-shell-tool");
+        }
+        for arg in &self.extra_args {
+            cmd.arg(arg);
         }
         // `--prompt-file` replaces the positional prompt.
         if let Some(file) = &self.prompt_file {
@@ -679,6 +698,29 @@ mod tests {
         assert_eq!(got.last().map(String::as_str), Some("/tmp/p.txt"));
         assert!(got.contains(&"--prompt-file".to_string()));
         assert!(!got.contains(&"ignored".to_string()));
+    }
+
+    /// Raw passthrough lands after typed flags, before the prompt — the
+    /// position a launch dialog's freeform tokens must occupy.
+    #[test]
+    fn extra_args_sit_between_typed_flags_and_the_prompt() {
+        let got = args(
+            &MuseExecBuilder::new("go")
+                .model("m-1")
+                .extra_args(["--reasoning-effort", "low"]),
+        );
+        assert_eq!(
+            got,
+            [
+                "exec",
+                "--json",
+                "--model",
+                "m-1",
+                "--reasoning-effort",
+                "low",
+                "go"
+            ]
+        );
     }
 
     /// Nothing optional leaks into a minimal invocation.

--- a/muse-codes/src/lib.rs
+++ b/muse-codes/src/lib.rs
@@ -55,6 +55,6 @@ pub use io::{
 };
 
 #[cfg(feature = "async-client")]
-pub use cli::{MuseExecBuilder, Provider};
+pub use cli::{MuseExecBuilder, Provider, WorktreeMode};
 #[cfg(feature = "async-client")]
 pub use client_async::ExecRun;

--- a/muse-codes/tests/integration_tests.rs
+++ b/muse-codes/tests/integration_tests.rs
@@ -286,3 +286,94 @@ fn uuid_v4_like() -> String {
         (n & 0xffff_ffff_ffff) as u64
     )
 }
+
+/// Every echo-compatible flag in the builder is accepted by the real CLI
+/// and the run still reaches its terminal record. Meta-only flags
+/// (`--api-key-stdin`, `--parallel-tool-calls`, `--image`) and
+/// `--allow-workspace-switch` (requires a session id) are exercised for
+/// *rejection* below, so the acceptance list and the constraint notes on
+/// the builder can't silently drift apart.
+#[tokio::test]
+async fn full_echo_flag_surface_is_accepted_live() {
+    let dir = std::env::temp_dir().join(format!("muse-flags-{}", uuid_v4_like()));
+    std::fs::create_dir_all(&dir).expect("tempdir");
+    let prompt_path = dir.join("prompt.txt");
+    std::fs::write(&prompt_path, "hello from a prompt file").expect("write prompt");
+
+    let builder = muse_codes::MuseExecBuilder::new("")
+        .prompt_file(&prompt_path)
+        .provider(muse_codes::Provider::Echo)
+        .session_id(uuid_v4_like())
+        .workspace(&dir)
+        .context_compaction_strategy("summary-preserved-suffix/v1")
+        .context_compaction_soft_threshold(0.7)
+        .context_compaction_hard_threshold(0.9)
+        .max_model_steps(5)
+        .max_tool_output_bytes(10_000)
+        .allow_workspace_switch(true)
+        .user_input_auto_resolve(true)
+        .subagent_worktree_isolation(true)
+        .disable_web_tools(true)
+        .no_foreign_personal_context(true)
+        .trust_workspace(true)
+        .disable_approval(true)
+        .disable_sandbox(true)
+        .sandbox_network("proxy-only")
+        .disable_write(true)
+        .disable_shell(true)
+        .working_directory(&dir);
+
+    let run = muse_codes::ExecRun::spawn(&builder).await.expect("spawn");
+    let terminal = tokio::time::timeout(
+        std::time::Duration::from_secs(60),
+        run.wait_terminal(|_| {}),
+    )
+    .await
+    .expect("echo run should finish inside a minute")
+    .expect("run reaches terminal despite the full flag surface");
+    assert_eq!(terminal.terminal, "completed");
+
+    // `--no-session-log` conflicts with `--session-id` ("a session id
+    // needs retained logging" — measured), so it gets its own run.
+    let run = muse_codes::ExecRun::spawn(
+        &muse_codes::MuseExecBuilder::new("hi")
+            .provider(muse_codes::Provider::Echo)
+            .no_session_log(true)
+            .working_directory(&dir),
+    )
+    .await
+    .expect("spawn");
+    let terminal = tokio::time::timeout(
+        std::time::Duration::from_secs(60),
+        run.wait_terminal(|_| {}),
+    )
+    .await
+    .expect("echo run should finish inside a minute")
+    .expect("--no-session-log run reaches terminal");
+    assert_eq!(terminal.terminal, "completed");
+}
+
+/// The constraints documented on the builder are the CLI's real behavior:
+/// meta-only flags fail fast on the echo provider with a usage error
+/// rather than starting a run. Pins the constraint notes to the binary.
+#[tokio::test]
+async fn meta_only_flags_are_rejected_by_the_echo_provider_live() {
+    for build in [
+        muse_codes::MuseExecBuilder::new("hi")
+            .provider(muse_codes::Provider::Echo)
+            .parallel_tool_calls(true),
+        muse_codes::MuseExecBuilder::new("hi")
+            .provider(muse_codes::Provider::Echo)
+            .api_key_stdin(true),
+    ] {
+        let mut child = build.spawn().await.expect("spawn");
+        let status = tokio::time::timeout(std::time::Duration::from_secs(20), child.wait())
+            .await
+            .expect("usage errors fail fast")
+            .expect("wait");
+        assert!(
+            !status.success(),
+            "a meta-only flag must be rejected under the echo provider"
+        );
+    }
+}

--- a/opencode-codes/CHANGELOG.md
+++ b/opencode-codes/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.14] - 2026-08-07
+
+### Changed
+
+- Track opencode CLI 1.18.14 (nightly OpenAPI drift check green across
+  the span — no wire changes; version pin moved forward).
+- The version-drift assertion now compares against `CARGO_PKG_VERSION`
+  instead of a second hardcoded copy of the version, so the pin cannot
+  fall out of sync with `Cargo.toml`.
+- The in-crate live SSE test honors `OPENCODE_BASE_URL` (matching the
+  integration tests), so harnesses running it against a managed server
+  on a random port work.
+
 ### Added
 
 - **`OpencodeClient::fork_session`** — wraps `POST /session/{sessionID}/fork`

--- a/opencode-codes/Cargo.toml
+++ b/opencode-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opencode-codes"
-version = "1.18.5"
+version = "1.18.14"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/opencode-codes/README.md
+++ b/opencode-codes/README.md
@@ -27,7 +27,7 @@ models of the server's OpenAPI 3.1 wire contract, an async (Tokio) client over
 `reqwest`, an SSE reader for the `GET /event` stream, and an optional managed
 launcher for the `opencode serve` process.
 
-**Tested against:** opencode 1.18.5
+**Tested against:** opencode 1.18.14
 
 ## Installation
 

--- a/opencode-codes/src/sse.rs
+++ b/opencode-codes/src/sse.rs
@@ -378,7 +378,13 @@ mod tests {
     mod live {
         use super::*;
 
-        const BASE_URL: &str = "http://127.0.0.1:41999";
+        /// Same contract as `tests/integration_tests.rs`: default to the
+        /// local capture instance, honor `OPENCODE_BASE_URL` so a harness
+        /// (wirecheck's managed server, CI) can point the test anywhere.
+        fn base_url() -> String {
+            std::env::var("OPENCODE_BASE_URL")
+                .unwrap_or_else(|_| "http://127.0.0.1:41999".to_string())
+        }
 
         async fn next_item(stream: &mut EventStream) -> Option<Result<StreamEvent>> {
             stream.next().await
@@ -388,7 +394,7 @@ mod tests {
         async fn connects_and_receives_real_frames() {
             let client = Client::new();
             let mut stream =
-                EventStream::connect_with(&client, BASE_URL, RetryConfig::default()).unwrap();
+                EventStream::connect_with(&client, &base_url(), RetryConfig::default()).unwrap();
 
             // First item off a healthy server is the connection-open marker.
             let first = tokio::time::timeout(Duration::from_secs(5), next_item(&mut stream))
@@ -400,7 +406,7 @@ mod tests {
 
             // Trigger activity so at least one event flows.
             let created = client
-                .post(format!("{BASE_URL}/session"))
+                .post(format!("{}/session", base_url()))
                 .json(&serde_json::json!({}))
                 .send()
                 .await
@@ -430,7 +436,7 @@ mod tests {
         #[tokio::test]
         async fn event_stream_is_a_futures_stream() {
             fn assert_stream<S: Stream>(_: &S) {}
-            let stream = EventStream::connect(BASE_URL).unwrap();
+            let stream = EventStream::connect(&base_url()).unwrap();
             assert_stream(&stream);
         }
     }

--- a/opencode-codes/tests/integration_tests.rs
+++ b/opencode-codes/tests/integration_tests.rs
@@ -97,7 +97,11 @@ async fn create_list_abort_loop() {
         "session id should be a ses… handle, got {}",
         session.id
     );
-    assert_eq!(session.version, "1.18.5", "server version drifted");
+    assert_eq!(
+        session.version,
+        env!("CARGO_PKG_VERSION"),
+        "server version drifted from the crate pin"
+    );
 
     // A brand-new session has no messages yet.
     let messages = client

--- a/wirecheck/Cargo.toml
+++ b/wirecheck/Cargo.toml
@@ -6,9 +6,11 @@ publish = false
 description = "Local web portal: log in to each wrapped agent CLI and run live wire-format checks"
 
 [dependencies]
-claude-codes = { path = "../claude-codes", features = ["async-client", "auth"] }
+claude-codes = { path = "../claude-codes", features = ["async-client", "auth", "integration-tests"] }
 codex-codes = { path = "../codex-codes", features = ["async-client"] }
 muse-codes = { path = "../muse-codes", features = ["async-client"] }
+opencode-codes = { path = "../opencode-codes", features = ["async-client", "server"] }
+uuid = { version = "1", features = ["v4"] }
 axum = "0.8"
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/wirecheck/Cargo.toml
+++ b/wirecheck/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 description = "Local web portal: log in to each wrapped agent CLI and run live wire-format checks"
 
 [dependencies]
-claude-codes = { path = "../claude-codes", features = ["async-client", "auth", "integration-tests"] }
+claude-codes = { path = "../claude-codes", features = ["async-client", "auth"] }
 codex-codes = { path = "../codex-codes", features = ["async-client"] }
 muse-codes = { path = "../muse-codes", features = ["async-client"] }
 opencode-codes = { path = "../opencode-codes", features = ["async-client", "server"] }

--- a/wirecheck/Cargo.toml
+++ b/wirecheck/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "wirecheck"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Local web portal: log in to each wrapped agent CLI and run live wire-format checks"
+
+[dependencies]
+claude-codes = { path = "../claude-codes", features = ["async-client", "auth"] }
+codex-codes = { path = "../codex-codes", features = ["async-client"] }
+muse-codes = { path = "../muse-codes", features = ["async-client"] }
+axum = "0.8"
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+
+[lints]
+workspace = true

--- a/wirecheck/src/checks/cargo_suite.rs
+++ b/wirecheck/src/checks/cargo_suite.rs
@@ -1,0 +1,214 @@
+//! Run a crate's REAL integration tests (`cargo test --features
+//! integration-tests`) as a subprocess and stream per-test results into
+//! the shared state. This is the no-drift tier: nothing is ported or
+//! duplicated — wirecheck executes the same test binaries CI and
+//! developers run, and presents their outcomes.
+
+use crate::state::{CheckResult, CheckStatus, Shared};
+use std::process::Stdio;
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+/// Which crate + extras each agent's cargo tier runs.
+pub fn plan(agent: &str) -> Option<(&'static str, &'static [(&'static str, &'static str)])> {
+    match agent {
+        "claude" => Some(("claude-codes", &[])),
+        "codex" => Some(("codex-codes", &[])),
+        "muse" => Some(("muse-codes", &[])),
+        // opencode's tests target a base URL; the caller pre-spawns a
+        // managed server and passes it via env.
+        "opencode" => Some(("opencode-codes", &[])),
+        _ => None,
+    }
+}
+
+pub async fn run(state: Shared, agent: &'static str) {
+    let Some((package, _)) = plan(agent) else {
+        return;
+    };
+
+    // opencode's integration tests read OPENCODE_BASE_URL; spawn a managed
+    // server for the duration so they run hermetically.
+    let mut managed: Option<opencode_codes::server::ManagedServer> = None;
+    let mut envs: Vec<(String, String)> = Vec::new();
+    if agent == "opencode" {
+        set_status(&state, agent, "starting managed opencode server…").await;
+        match opencode_codes::server::ManagedServer::builder()
+            .startup_timeout(std::time::Duration::from_secs(30))
+            .spawn()
+            .await
+        {
+            Ok(server) => {
+                envs.push(("OPENCODE_BASE_URL".into(), server.url().to_string()));
+                managed = Some(server);
+            }
+            Err(e) => {
+                push_result(
+                    &state,
+                    agent,
+                    CheckResult {
+                        name: "managed server".into(),
+                        what: "",
+                        status: CheckStatus::Fail,
+                        detail: format!("could not spawn opencode serve: {e}"),
+                        ms: None,
+                    },
+                )
+                .await;
+                finish(&state, agent, None).await;
+                return;
+            }
+        }
+    }
+
+    set_status(&state, agent, "cargo test (compiling if needed)…").await;
+    let mut cmd = tokio::process::Command::new("cargo");
+    cmd.args([
+        "test",
+        "-p",
+        package,
+        "--features",
+        "integration-tests",
+        "--",
+        "--test-threads=1",
+    ])
+    .current_dir(env!("CARGO_MANIFEST_DIR").trim_end_matches("/wirecheck"))
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .kill_on_drop(true);
+    for (k, v) in &envs {
+        cmd.env(k, v);
+    }
+
+    let started = std::time::Instant::now();
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            push_result(
+                &state,
+                agent,
+                CheckResult {
+                    name: "cargo test".into(),
+                    what: "",
+                    status: CheckStatus::Fail,
+                    detail: e.to_string(),
+                    ms: None,
+                },
+            )
+            .await;
+            finish(&state, agent, managed).await;
+            return;
+        }
+    };
+
+    // libtest lines: `test path::to::name ... ok|FAILED|ignored`.
+    // Failure details follow in `---- name stdout ----` blocks; collect the
+    // whole stdout so they can be attached after the run.
+    let stdout = child.stdout.take();
+    let mut full = String::new();
+    if let Some(out) = stdout {
+        let mut lines = BufReader::new(out).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            full.push_str(&line);
+            full.push('\n');
+            if let Some(rest) = line.strip_prefix("test ") {
+                if let Some((name, verdict)) = rest.rsplit_once(" ... ") {
+                    // Skip doc-test headers and the summary line.
+                    if name.contains("::") || !name.contains(' ') {
+                        let status = match verdict.trim() {
+                            v if v.starts_with("ok") => CheckStatus::Pass,
+                            v if v.starts_with("ignored") => CheckStatus::Skipped,
+                            _ => CheckStatus::Fail,
+                        };
+                        let short = name.rsplit("::").next().unwrap_or(name).to_string();
+                        set_status(&state, agent, &format!("ran {short}")).await;
+                        push_result(
+                            &state,
+                            agent,
+                            CheckResult {
+                                name: short,
+                                what: "",
+                                status,
+                                detail: String::new(),
+                                ms: None,
+                            },
+                        )
+                        .await;
+                    }
+                }
+            }
+        }
+    }
+    let status = child.wait().await;
+    let elapsed = started.elapsed().as_millis();
+
+    // Attach failure output blocks to their tests.
+    attach_failures(&state, agent, &full).await;
+
+    let summary = match &status {
+        Ok(s) if s.success() => format!("all suites green in {}s", elapsed / 1000),
+        Ok(_) => format!(
+            "failures present ({}s) — details attached per test",
+            elapsed / 1000
+        ),
+        Err(e) => format!("cargo did not run: {e}"),
+    };
+    set_status(&state, agent, &summary).await;
+    finish(&state, agent, managed).await;
+}
+
+/// Pull `---- name stdout ----` blocks out of libtest output and attach
+/// them (truncated) to the failing test's row.
+async fn attach_failures(state: &Shared, agent: &str, full: &str) {
+    let mut portal = state.write().await;
+    let Some(panel) = portal.agents.get_mut(agent) else {
+        return;
+    };
+    for test in &mut panel.cargo_tests {
+        if test.status != CheckStatus::Fail || !test.detail.is_empty() {
+            continue;
+        }
+        let marker = "---- ";
+        for block in full.split(marker).skip(1) {
+            if let Some((header, body)) = block.split_once(" ----\n") {
+                if header.ends_with(&format!("::{} stdout", test.name))
+                    || header == format!("{} stdout", test.name)
+                {
+                    let body = body.split("\n\n").next().unwrap_or(body);
+                    test.detail = body.chars().take(600).collect();
+                }
+            }
+        }
+        if test.detail.is_empty() {
+            test.detail = "failed — full output in the wirecheck server log".into();
+        }
+    }
+}
+
+async fn set_status(state: &Shared, agent: &str, msg: &str) {
+    let mut portal = state.write().await;
+    if let Some(panel) = portal.agents.get_mut(agent) {
+        panel.cargo_status = Some(msg.to_string());
+    }
+}
+
+async fn push_result(state: &Shared, agent: &str, result: CheckResult) {
+    let mut portal = state.write().await;
+    if let Some(panel) = portal.agents.get_mut(agent) {
+        panel.cargo_tests.retain(|c| c.name != result.name);
+        panel.cargo_tests.push(result);
+    }
+}
+
+async fn finish(
+    state: &Shared,
+    agent: &str,
+    managed: Option<opencode_codes::server::ManagedServer>,
+) {
+    if let Some(server) = managed {
+        let _ = server.stop().await;
+    }
+    let mut portal = state.write().await;
+    if let Some(panel) = portal.agents.get_mut(agent) {
+        panel.cargo_running = false;
+    }
+}

--- a/wirecheck/src/checks/claude.rs
+++ b/wirecheck/src/checks/claude.rs
@@ -1,0 +1,150 @@
+//! Claude Code wire checks: binary, credential state, and a live
+//! stream-json round trip through the typed async client — send a user
+//! message, receive typed Assistant + Result frames, session id present.
+
+use crate::state::{CheckStatus, Reporter};
+use claude_codes::io::ClaudeOutput;
+
+pub async fn run_suite(reporter: Reporter) {
+    let started = reporter.start("binary", "claude CLI present on PATH").await;
+    let version = tokio::process::Command::new("claude")
+        .arg("--version")
+        .output()
+        .await;
+    match &version {
+        Ok(o) if o.status.success() => {
+            reporter
+                .finish(
+                    "binary",
+                    started,
+                    CheckStatus::Pass,
+                    String::from_utf8_lossy(&o.stdout).trim().to_string(),
+                )
+                .await;
+        }
+        other => {
+            reporter
+                .finish("binary", started, CheckStatus::Fail, format!("{other:?}"))
+                .await;
+            return;
+        }
+    }
+
+    let started = reporter
+        .start("auth", "credential state via `claude auth status`")
+        .await;
+    let status = tokio::task::spawn_blocking(claude_codes::auth::auth_status).await;
+    let logged_in = match status {
+        Ok(Ok(s)) => {
+            let detail = format!(
+                "logged_in={} method={} provider={}",
+                s.logged_in,
+                s.auth_method.as_deref().unwrap_or("-"),
+                s.api_provider.as_deref().unwrap_or("-"),
+            );
+            let st = if s.logged_in {
+                CheckStatus::Pass
+            } else {
+                CheckStatus::Fail
+            };
+            reporter.finish("auth", started, st, detail).await;
+            s.logged_in
+        }
+        other => {
+            reporter
+                .finish("auth", started, CheckStatus::Fail, format!("{other:?}"))
+                .await;
+            false
+        }
+    };
+
+    if !logged_in {
+        let started = reporter
+            .start(
+                "live_turn",
+                "typed stream-json round trip (send → Assistant → Result)",
+            )
+            .await;
+        reporter
+            .finish(
+                "live_turn",
+                started,
+                CheckStatus::Skipped,
+                "not logged in — use the login flow above first".into(),
+            )
+            .await;
+        return;
+    }
+
+    live_turn(&reporter).await;
+}
+
+/// One real turn through the typed client. Everything the wire returns
+/// must deserialize into a typed [`ClaudeOutput`]; the client itself
+/// errors on undecodable frames, so a clean query IS the strict audit.
+async fn live_turn(reporter: &Reporter) {
+    let started = reporter
+        .start(
+            "live_turn",
+            "typed stream-json round trip (send → Assistant → Result)",
+        )
+        .await;
+    let fut = async {
+        let mut client = claude_codes::AsyncClient::with_defaults()
+            .await
+            .map_err(|e| e.to_string())?;
+        let outputs = client
+            .query("Reply with exactly: pong")
+            .await
+            .map_err(|e| e.to_string())?;
+        let session = client.session_uuid().map_err(|e| e.to_string())?;
+        let mut kinds = Vec::new();
+        let mut assistant_text = String::new();
+        let mut got_result = false;
+        for out in &outputs {
+            match out {
+                ClaudeOutput::Assistant(m) => {
+                    kinds.push("assistant");
+                    assistant_text.push_str(&format!("{m:?}"));
+                }
+                ClaudeOutput::Result(_) => {
+                    kinds.push("result");
+                    got_result = true;
+                }
+                ClaudeOutput::System(_) => kinds.push("system"),
+                ClaudeOutput::User(_) => kinds.push("user"),
+                _ => kinds.push("other"),
+            }
+        }
+        client.shutdown().await.map_err(|e| e.to_string())?;
+        if !got_result {
+            return Err(format!("no Result frame; frames: {kinds:?}"));
+        }
+        if !assistant_text.to_lowercase().contains("pong") {
+            return Err("assistant reply did not contain the requested text".to_string());
+        }
+        Ok(format!("session {session}; frames: {kinds:?}"))
+    };
+    match tokio::time::timeout(std::time::Duration::from_secs(120), fut).await {
+        Ok(Ok(detail)) => {
+            reporter
+                .finish("live_turn", started, CheckStatus::Pass, detail)
+                .await;
+        }
+        Ok(Err(e)) => {
+            reporter
+                .finish("live_turn", started, CheckStatus::Fail, e)
+                .await;
+        }
+        Err(_) => {
+            reporter
+                .finish(
+                    "live_turn",
+                    started,
+                    CheckStatus::Fail,
+                    "timed out after 120s".into(),
+                )
+                .await;
+        }
+    }
+}

--- a/wirecheck/src/checks/claude.rs
+++ b/wirecheck/src/checks/claude.rs
@@ -77,6 +77,240 @@ pub async fn run_suite(reporter: Reporter) {
     }
 
     live_turn(&reporter).await;
+    ping(&reporter).await;
+    conversation_continuity(&reporter).await;
+    fork_carries_history(&reporter).await;
+    tool_use_blocks(&reporter).await;
+    approval_handshake(&reporter).await;
+}
+
+/// Control-protocol liveness: a running client answers a ping.
+async fn ping(reporter: &Reporter) {
+    let started = reporter
+        .start("ping", "control-protocol ping round trip")
+        .await;
+    let fut = async {
+        let mut client = claude_codes::AsyncClient::with_defaults()
+            .await
+            .map_err(|e| e.to_string())?;
+        let ok = client.ping().await;
+        client.shutdown().await.map_err(|e| e.to_string())?;
+        if ok {
+            Ok("pong".to_string())
+        } else {
+            Err("ping returned false".to_string())
+        }
+    };
+    report_timed(reporter, "ping", started, 60, fut).await;
+}
+
+/// Two queries in one process share the conversation: the second answer
+/// must recall a token from the first.
+async fn conversation_continuity(reporter: &Reporter) {
+    let started = reporter
+        .start(
+            "conversation",
+            "second turn recalls the first (same process)",
+        )
+        .await;
+    let fut = async {
+        let mut client = claude_codes::AsyncClient::with_defaults()
+            .await
+            .map_err(|e| e.to_string())?;
+        client
+            .query("Remember the word 'pineapple'. Reply with just OK.")
+            .await
+            .map_err(|e| e.to_string())?;
+        let outputs = client
+            .query("What word did I ask you to remember? Reply with just that word.")
+            .await
+            .map_err(|e| e.to_string())?;
+        client.shutdown().await.map_err(|e| e.to_string())?;
+        let text = assistant_text(&outputs);
+        if text.to_lowercase().contains("pineapple") {
+            Ok("second turn recalled the token".to_string())
+        } else {
+            Err(format!(
+                "recall failed; assistant said: {}",
+                &text[..text.len().min(80)]
+            ))
+        }
+    };
+    report_timed(reporter, "conversation", started, 180, fut).await;
+}
+
+/// `--fork-session`: a fork carries the source session's history under a
+/// NEW session id.
+async fn fork_carries_history(reporter: &Reporter) {
+    let started = reporter
+        .start(
+            "fork_session",
+            "fork carries history under a new session id",
+        )
+        .await;
+    let fut = async {
+        let source = uuid::Uuid::new_v4();
+        let builder = claude_codes::ClaudeCliBuilder::new()
+            .allow_recursion()
+            .session_id(source);
+        let mut client = claude_codes::AsyncClient::from_builder(builder)
+            .await
+            .map_err(|e| e.to_string())?;
+        client
+            .query("Remember the word 'kumquat'. Reply with just OK.")
+            .await
+            .map_err(|e| e.to_string())?;
+        client.shutdown().await.map_err(|e| e.to_string())?;
+
+        let fork_id = uuid::Uuid::new_v4();
+        let builder = claude_codes::ClaudeCliBuilder::new()
+            .allow_recursion()
+            .fork_from(source.to_string())
+            .session_id(fork_id);
+        let mut fork = claude_codes::AsyncClient::from_builder(builder)
+            .await
+            .map_err(|e| e.to_string())?;
+        let outputs = fork
+            .query("What word did I ask you to remember? Reply with just that word.")
+            .await
+            .map_err(|e| e.to_string())?;
+        let session = fork.session_uuid().map_err(|e| e.to_string())?;
+        fork.shutdown().await.map_err(|e| e.to_string())?;
+        let text = assistant_text(&outputs);
+        if session == source {
+            return Err("fork kept the SOURCE session id".to_string());
+        }
+        if !text.to_lowercase().contains("kumquat") {
+            return Err(format!(
+                "fork lost history; said: {}",
+                &text[..text.len().min(80)]
+            ));
+        }
+        Ok(format!("history carried into {session}"))
+    };
+    report_timed(reporter, "fork_session", started, 240, fut).await;
+}
+
+/// Tool use over the wire: a bash-running prompt produces typed ToolUse
+/// content and a tool-result user frame before the Result.
+async fn tool_use_blocks(reporter: &Reporter) {
+    let started = reporter
+        .start(
+            "tool_use",
+            "typed ToolUse block + tool-result frame round trip",
+        )
+        .await;
+    let fut = async {
+        let mut client = claude_codes::AsyncClient::with_defaults()
+            .await
+            .map_err(|e| e.to_string())?;
+        let outputs = client
+            .query("Run `echo wirecheck-tool-probe` with your Bash tool and reply with its output.")
+            .await
+            .map_err(|e| e.to_string())?;
+        client.shutdown().await.map_err(|e| e.to_string())?;
+        let mut saw_tool_use = false;
+        let mut saw_tool_result = false;
+        for out in &outputs {
+            let v = serde_json::to_value(out).unwrap_or_default();
+            let blocks = v
+                .get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(|c| c.as_array())
+                .cloned()
+                .unwrap_or_default();
+            for b in blocks {
+                match b.get("type").and_then(|t| t.as_str()) {
+                    Some("tool_use") => saw_tool_use = true,
+                    Some("tool_result") => saw_tool_result = true,
+                    _ => {}
+                }
+            }
+        }
+        if !saw_tool_use {
+            return Err("no tool_use block in the stream".to_string());
+        }
+        if !saw_tool_result {
+            return Err("tool_use without a tool_result frame".to_string());
+        }
+        Ok("tool_use and tool_result both present and typed".to_string())
+    };
+    report_timed(reporter, "tool_use", started, 180, fut).await;
+}
+
+/// The stdio permission-prompt handshake: enabling tool approval performs
+/// the control-protocol initialization and is idempotent.
+async fn approval_handshake(reporter: &Reporter) {
+    let started = reporter
+        .start(
+            "approval_handshake",
+            "can_use_tool control initialization succeeds and is idempotent",
+        )
+        .await;
+    let fut = async {
+        let child = claude_codes::ClaudeCliBuilder::new()
+            .allow_recursion()
+            .permission_prompt_tool("stdio")
+            .spawn()
+            .await
+            .map_err(|e| e.to_string())?;
+        let mut client = claude_codes::AsyncClient::new(child).map_err(|e| e.to_string())?;
+        if client.is_tool_approval_enabled() {
+            return Err("approval reported enabled before the handshake".to_string());
+        }
+        client
+            .enable_tool_approval()
+            .await
+            .map_err(|e| e.to_string())?;
+        if !client.is_tool_approval_enabled() {
+            return Err("handshake succeeded but approval reads disabled".to_string());
+        }
+        // Second call must be a no-op, not a second handshake.
+        client
+            .enable_tool_approval()
+            .await
+            .map_err(|e| e.to_string())?;
+        client.shutdown().await.map_err(|e| e.to_string())?;
+        Ok("handshake ok, idempotent".to_string())
+    };
+    report_timed(reporter, "approval_handshake", started, 90, fut).await;
+}
+
+fn assistant_text(outputs: &[ClaudeOutput]) -> String {
+    let mut text = String::new();
+    for out in outputs {
+        if let ClaudeOutput::Assistant(m) = out {
+            text.push_str(&format!("{m:?}"));
+        }
+    }
+    text
+}
+
+async fn report_timed(
+    reporter: &Reporter,
+    name: &'static str,
+    started: std::time::Instant,
+    timeout_s: u64,
+    fut: impl std::future::Future<Output = Result<String, String>>,
+) {
+    match tokio::time::timeout(std::time::Duration::from_secs(timeout_s), fut).await {
+        Ok(Ok(detail)) => {
+            reporter
+                .finish(name, started, CheckStatus::Pass, detail)
+                .await
+        }
+        Ok(Err(e)) => reporter.finish(name, started, CheckStatus::Fail, e).await,
+        Err(_) => {
+            reporter
+                .finish(
+                    name,
+                    started,
+                    CheckStatus::Fail,
+                    format!("timed out after {timeout_s}s"),
+                )
+                .await
+        }
+    }
 }
 
 /// One real turn through the typed client. Everything the wire returns

--- a/wirecheck/src/checks/claude.rs
+++ b/wirecheck/src/checks/claude.rs
@@ -150,9 +150,7 @@ async fn fork_carries_history(reporter: &Reporter) {
         .await;
     let fut = async {
         let source = uuid::Uuid::new_v4();
-        let builder = claude_codes::ClaudeCliBuilder::new()
-            .allow_recursion()
-            .session_id(source);
+        let builder = claude_codes::ClaudeCliBuilder::new().session_id(source);
         let mut client = claude_codes::AsyncClient::from_builder(builder)
             .await
             .map_err(|e| e.to_string())?;
@@ -164,7 +162,6 @@ async fn fork_carries_history(reporter: &Reporter) {
 
         let fork_id = uuid::Uuid::new_v4();
         let builder = claude_codes::ClaudeCliBuilder::new()
-            .allow_recursion()
             .fork_from(source.to_string())
             .session_id(fork_id);
         let mut fork = claude_codes::AsyncClient::from_builder(builder)
@@ -249,7 +246,6 @@ async fn approval_handshake(reporter: &Reporter) {
         .await;
     let fut = async {
         let child = claude_codes::ClaudeCliBuilder::new()
-            .allow_recursion()
             .permission_prompt_tool("stdio")
             .spawn()
             .await

--- a/wirecheck/src/checks/codex.rs
+++ b/wirecheck/src/checks/codex.rs
@@ -71,6 +71,158 @@ pub async fn run_suite(reporter: Reporter) {
     }
 
     live_turn(&reporter).await;
+    thread_fork(&reporter).await;
+    account_read_family(&reporter).await;
+}
+
+/// A fork gets a NEW thread id after a seeded turn — the history-carrying
+/// wire behavior downstream session forks rest on.
+async fn thread_fork(reporter: &Reporter) {
+    let started = reporter
+        .start(
+            "thread_fork",
+            "thread/fork returns a distinct thread after a seed turn",
+        )
+        .await;
+    let fut = async {
+        let mut client = codex_codes::AsyncClient::start()
+            .await
+            .map_err(|e| e.to_string())?;
+        let source = client
+            .thread_start(&ThreadStartParams::default())
+            .await
+            .map_err(|e| e.to_string())?;
+        client
+            .turn_start(&TurnStartParams {
+                thread_id: source.thread.id.clone(),
+                input: vec![UserInput::Text {
+                    text: "Reply with just OK.".to_string(),
+                    text_elements: None,
+                }],
+                approval_policy: None,
+                approvals_reviewer: None,
+                client_user_message_id: None,
+                cwd: None,
+                effort: None,
+                model: None,
+                output_schema: None,
+                personality: None,
+                sandbox_policy: None,
+                service_tier: None,
+                summary: None,
+            })
+            .await
+            .map_err(|e| e.to_string())?;
+        let mut n = 0usize;
+        while let Some(msg) = client.next_message().await.map_err(|e| e.to_string())? {
+            n += 1;
+            match msg {
+                ServerMessage::Notification(Notification::TurnCompleted(_)) => break,
+                ServerMessage::Notification(_) => {}
+                ServerMessage::Request { id, .. } => {
+                    client
+                        .respond(id, &serde_json::json!({"decision": "accept"}))
+                        .await
+                        .map_err(|e| e.to_string())?;
+                }
+            }
+            if n > 200 {
+                return Err("seed turn did not complete".to_string());
+            }
+        }
+        let fork = client
+            .thread_fork(
+                &serde_json::from_value(serde_json::json!({ "threadId": source.thread.id }))
+                    .map_err(|e| e.to_string())?,
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+        client.shutdown().await.map_err(|e| e.to_string())?;
+        if fork.thread.id.is_empty() || fork.thread.id == source.thread.id {
+            return Err(format!("bad fork id {:?}", fork.thread.id));
+        }
+        Ok(format!("{} → {}", source.thread.id, fork.thread.id))
+    };
+    match tokio::time::timeout(std::time::Duration::from_secs(120), fut).await {
+        Ok(Ok(detail)) => {
+            reporter
+                .finish("thread_fork", started, CheckStatus::Pass, detail)
+                .await
+        }
+        Ok(Err(e)) => {
+            reporter
+                .finish("thread_fork", started, CheckStatus::Fail, e)
+                .await
+        }
+        Err(_) => {
+            reporter
+                .finish(
+                    "thread_fork",
+                    started,
+                    CheckStatus::Fail,
+                    "timed out after 120s".into(),
+                )
+                .await
+        }
+    }
+}
+
+/// account/read family: typed requests go out and typed responses (or
+/// well-formed JSON-RPC errors — the usage backend can reject a locally
+/// valid token) come back.
+async fn account_read_family(reporter: &Reporter) {
+    let started = reporter
+        .start(
+            "account_reads",
+            "account/read + rateLimits + usage answer typed or as JSON-RPC errors",
+        )
+        .await;
+    let fut = async {
+        let mut client = codex_codes::AsyncClient::start()
+            .await
+            .map_err(|e| e.to_string())?;
+        client
+            .account_read(&codex_codes::protocol_generated::types::GetAccountParams::default())
+            .await
+            .map_err(|e| format!("account/read: {e}"))?;
+        for (name, result) in [
+            (
+                "rateLimits",
+                client.account_rate_limits_read().await.map(|_| ()),
+            ),
+            ("usage", client.account_usage_read().await.map(|_| ())),
+        ] {
+            match result {
+                Ok(()) => {}
+                Err(codex_codes::Error::JsonRpc { code: -32603, .. }) => {}
+                Err(other) => return Err(format!("account/{name}: transport failure: {other}")),
+            }
+        }
+        client.shutdown().await.map_err(|e| e.to_string())?;
+        Ok("all three account reads answered in protocol".to_string())
+    };
+    match tokio::time::timeout(std::time::Duration::from_secs(60), fut).await {
+        Ok(Ok(detail)) => {
+            reporter
+                .finish("account_reads", started, CheckStatus::Pass, detail)
+                .await
+        }
+        Ok(Err(e)) => {
+            reporter
+                .finish("account_reads", started, CheckStatus::Fail, e)
+                .await
+        }
+        Err(_) => {
+            reporter
+                .finish(
+                    "account_reads",
+                    started,
+                    CheckStatus::Fail,
+                    "timed out after 60s".into(),
+                )
+                .await
+        }
+    }
 }
 
 async fn live_turn(reporter: &Reporter) {

--- a/wirecheck/src/checks/codex.rs
+++ b/wirecheck/src/checks/codex.rs
@@ -1,0 +1,179 @@
+//! Codex wire checks: binary, local credential snapshot, and a live
+//! app-server session — initialize, thread_start, one turn driven to
+//! `TurnCompleted` through the typed JSON-RPC client.
+
+use crate::state::{CheckStatus, Reporter};
+use codex_codes::{Notification, ServerMessage, ThreadStartParams, TurnStartParams, UserInput};
+
+pub async fn run_suite(reporter: Reporter) {
+    let started = reporter.start("binary", "codex CLI present on PATH").await;
+    let version = tokio::process::Command::new("codex")
+        .arg("--version")
+        .output()
+        .await;
+    match &version {
+        Ok(o) if o.status.success() => {
+            reporter
+                .finish(
+                    "binary",
+                    started,
+                    CheckStatus::Pass,
+                    String::from_utf8_lossy(&o.stdout).trim().to_string(),
+                )
+                .await;
+        }
+        other => {
+            reporter
+                .finish("binary", started, CheckStatus::Fail, format!("{other:?}"))
+                .await;
+            return;
+        }
+    }
+
+    let started = reporter
+        .start("auth", "local credential snapshot (~/.codex/auth.json)")
+        .await;
+    let logged_in = match codex_codes::auth_local::auth_status_local() {
+        Ok(s) => {
+            let detail = format!("logged_in={} method={:?}", s.logged_in, s.auth_mode);
+            let st = if s.logged_in {
+                CheckStatus::Pass
+            } else {
+                CheckStatus::Fail
+            };
+            reporter.finish("auth", started, st, detail).await;
+            s.logged_in
+        }
+        Err(e) => {
+            reporter
+                .finish("auth", started, CheckStatus::Fail, e.to_string())
+                .await;
+            false
+        }
+    };
+
+    if !logged_in {
+        let started = reporter
+            .start(
+                "live_turn",
+                "app-server turn to TurnCompleted through typed JSON-RPC",
+            )
+            .await;
+        reporter
+            .finish(
+                "live_turn",
+                started,
+                CheckStatus::Skipped,
+                "not logged in — run `codex login` on this host (browser callback flow)".into(),
+            )
+            .await;
+        return;
+    }
+
+    live_turn(&reporter).await;
+}
+
+async fn live_turn(reporter: &Reporter) {
+    let started = reporter
+        .start(
+            "live_turn",
+            "app-server turn to TurnCompleted through typed JSON-RPC",
+        )
+        .await;
+    let fut = async {
+        let mut client = codex_codes::AsyncClient::start()
+            .await
+            .map_err(|e| e.to_string())?;
+        let thread = client
+            .thread_start(&ThreadStartParams::default())
+            .await
+            .map_err(|e| e.to_string())?;
+        if thread.thread.id.is_empty() {
+            return Err("thread_start returned an empty thread id".to_string());
+        }
+        client
+            .turn_start(&TurnStartParams {
+                thread_id: thread.thread.id.clone(),
+                input: vec![UserInput::Text {
+                    text: "What is 2 + 2? Reply with just the number.".to_string(),
+                    text_elements: None,
+                }],
+                approval_policy: None,
+                approvals_reviewer: None,
+                client_user_message_id: None,
+                cwd: None,
+                effort: None,
+                model: None,
+                output_schema: None,
+                personality: None,
+                sandbox_policy: None,
+                service_tier: None,
+                summary: None,
+            })
+            .await
+            .map_err(|e| e.to_string())?;
+
+        let mut notifications = 0usize;
+        let mut answered = false;
+        let mut completed = false;
+        while let Some(msg) = client.next_message().await.map_err(|e| e.to_string())? {
+            match msg {
+                ServerMessage::Notification(Notification::AgentMessageDelta(d)) => {
+                    notifications += 1;
+                    if d.delta.contains('4') {
+                        answered = true;
+                    }
+                }
+                ServerMessage::Notification(Notification::TurnCompleted(_)) => {
+                    completed = true;
+                    break;
+                }
+                ServerMessage::Notification(_) => notifications += 1,
+                ServerMessage::Request { id, .. } => {
+                    // Auto-accept approvals: this is a 2+2 turn in a scratch
+                    // thread; nothing it can ask for is consequential.
+                    client
+                        .respond(id, &serde_json::json!({"decision": "accept"}))
+                        .await
+                        .map_err(|e| e.to_string())?;
+                }
+            }
+            if notifications > 500 {
+                return Err("runaway notification stream (>500 before TurnCompleted)".to_string());
+            }
+        }
+        client.shutdown().await.map_err(|e| e.to_string())?;
+        if !completed {
+            return Err("stream ended without TurnCompleted".to_string());
+        }
+        if !answered {
+            return Err("no delta contained the expected answer".to_string());
+        }
+        Ok(format!(
+            "thread {}; {notifications} typed notifications to completion",
+            thread.thread.id
+        ))
+    };
+    match tokio::time::timeout(std::time::Duration::from_secs(120), fut).await {
+        Ok(Ok(detail)) => {
+            reporter
+                .finish("live_turn", started, CheckStatus::Pass, detail)
+                .await;
+        }
+        Ok(Err(e)) => {
+            reporter
+                .finish("live_turn", started, CheckStatus::Fail, e)
+                .await;
+        }
+        Err(_) => {
+            reporter
+                .finish(
+                    "live_turn",
+                    started,
+                    CheckStatus::Fail,
+                    "timed out after 120s".into(),
+                )
+                .await;
+        }
+    }
+}

--- a/wirecheck/src/checks/codex.rs
+++ b/wirecheck/src/checks/codex.rs
@@ -35,7 +35,11 @@ pub async fn run_suite(reporter: Reporter) {
         .await;
     let logged_in = match codex_codes::auth_local::auth_status_local() {
         Ok(s) => {
-            let detail = format!("logged_in={} method={:?}", s.logged_in, s.auth_mode);
+            let detail = format!(
+                "logged_in={} method={}",
+                s.logged_in,
+                s.auth_mode.as_deref().unwrap_or("-")
+            );
             let st = if s.logged_in {
                 CheckStatus::Pass
             } else {

--- a/wirecheck/src/checks/mod.rs
+++ b/wirecheck/src/checks/mod.rs
@@ -1,6 +1,7 @@
 //! Per-agent check suites. Each suite reports into the shared state via
 //! [`crate::state::Reporter`] as it goes, so the page shows progress live.
 
+pub mod cargo_suite;
 pub mod claude;
 pub mod codex;
 pub mod muse;

--- a/wirecheck/src/checks/mod.rs
+++ b/wirecheck/src/checks/mod.rs
@@ -4,3 +4,4 @@
 pub mod claude;
 pub mod codex;
 pub mod muse;
+pub mod opencode;

--- a/wirecheck/src/checks/mod.rs
+++ b/wirecheck/src/checks/mod.rs
@@ -1,0 +1,6 @@
+//! Per-agent check suites. Each suite reports into the shared state via
+//! [`crate::state::Reporter`] as it goes, so the page shows progress live.
+
+pub mod claude;
+pub mod codex;
+pub mod muse;

--- a/wirecheck/src/checks/muse.rs
+++ b/wirecheck/src/checks/muse.rs
@@ -22,6 +22,10 @@ pub async fn run_suite(reporter: Reporter) {
         session_id_adoption(&reporter, records).await;
     }
     record_id_counter_trap(&reporter).await;
+    continuity_across_turns(&reporter).await;
+    interrupt_is_a_safe_kill(&reporter).await;
+    flag_surface_accepted(&reporter).await;
+    meta_only_flags_rejected(&reporter).await;
 
     if muse_codes::auth::credentials_present() {
         live_meta_checks(&reporter).await;
@@ -406,6 +410,239 @@ async fn live_meta_checks(reporter: &Reporter) {
     }
 
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Multi-turn continuity: same `--session-id` across two processes means
+/// same `stream.id`, per-turn sequence restart, and NO record-id repeats
+/// within the session — the exact identity rules consumers key on.
+async fn continuity_across_turns(reporter: &Reporter) {
+    let started = reporter
+        .start(
+            "continuity",
+            "two turns, one session: stream stable, sequence restarts, ids unique within session",
+        )
+        .await;
+    let session = uuid_v4();
+    let one = capture(
+        MuseExecBuilder::new("turn one")
+            .provider(Provider::Echo)
+            .session_id(&session),
+        60,
+    )
+    .await;
+    let two = capture(
+        MuseExecBuilder::new("turn two")
+            .provider(Provider::Echo)
+            .session_id(&session),
+        60,
+    )
+    .await;
+    let (one, two) = match (one, two) {
+        (Ok(a), Ok(b)) => (a, b),
+        (a, b) => {
+            reporter
+                .finish(
+                    "continuity",
+                    started,
+                    CheckStatus::Fail,
+                    format!("capture failed: turn1={} turn2={}", a.is_ok(), b.is_ok()),
+                )
+                .await;
+            return;
+        }
+    };
+    let mut problems = Vec::new();
+    for r in one.iter().chain(&two) {
+        if r.stream.kind == muse_codes::StreamKind::Session && r.stream.id != session {
+            problems.push(format!("session stream drifted to {}", r.stream.id));
+        }
+    }
+    let min1 = one.iter().map(|r| r.sequence).min().unwrap_or(0);
+    let min2 = two.iter().map(|r| r.sequence).min().unwrap_or(0);
+    if min2 > min1 + 5 {
+        problems.push(format!(
+            "sequence did not restart on turn 2 (turn1 min {min1}, turn2 min {min2}) — \
+             if muse made sequences session-continuous, ordering rules changed"
+        ));
+    }
+    let ids1: BTreeSet<&str> = one.iter().map(|r| r.id.as_str()).collect();
+    let repeats = two.iter().filter(|r| ids1.contains(r.id.as_str())).count();
+    if repeats > 0 {
+        problems.push(format!(
+            "{repeats} record ids repeated ACROSS TURNS within one session — \
+             (stream_id, id) would collide; persistence keying is broken"
+        ));
+    }
+    finish_list(reporter, "continuity", started, problems, || {
+        format!(
+            "stream stable, sequences restart ({min1}→{min2}), {} + {} unique ids",
+            one.len(),
+            two.len()
+        )
+    })
+    .await;
+}
+
+/// There is no interrupt protocol: SIGKILL mid-run must leave the session
+/// store usable, so the next turn on the same id runs clean.
+async fn interrupt_is_a_safe_kill(reporter: &Reporter) {
+    let started = reporter
+        .start(
+            "interrupt_kill",
+            "SIGKILL mid-run leaves the session resumable",
+        )
+        .await;
+    let session = uuid_v4();
+    let spawn = MuseExecBuilder::new("about to be killed")
+        .provider(Provider::Echo)
+        .session_id(&session)
+        .spawn()
+        .await;
+    let mut child = match spawn {
+        Ok(c) => c,
+        Err(e) => {
+            reporter
+                .finish("interrupt_kill", started, CheckStatus::Fail, e.to_string())
+                .await;
+            return;
+        }
+    };
+    // 60ms: early enough that the echo run (~250ms) is genuinely mid-flight.
+    tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+    let _ = child.kill().await;
+    match capture(
+        MuseExecBuilder::new("resumed after kill")
+            .provider(Provider::Echo)
+            .session_id(&session),
+        60,
+    )
+    .await
+    {
+        Ok(records) => {
+            reporter
+                .finish(
+                    "interrupt_kill",
+                    started,
+                    CheckStatus::Pass,
+                    format!(
+                        "resume turn reached terminal with {} records",
+                        records.len()
+                    ),
+                )
+                .await;
+        }
+        Err(e) => {
+            reporter
+                .finish(
+                    "interrupt_kill",
+                    started,
+                    CheckStatus::Fail,
+                    format!("session did not survive a mid-run kill: {e}"),
+                )
+                .await;
+        }
+    }
+}
+
+/// The full echo-safe `muse exec` flag surface is still accepted — a CLI
+/// release that drops or renames a flag fails here, not in production.
+async fn flag_surface_accepted(reporter: &Reporter) {
+    let started = reporter
+        .start(
+            "flag_surface",
+            "echo-safe builder flag surface accepted by the CLI",
+        )
+        .await;
+    let dir = std::env::temp_dir().join(format!("wirecheck-flags-{}", uuid_v4()));
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        reporter
+            .finish("flag_surface", started, CheckStatus::Fail, e.to_string())
+            .await;
+        return;
+    }
+    let prompt_file = dir.join("prompt.txt");
+    let _ = std::fs::write(&prompt_file, "flag surface probe");
+    let builder = MuseExecBuilder::new("")
+        .prompt_file(&prompt_file)
+        .provider(Provider::Echo)
+        .session_id(uuid_v4())
+        .workspace(&dir)
+        .context_compaction_strategy("summary-preserved-suffix/v1")
+        .context_compaction_soft_threshold(0.7)
+        .context_compaction_hard_threshold(0.9)
+        .max_model_steps(5)
+        .max_tool_output_bytes(10_000)
+        .allow_workspace_switch(true)
+        .user_input_auto_resolve(true)
+        .subagent_worktree_isolation(true)
+        .disable_web_tools(true)
+        .no_foreign_personal_context(true)
+        .trust_workspace(true)
+        .disable_approval(true)
+        .disable_sandbox(true)
+        .sandbox_network("proxy-only")
+        .disable_write(true)
+        .disable_shell(true)
+        .working_directory(&dir);
+    match capture(builder, 60).await {
+        Ok(records) => {
+            reporter
+                .finish(
+                    "flag_surface",
+                    started,
+                    CheckStatus::Pass,
+                    format!("all flags accepted; {} records to terminal", records.len()),
+                )
+                .await;
+        }
+        Err(e) => {
+            reporter
+                .finish("flag_surface", started, CheckStatus::Fail, e)
+                .await;
+        }
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The documented cross-flag constraints are real CLI behavior: meta-only
+/// flags must fail FAST under the echo provider, not start a run.
+async fn meta_only_flags_rejected(reporter: &Reporter) {
+    let started = reporter
+        .start(
+            "flag_constraints",
+            "meta-only flags rejected at startup under echo",
+        )
+        .await;
+    let mut problems = Vec::new();
+    for (label, builder) in [
+        (
+            "--parallel-tool-calls",
+            MuseExecBuilder::new("hi")
+                .provider(Provider::Echo)
+                .parallel_tool_calls(true),
+        ),
+        (
+            "--api-key-stdin",
+            MuseExecBuilder::new("hi")
+                .provider(Provider::Echo)
+                .api_key_stdin(true),
+        ),
+    ] {
+        match builder.spawn().await {
+            Ok(mut child) => {
+                match tokio::time::timeout(std::time::Duration::from_secs(20), child.wait()).await {
+                    Ok(Ok(status)) if !status.success() => {}
+                    Ok(Ok(_)) => problems.push(format!("{label} was ACCEPTED under echo")),
+                    other => problems.push(format!("{label}: {other:?}")),
+                }
+            }
+            Err(e) => problems.push(format!("{label}: spawn failed: {e}")),
+        }
+    }
+    finish_list(reporter, "flag_constraints", started, problems, || {
+        "both meta-only flags fail fast under echo, as documented".to_string()
+    })
+    .await;
 }
 
 // ── plumbing ─────────────────────────────────────────────────────────

--- a/wirecheck/src/checks/muse.rs
+++ b/wirecheck/src/checks/muse.rs
@@ -1,0 +1,494 @@
+//! Muse Code wire checks.
+//!
+//! Two tiers: the echo tier runs credential-free and pins the envelope
+//! contract; the live tier (Meta provider) covers exactly what the nightly
+//! echo-only drift fingerprint cannot — the provider-only vocabulary
+//! (`tool.result`, `run.model.configured`, live task lifecycle) and the
+//! tool-name ↔ `tool.<name>`-task correlation consumers key on.
+
+use crate::state::{CheckStatus, Reporter};
+use muse_codes::{ExecRun, MuseExecBuilder, MusePayload, MuseRecord, Provider};
+use std::collections::{BTreeMap, BTreeSet};
+
+pub async fn run_suite(reporter: Reporter) {
+    let Some(version) = binary_check(&reporter).await else {
+        return; // no binary — every other check is meaningless
+    };
+    let _ = version;
+
+    let echo = echo_capture(&reporter).await;
+    if let Some(records) = &echo {
+        envelope_invariants(&reporter, records).await;
+        session_id_adoption(&reporter, records).await;
+    }
+    record_id_counter_trap(&reporter).await;
+
+    if muse_codes::auth::credentials_present() {
+        live_meta_checks(&reporter).await;
+    } else {
+        let started = reporter
+            .start(
+                "meta_live",
+                "live-provider vocabulary (typed audit, tool correlation, answer text)",
+            )
+            .await;
+        reporter
+            .finish(
+                "meta_live",
+                started,
+                CheckStatus::Skipped,
+                "no Meta credentials — log in above to enable the live tier".into(),
+            )
+            .await;
+    }
+}
+
+async fn binary_check(reporter: &Reporter) -> Option<String> {
+    let started = reporter.start("binary", "muse CLI present on PATH").await;
+    let out = tokio::process::Command::new("muse")
+        .arg("--version")
+        .output()
+        .await;
+    match out {
+        Ok(o) if o.status.success() => {
+            let v = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            reporter
+                .finish("binary", started, CheckStatus::Pass, v.clone())
+                .await;
+            Some(v)
+        }
+        other => {
+            reporter
+                .finish(
+                    "binary",
+                    started,
+                    CheckStatus::Fail,
+                    format!("muse --version failed: {other:?}"),
+                )
+                .await;
+            None
+        }
+    }
+}
+
+/// One echo run to its terminal, records collected. Reported as its own
+/// check so a hang here is visible rather than blocking silently.
+async fn echo_capture(reporter: &Reporter) -> Option<Vec<MuseRecord>> {
+    let started = reporter
+        .start(
+            "echo_stream",
+            "echo run reaches run.terminal.* and every line parses",
+        )
+        .await;
+    match capture(
+        MuseExecBuilder::new("wirecheck echo probe").provider(Provider::Echo),
+        60,
+    )
+    .await
+    {
+        Ok(records) => {
+            reporter
+                .finish(
+                    "echo_stream",
+                    started,
+                    CheckStatus::Pass,
+                    format!("{} records to terminal", records.len()),
+                )
+                .await;
+            Some(records)
+        }
+        Err(e) => {
+            reporter
+                .finish("echo_stream", started, CheckStatus::Fail, e)
+                .await;
+            None
+        }
+    }
+}
+
+/// Envelope contract: schema_version stable, sequence strictly increasing
+/// within each stream, and every payload lifts into a typed variant.
+async fn envelope_invariants(reporter: &Reporter, records: &[MuseRecord]) {
+    let started = reporter
+        .start(
+            "envelope",
+            "schema_version, per-stream sequence monotonicity, typed lift",
+        )
+        .await;
+    let mut problems = Vec::new();
+    let mut last_seq: BTreeMap<&str, u64> = BTreeMap::new();
+    for r in records {
+        if r.schema_version != 1 {
+            problems.push(format!(
+                "schema_version {} on {}",
+                r.schema_version, r.payload_type
+            ));
+        }
+        if let Some(prev) = last_seq.get(r.stream.id.as_str()) {
+            if r.sequence <= *prev {
+                problems.push(format!(
+                    "sequence not increasing in stream {}: {} after {}",
+                    r.stream.id, r.sequence, prev
+                ));
+            }
+        }
+        last_seq.insert(&r.stream.id, r.sequence);
+        if let Err(e) = r.typed_payload() {
+            problems.push(format!("{} failed typed lift: {e}", r.payload_type));
+        }
+    }
+    finish_list(reporter, "envelope", started, problems, || {
+        format!(
+            "{} records clean across {} streams",
+            records.len(),
+            last_seq.len()
+        )
+    })
+    .await;
+}
+
+/// A caller-supplied `--session-id` must be adopted verbatim as the session
+/// `stream.id` — the property the composite persistence key rests on.
+async fn session_id_adoption(reporter: &Reporter, prior: &[MuseRecord]) {
+    let started = reporter
+        .start(
+            "session_identity",
+            "--session-id adopted verbatim as stream.id",
+        )
+        .await;
+    let supplied = uuid_v4();
+    match capture(
+        MuseExecBuilder::new("identity probe")
+            .provider(Provider::Echo)
+            .session_id(&supplied),
+        60,
+    )
+    .await
+    {
+        Ok(records) => {
+            let session_streams: BTreeSet<&str> = records
+                .iter()
+                .filter(|r| r.stream.kind == muse_codes::StreamKind::Session)
+                .map(|r| r.stream.id.as_str())
+                .collect();
+            if session_streams.contains(supplied.as_str()) {
+                reporter
+                    .finish(
+                        "session_identity",
+                        started,
+                        CheckStatus::Pass,
+                        format!("stream.id == supplied id ({supplied})"),
+                    )
+                    .await;
+            } else {
+                reporter
+                    .finish(
+                        "session_identity",
+                        started,
+                        CheckStatus::Fail,
+                        format!("supplied {supplied}, session streams: {session_streams:?}"),
+                    )
+                    .await;
+            }
+            let _ = prior;
+        }
+        Err(e) => {
+            reporter
+                .finish("session_identity", started, CheckStatus::Fail, e)
+                .await;
+        }
+    }
+}
+
+/// Record ids are UUID-shaped COUNTERS: two fresh sessions must emit
+/// byte-identical id sequences. If this ever fails, Meta fixed the counter
+/// and the composite-key documentation should be revisited.
+async fn record_id_counter_trap(reporter: &Reporter) {
+    let started = reporter
+        .start(
+            "id_counter_trap",
+            "record ids repeat byte-identical across sessions",
+        )
+        .await;
+    let a = capture(MuseExecBuilder::new("ids a").provider(Provider::Echo), 60).await;
+    let b = capture(MuseExecBuilder::new("ids b").provider(Provider::Echo), 60).await;
+    match (a, b) {
+        (Ok(a), Ok(b)) => {
+            let ids_a: Vec<&str> = a.iter().map(|r| r.id.as_str()).collect();
+            let ids_b: Vec<&str> = b.iter().map(|r| r.id.as_str()).collect();
+            let overlap = ids_a.iter().filter(|id| ids_b.contains(id)).count();
+            if overlap > 0 {
+                reporter
+                    .finish(
+                        "id_counter_trap",
+                        started,
+                        CheckStatus::Pass,
+                        format!(
+                            "{overlap}/{} ids collide across sessions — ids are counters; \
+                             composite (stream_id, id) keying remains required",
+                            ids_a.len()
+                        ),
+                    )
+                    .await;
+            } else {
+                reporter
+                    .finish(
+                        "id_counter_trap",
+                        started,
+                        CheckStatus::Fail,
+                        "no cross-session id collisions: Meta may have fixed the counter — \
+                         re-measure before relaxing any keying rules"
+                            .into(),
+                    )
+                    .await;
+            }
+        }
+        (a, b) => {
+            reporter
+                .finish(
+                    "id_counter_trap",
+                    started,
+                    CheckStatus::Fail,
+                    format!("capture failed: a={:?} b={:?}", a.is_ok(), b.is_ok()),
+                )
+                .await;
+        }
+    }
+}
+
+/// One live Meta tool-use turn evaluated for several properties at once —
+/// one model turn, four checks, so the live tier stays cheap.
+async fn live_meta_checks(reporter: &Reporter) {
+    let started = reporter
+        .start("meta_capture", "live Meta tool-use turn reaches terminal")
+        .await;
+    let dir = std::env::temp_dir().join(format!("wirecheck-muse-{}", uuid_v4()));
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        reporter
+            .finish("meta_capture", started, CheckStatus::Fail, e.to_string())
+            .await;
+        return;
+    }
+    let records = match capture(
+        MuseExecBuilder::new(
+            "Use your file tools: create a file named probe.txt containing the word hello, \
+             then read it back and reply with its contents.",
+        )
+        .provider(Provider::Meta)
+        .working_directory(&dir),
+        300,
+    )
+    .await
+    {
+        Ok(r) => {
+            reporter
+                .finish(
+                    "meta_capture",
+                    started,
+                    CheckStatus::Pass,
+                    format!("{} records", r.len()),
+                )
+                .await;
+            r
+        }
+        Err(e) => {
+            reporter
+                .finish("meta_capture", started, CheckStatus::Fail, e)
+                .await;
+            return;
+        }
+    };
+
+    // 1. Strict typed audit — the drift catcher the nightly can't reach.
+    let started = reporter
+        .start(
+            "meta_typed_audit",
+            "every live record lifts into a typed payload (no Unknown)",
+        )
+        .await;
+    let mut unknown: BTreeSet<String> = BTreeSet::new();
+    let mut failed: Vec<String> = Vec::new();
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for r in &records {
+        seen.insert(r.payload_type.as_str());
+        match r.typed_payload() {
+            Ok(MusePayload::Unknown { .. }) => {
+                unknown.insert(r.payload_type.clone());
+            }
+            Ok(_) => {}
+            Err(e) => failed.push(format!("{}: {e}", r.payload_type)),
+        }
+    }
+    let mut problems: Vec<String> = unknown
+        .iter()
+        .map(|t| format!("untyped payload_type on the live wire: {t}"))
+        .collect();
+    problems.extend(failed);
+    finish_list(reporter, "meta_typed_audit", started, problems, || {
+        format!("{} payload types, all typed: {seen:?}", seen.len())
+    })
+    .await;
+
+    // 2. Tool correlation — each tool.result names a tool whose
+    //    `tool.<name>` task exists in the same turn.
+    let started = reporter
+        .start(
+            "tool_correlation",
+            "tool.result ↔ tool.<name> task kind-match holds live",
+        )
+        .await;
+    let tool_tasks: BTreeSet<String> = records
+        .iter()
+        .filter_map(|r| {
+            let ev = r.payload.get("event")?;
+            (ev.get("kind")?.as_str()? == "proposed")
+                .then(|| ev.get("task_kind")?.as_str().map(str::to_string))?
+        })
+        .filter(|k| k.starts_with("tool."))
+        .collect();
+    let results: Vec<&MuseRecord> = records
+        .iter()
+        .filter(|r| r.payload_type == "tool.result")
+        .collect();
+    let mut problems = Vec::new();
+    if results.is_empty() {
+        problems.push("model used no tools despite the prompt — rerun the suite".to_string());
+    }
+    for r in &results {
+        let name = r
+            .payload
+            .get("correlation_facts")
+            .and_then(|f| f.get("tool_name"))
+            .and_then(|t| t.as_str());
+        match name {
+            Some(n) if tool_tasks.contains(&format!("tool.{n}")) => {}
+            Some(n) => problems.push(format!("tool.result '{n}' has no matching tool.{n} task")),
+            None => problems.push("tool.result without correlation_facts.tool_name".to_string()),
+        }
+    }
+    finish_list(reporter, "tool_correlation", started, problems, || {
+        format!(
+            "{} tool results, all matched to {:?}",
+            results.len(),
+            tool_tasks
+        )
+    })
+    .await;
+
+    // 3. The answer is on the terminal record, non-empty.
+    let started = reporter
+        .start("answer_text", "run.terminal.* carries the reply text")
+        .await;
+    let text = records
+        .iter()
+        .filter(|r| r.payload_type.starts_with("run.terminal."))
+        .filter_map(|r| r.payload.get("text").and_then(|t| t.as_str()))
+        .next_back()
+        .unwrap_or("");
+    if text.trim().is_empty() {
+        reporter
+            .finish(
+                "answer_text",
+                started,
+                CheckStatus::Fail,
+                "terminal record has no text".into(),
+            )
+            .await;
+    } else {
+        reporter
+            .finish(
+                "answer_text",
+                started,
+                CheckStatus::Pass,
+                format!("{} chars of reply text", text.len()),
+            )
+            .await;
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ── plumbing ─────────────────────────────────────────────────────────
+
+async fn capture(builder: MuseExecBuilder, timeout_s: u64) -> Result<Vec<MuseRecord>, String> {
+    let fut = async {
+        let mut run = ExecRun::spawn(&builder).await.map_err(|e| e.to_string())?;
+        let mut records = Vec::new();
+        while let Some(record) = run.next_record().await.map_err(|e| e.to_string())? {
+            let terminal = record.payload_type.starts_with("run.terminal.");
+            records.push(record);
+            if terminal {
+                break;
+            }
+        }
+        Ok::<_, String>(records)
+    };
+    tokio::time::timeout(std::time::Duration::from_secs(timeout_s), fut)
+        .await
+        .map_err(|_| format!("timed out after {timeout_s}s"))?
+}
+
+async fn finish_list(
+    reporter: &Reporter,
+    name: &'static str,
+    started: std::time::Instant,
+    problems: Vec<String>,
+    pass_detail: impl FnOnce() -> String,
+) {
+    if problems.is_empty() {
+        reporter
+            .finish(name, started, CheckStatus::Pass, pass_detail())
+            .await;
+    } else {
+        reporter
+            .finish(name, started, CheckStatus::Fail, problems.join("; "))
+            .await;
+    }
+}
+
+/// Random v4-shaped id without a uuid dependency.
+fn uuid_v4() -> String {
+    let mut bytes = [0u8; 16];
+    // getrandom via std: fill from a hasher over time+pid is NOT random
+    // enough for crypto but fine for a probe session id.
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos() as u64
+        ^ (std::process::id() as u64) << 32
+        ^ SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+    let mut seed = nanos | 1;
+    for b in bytes.iter_mut() {
+        // xorshift64*
+        seed ^= seed << 13;
+        seed ^= seed >> 7;
+        seed ^= seed << 17;
+        *b = (seed & 0xff) as u8;
+    }
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    let h: Vec<String> = bytes.iter().map(|b| format!("{b:02x}")).collect();
+    format!(
+        "{}{}{}{}-{}{}-{}{}-{}{}-{}{}{}{}{}{}",
+        h[0],
+        h[1],
+        h[2],
+        h[3],
+        h[4],
+        h[5],
+        h[6],
+        h[7],
+        h[8],
+        h[9],
+        h[10],
+        h[11],
+        h[12],
+        h[13],
+        h[14],
+        h[15]
+    )
+}

--- a/wirecheck/src/checks/opencode.rs
+++ b/wirecheck/src/checks/opencode.rs
@@ -1,0 +1,234 @@
+//! opencode wire checks. No credentials needed for the lifecycle tier:
+//! the suite spawns its own `opencode serve` via [`ManagedServer`], so
+//! these checks pin the HTTP+SSE wire against a real server every run.
+
+use crate::state::{CheckStatus, Reporter};
+use opencode_codes::protocol_generated::types::SessionCreateParams;
+use opencode_codes::OpencodeClient;
+use std::time::Duration;
+
+pub async fn run_suite(reporter: Reporter) {
+    let started = reporter
+        .start("binary", "opencode CLI present on PATH")
+        .await;
+    let version = tokio::process::Command::new("opencode")
+        .arg("--version")
+        .output()
+        .await;
+    match &version {
+        Ok(o) if o.status.success() => {
+            reporter
+                .finish(
+                    "binary",
+                    started,
+                    CheckStatus::Pass,
+                    String::from_utf8_lossy(&o.stdout).trim().to_string(),
+                )
+                .await;
+        }
+        other => {
+            reporter
+                .finish("binary", started, CheckStatus::Fail, format!("{other:?}"))
+                .await;
+            return;
+        }
+    }
+
+    let started = reporter
+        .start(
+            "managed_server",
+            "spawn `opencode serve` and reach it over HTTP",
+        )
+        .await;
+    let server = match opencode_codes::server::ManagedServer::builder()
+        .startup_timeout(Duration::from_secs(30))
+        .spawn()
+        .await
+    {
+        Ok(s) => {
+            reporter
+                .finish(
+                    "managed_server",
+                    started,
+                    CheckStatus::Pass,
+                    s.url().to_string(),
+                )
+                .await;
+            s
+        }
+        Err(e) => {
+            reporter
+                .finish("managed_server", started, CheckStatus::Fail, e.to_string())
+                .await;
+            return;
+        }
+    };
+    let client = match OpencodeClient::builder()
+        .base_url(server.url())
+        .timeout(Duration::from_secs(30))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            let started = reporter.start("session_lifecycle", "client builds").await;
+            reporter
+                .finish(
+                    "session_lifecycle",
+                    started,
+                    CheckStatus::Fail,
+                    e.to_string(),
+                )
+                .await;
+            return;
+        }
+    };
+
+    session_lifecycle(&reporter, &client).await;
+    fork_session(&reporter, &client).await;
+    event_stream(&reporter, &client).await;
+
+    let started = reporter
+        .start("server_shutdown", "managed server stops cleanly")
+        .await;
+    match server.stop().await {
+        Ok(()) => {
+            reporter
+                .finish(
+                    "server_shutdown",
+                    started,
+                    CheckStatus::Pass,
+                    "stopped".into(),
+                )
+                .await;
+        }
+        Err(e) => {
+            reporter
+                .finish("server_shutdown", started, CheckStatus::Fail, e.to_string())
+                .await;
+        }
+    }
+}
+
+fn params(title: &str) -> SessionCreateParams {
+    SessionCreateParams {
+        title: Some(title.to_string()),
+        agent: None,
+        metadata: None,
+        model: None,
+        parent_id: None,
+        permission: None,
+        workspace_id: None,
+    }
+}
+
+/// create → list-messages(empty) → abort: the basic session wire cycle.
+async fn session_lifecycle(reporter: &Reporter, client: &OpencodeClient) {
+    let started = reporter
+        .start(
+            "session_lifecycle",
+            "create → list (empty) → abort round trip",
+        )
+        .await;
+    let fut = async {
+        let session = client
+            .create_session(&params("wirecheck lifecycle"))
+            .await
+            .map_err(|e| e.to_string())?;
+        if !session.id.starts_with("ses") {
+            return Err(format!("unexpected session id shape: {}", session.id));
+        }
+        let messages = client
+            .list_messages(&session.id)
+            .await
+            .map_err(|e| e.to_string())?;
+        if !messages.is_empty() {
+            return Err(format!(
+                "fresh session already has {} messages",
+                messages.len()
+            ));
+        }
+        let _: bool = client.abort(&session.id).await.map_err(|e| e.to_string())?;
+        Ok(format!("session {} created, listed, aborted", session.id))
+    };
+    finish_timed(reporter, "session_lifecycle", started, 60, fut).await;
+}
+
+/// Forking returns a NEW session id tied to the same server.
+async fn fork_session(reporter: &Reporter, client: &OpencodeClient) {
+    let started = reporter
+        .start("fork_session", "fork returns a distinct new session")
+        .await;
+    let fut = async {
+        let source = client
+            .create_session(&params("wirecheck fork source"))
+            .await
+            .map_err(|e| e.to_string())?;
+        let fork = client
+            .create_session(&SessionCreateParams {
+                parent_id: Some(source.id.clone()),
+                ..params("wirecheck fork")
+            })
+            .await
+            .map_err(|e| e.to_string())?;
+        if fork.id == source.id {
+            return Err("fork returned the source id".to_string());
+        }
+        Ok(format!("{} → {}", source.id, fork.id))
+    };
+    finish_timed(reporter, "fork_session", started, 60, fut).await;
+}
+
+/// The SSE event stream connects and emits at least one well-formed frame.
+async fn event_stream(reporter: &Reporter, client: &OpencodeClient) {
+    let started = reporter
+        .start(
+            "event_stream",
+            "SSE stream connects and yields a typed frame",
+        )
+        .await;
+    let fut = async {
+        let mut stream = client
+            .event_stream(Default::default())
+            .map_err(|e| e.to_string())?;
+        // Creating a session while subscribed guarantees at least one event.
+        let _ = client.create_session(&params("wirecheck sse ping")).await;
+        match tokio::time::timeout(Duration::from_secs(20), stream.next()).await {
+            Ok(Some(Ok(event))) => Ok(if event.is_connected() {
+                "connected frame received".to_string()
+            } else {
+                "typed event frame received".to_string()
+            }),
+            Ok(Some(Err(e))) => Err(e.to_string()),
+            Ok(None) => Err("stream ended without a frame".to_string()),
+            Err(_) => Err("no frame within 20s".to_string()),
+        }
+    };
+    finish_timed(reporter, "event_stream", started, 60, fut).await;
+}
+
+async fn finish_timed(
+    reporter: &Reporter,
+    name: &'static str,
+    started: std::time::Instant,
+    timeout_s: u64,
+    fut: impl std::future::Future<Output = Result<String, String>>,
+) {
+    match tokio::time::timeout(Duration::from_secs(timeout_s), fut).await {
+        Ok(Ok(detail)) => {
+            reporter
+                .finish(name, started, CheckStatus::Pass, detail)
+                .await
+        }
+        Ok(Err(e)) => reporter.finish(name, started, CheckStatus::Fail, e).await,
+        Err(_) => {
+            reporter
+                .finish(
+                    name,
+                    started,
+                    CheckStatus::Fail,
+                    format!("timed out after {timeout_s}s"),
+                )
+                .await
+        }
+    }
+}

--- a/wirecheck/src/html.rs
+++ b/wirecheck/src/html.rs
@@ -39,7 +39,7 @@ pub const PAGE: &str = r#"<!doctype html>
   <button style="float:right" onclick="post('/api/refresh')">refresh auth</button></h1>
 <div class="cards" id="cards"></div>
 <script>
-const AGENTS = ["claude","codex","muse"];
+const AGENTS = ["claude","codex","muse","opencode"];
 async function post(url, body){ await fetch(url,{method:"POST",headers:{"content-type":"application/json"},body:body?JSON.stringify(body):null}); tick(); }
 function esc(s){ const d=document.createElement("div"); d.innerText=s??""; return d.innerHTML; }
 function icon(st){ return {pass:"✔",fail:"✘",running:"◌",skipped:"–"}[st]||"?"; }
@@ -67,8 +67,10 @@ function loginBlock(name, p){
   } else if(name==="claude"){
     controls = `<button onclick="post('/api/login/claude/start',{mode:'claudeai'})">claude.ai login</button>
       <button onclick="post('/api/login/claude/start',{mode:'console'})">console login</button>`;
-  } else {
+  } else if(name==="codex"){
     controls = `<span class="what">login: run <b>codex login</b> on the host (browser callback flow)</span>`;
+  } else {
+    controls = `<span class="what">no credentials needed — the suite spawns its own <b>opencode serve</b></span>`;
   }
   return `<div class="login">${controls}${inner?"<div style='margin-top:.4rem'>"+inner+"</div>":""}</div>`;
 }

--- a/wirecheck/src/html.rs
+++ b/wirecheck/src/html.rs
@@ -89,7 +89,14 @@ function card(name, p){
     ${loginBlock(name,p)}
     <button onclick="post('/api/checks/${name}')" ${p.checks_running?"disabled":""}>
       ${p.checks_running?"running…":"run checks"}</button>
+    <button onclick="post('/api/suite/${name}')" ${p.cargo_running?"disabled":""}>
+      ${p.cargo_running?"cargo tests running…":"run cargo integration tests"}</button>
     <ul class="checks">${checks}</ul>
+    ${(p.cargo_tests&&p.cargo_tests.length)||p.cargo_status?`
+      <div class="what" style="margin-top:.6rem">cargo integration tests${p.cargo_status?` — ${esc(p.cargo_status)}`:""}</div>
+      <ul class="checks">${(p.cargo_tests||[]).map(c=>`
+        <li><span class="st ${c.status}">${icon(c.status)}</span>${esc(c.name)}
+            ${c.detail?`<div class="detail">${esc(c.detail)}</div>`:""}</li>`).join("")}</ul>`:""}
   </div>`;
 }
 

--- a/wirecheck/src/html.rs
+++ b/wirecheck/src/html.rs
@@ -1,0 +1,105 @@
+//! The dashboard: one inline page, no build step. Polls `/api/state` and
+//! renders per-agent cards — auth badge, login controls, check results.
+
+pub const PAGE: &str = r#"<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>wirecheck</title>
+<style>
+  :root { color-scheme: dark; }
+  body { background:#1a1b26; color:#c0caf5; font:14px/1.5 ui-monospace,monospace; margin:0; padding:1.5rem; }
+  h1 { font-size:1.1rem; letter-spacing:.06em; }
+  h1 .sub { color:#565f89; font-weight:normal; font-size:.8rem; margin-left:.6rem; }
+  .cards { display:grid; grid-template-columns:repeat(auto-fit,minmax(340px,1fr)); gap:1rem; }
+  .card { background:#16161e; border:1px solid #2f334d; border-radius:.5rem; padding:1rem; }
+  .card h2 { margin:0 0 .4rem; font-size:1rem; text-transform:capitalize; display:flex; align-items:center; gap:.5rem; }
+  .badge { font-size:.7rem; padding:.1rem .45rem; border-radius:.25rem; background:#2f334d; }
+  .badge.ok { color:#9ece6a; } .badge.no { color:#f7768e; }
+  .ver { color:#565f89; font-size:.75rem; }
+  .login { margin:.6rem 0; padding:.5rem; border:1px dashed #2f334d; border-radius:.4rem; }
+  .login a { color:#7aa2f7; word-break:break-all; }
+  .login .code { font-size:1.2rem; color:#e0af68; letter-spacing:.15em; }
+  button { background:#2f334d; color:#c0caf5; border:0; border-radius:.3rem; padding:.35rem .7rem; cursor:pointer; font:inherit; font-size:.8rem; }
+  button:hover { background:#414868; }
+  input { background:#1a1b26; color:#c0caf5; border:1px solid #2f334d; border-radius:.3rem; padding:.3rem .5rem; font:inherit; font-size:.8rem; }
+  ul.checks { list-style:none; margin:.6rem 0 0; padding:0; }
+  ul.checks li { padding:.3rem 0; border-top:1px solid #1f2335; }
+  .st { display:inline-block; width:1.2rem; }
+  .st.pass { color:#9ece6a; } .st.fail { color:#f7768e; } .st.running { color:#7aa2f7; } .st.skipped { color:#565f89; }
+  .what { color:#565f89; font-size:.75rem; }
+  .detail { color:#a9b1d6; font-size:.78rem; margin-left:1.2rem; word-break:break-word; }
+  .ms { color:#565f89; font-size:.7rem; float:right; }
+  .spin { color:#7aa2f7; font-size:.75rem; }
+</style>
+</head>
+<body>
+<h1>wirecheck<span class="sub">login + live wire-format checks — agents read /api/state</span>
+  <button style="float:right" onclick="post('/api/refresh')">refresh auth</button></h1>
+<div class="cards" id="cards"></div>
+<script>
+const AGENTS = ["claude","codex","muse"];
+async function post(url, body){ await fetch(url,{method:"POST",headers:{"content-type":"application/json"},body:body?JSON.stringify(body):null}); tick(); }
+function esc(s){ const d=document.createElement("div"); d.innerText=s??""; return d.innerHTML; }
+function icon(st){ return {pass:"✔",fail:"✘",running:"◌",skipped:"–"}[st]||"?"; }
+
+function loginBlock(name, p){
+  const l = p.login||{phase:"idle"};
+  let inner = "";
+  if(l.phase==="await_user"){
+    inner += `<div>1. Open <a href="${esc(l.url)}" target="_blank" rel="noopener">${esc(l.url)}</a></div>`;
+    if(l.code) inner += `<div>2. Confirm code <span class="code">${esc(l.code)}</span></div>`;
+    if(l.needs_code_paste) inner += `<div>2. Paste the code shown after login:
+      <input id="${name}-code" size="14"> <button onclick="post('/api/login/${name}/code',{code:document.getElementById('${name}-code').value})">submit</button></div>`;
+  } else if(l.phase==="starting" || l.phase==="waiting"){
+    inner += `<span class="spin">login flow ${l.phase}…</span>`;
+  } else if(l.phase==="done"){
+    inner += `<span class="st pass">✔</span> ${esc(l.detail)}`;
+  } else if(l.phase==="failed"){
+    inner += `<span class="st fail">✘</span> ${esc(l.error)}`;
+  }
+  let controls = "";
+  if(name==="muse"){
+    controls = `<button onclick="post('/api/login/muse/device')">browser login</button>
+      <input id="muse-key" type="password" placeholder="META_API_KEY" size="18">
+      <button onclick="post('/api/login/muse/apikey',{key:document.getElementById('muse-key').value})">set key</button>`;
+  } else if(name==="claude"){
+    controls = `<button onclick="post('/api/login/claude/start',{mode:'claudeai'})">claude.ai login</button>
+      <button onclick="post('/api/login/claude/start',{mode:'console'})">console login</button>`;
+  } else {
+    controls = `<span class="what">login: run <b>codex login</b> on the host (browser callback flow)</span>`;
+  }
+  return `<div class="login">${controls}${inner?"<div style='margin-top:.4rem'>"+inner+"</div>":""}</div>`;
+}
+
+function card(name, p){
+  const checks = (p.checks||[]).map(c=>`
+    <li><span class="st ${c.status}">${icon(c.status)}</span><b>${esc(c.name)}</b>
+        ${c.ms!=null?`<span class="ms">${c.ms} ms</span>`:""}
+        <div class="what" style="margin-left:1.2rem">${esc(c.what)}</div>
+        ${c.detail?`<div class="detail">${esc(c.detail)}</div>`:""}</li>`).join("");
+  return `<div class="card">
+    <h2>${name}
+      <span class="badge ${p.logged_in?"ok":"no"}">${p.logged_in?"authenticated":"no credentials"}</span>
+      <span class="ver">${esc(p.binary||"binary not found")}</span></h2>
+    <div class="what">${esc(p.auth||"")}</div>
+    ${loginBlock(name,p)}
+    <button onclick="post('/api/checks/${name}')" ${p.checks_running?"disabled":""}>
+      ${p.checks_running?"running…":"run checks"}</button>
+    <ul class="checks">${checks}</ul>
+  </div>`;
+}
+
+async function tick(){
+  try{
+    const s = await (await fetch("/api/state")).json();
+    document.getElementById("cards").innerHTML =
+      AGENTS.map(a=>card(a, s.agents[a]||{})).join("");
+  }catch(e){ /* server restarting; keep polling */ }
+}
+tick(); setInterval(tick, 1500);
+</script>
+</body>
+</html>
+"#;

--- a/wirecheck/src/login.rs
+++ b/wirecheck/src/login.rs
@@ -1,0 +1,211 @@
+//! Login-flow drivers, one per CLI that supports programmatic login.
+//!
+//! Secrets never touch argv or logs: the muse API key goes over the SDK's
+//! stdin path, and the claude flow's pasted code goes straight into the
+//! PTY driver. State snapshots only ever carry URLs, display codes, and
+//! outcome summaries.
+
+use crate::state::{LoginState, Shared};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// The claude login flow spans two HTTP requests (start → paste code), so
+/// the blocking flow thread parks on this channel until the code arrives.
+#[derive(Default)]
+pub struct ClaudeFlowSlot {
+    pub code_tx: Mutex<Option<std::sync::mpsc::Sender<String>>>,
+}
+
+async fn set_login(state: &Shared, agent: &'static str, login: LoginState) {
+    let mut portal = state.write().await;
+    if let Some(panel) = portal.agents.get_mut(agent) {
+        panel.login = login;
+    }
+}
+
+// ── muse ─────────────────────────────────────────────────────────────
+
+/// Browser device-code flow: URL + confirmation code, then poll approval.
+pub async fn muse_device(state: Shared) {
+    set_login(&state, "muse", LoginState::Starting).await;
+    let mut flow = match muse_codes::auth::DeviceLoginFlow::start().await {
+        Ok(f) => f,
+        Err(e) => {
+            set_login(
+                &state,
+                "muse",
+                LoginState::Failed {
+                    error: e.to_string(),
+                },
+            )
+            .await;
+            return;
+        }
+    };
+    let dc = match flow.device_code(Duration::from_secs(30)).await {
+        Ok(dc) => dc,
+        Err(e) => {
+            set_login(
+                &state,
+                "muse",
+                LoginState::Failed {
+                    error: e.to_string(),
+                },
+            )
+            .await;
+            return;
+        }
+    };
+    set_login(
+        &state,
+        "muse",
+        LoginState::AwaitUser {
+            url: dc.verification_url.clone(),
+            code: Some(dc.code.clone()),
+            needs_code_paste: false,
+        },
+    )
+    .await;
+    match flow.wait_approved(Duration::from_secs(600)).await {
+        Ok(()) => {
+            set_login(
+                &state,
+                "muse",
+                LoginState::Done {
+                    detail: "device flow approved; credentials stored".into(),
+                },
+            )
+            .await;
+        }
+        Err(e) => {
+            set_login(
+                &state,
+                "muse",
+                LoginState::Failed {
+                    error: e.to_string(),
+                },
+            )
+            .await;
+        }
+    }
+    crate::refresh_agent_auth(&state, "muse").await;
+}
+
+/// API-key path (key travels via the SDK's stdin mechanism, never argv).
+pub async fn muse_api_key(state: Shared, key: String) {
+    set_login(&state, "muse", LoginState::Waiting).await;
+    match muse_codes::auth::auth_set(&key, None).await {
+        Ok(()) => {
+            set_login(
+                &state,
+                "muse",
+                LoginState::Done {
+                    detail: "API key stored via `muse auth set`".into(),
+                },
+            )
+            .await;
+        }
+        Err(e) => {
+            set_login(
+                &state,
+                "muse",
+                LoginState::Failed {
+                    error: e.to_string(),
+                },
+            )
+            .await;
+        }
+    }
+    crate::refresh_agent_auth(&state, "muse").await;
+}
+
+// ── claude ───────────────────────────────────────────────────────────
+
+/// Start the claude visit-URL/paste-code flow. The PTY driver is
+/// synchronous, so the whole flow lives on one blocking thread that parks
+/// waiting for the pasted code.
+pub async fn claude_start(state: Shared, slot: Arc<ClaudeFlowSlot>, mode: String) {
+    use claude_codes::auth::{LoginFlow, LoginMode};
+    let mode = match mode.as_str() {
+        "console" => LoginMode::Console,
+        "setup-token" => LoginMode::SetupToken,
+        _ => LoginMode::ClaudeAi,
+    };
+    set_login(&state, "claude", LoginState::Starting).await;
+
+    let (tx, rx) = std::sync::mpsc::channel::<String>();
+    if let Ok(mut guard) = slot.code_tx.lock() {
+        *guard = Some(tx);
+    }
+
+    let state_for_thread = state.clone();
+    let outcome = tokio::task::spawn_blocking(move || {
+        let mut flow = LoginFlow::start(mode).map_err(|e| e.to_string())?;
+        let url = flow
+            .auth_url(Duration::from_secs(60))
+            .map_err(|e| e.to_string())?;
+        // Publish the URL from inside the blocking thread so the page can
+        // show it while we park on the code.
+        {
+            let mut portal = state_for_thread.blocking_write();
+            if let Some(panel) = portal.agents.get_mut("claude") {
+                panel.login = LoginState::AwaitUser {
+                    url,
+                    code: None,
+                    needs_code_paste: true,
+                };
+            }
+        }
+        let code = rx
+            .recv_timeout(Duration::from_secs(600))
+            .map_err(|_| "timed out waiting for the pasted code".to_string())?;
+        {
+            let mut portal = state_for_thread.blocking_write();
+            if let Some(panel) = portal.agents.get_mut("claude") {
+                panel.login = LoginState::Waiting;
+            }
+        }
+        let outcome = flow
+            .submit_code_and_wait(&code, Duration::from_secs(120))
+            .map_err(|e| e.to_string())?;
+        // Summarize WITHOUT the token value: setup-token outcomes carry a
+        // secret that must not reach state/logs; its presence is the news.
+        Ok::<String, String>(format!(
+            "login ok{}",
+            if outcome.token.is_some() {
+                " (token minted — retrieve via SDK)"
+            } else {
+                ""
+            }
+        ))
+    })
+    .await;
+
+    match outcome {
+        Ok(Ok(detail)) => set_login(&state, "claude", LoginState::Done { detail }).await,
+        Ok(Err(e)) => set_login(&state, "claude", LoginState::Failed { error: e }).await,
+        Err(e) => {
+            set_login(
+                &state,
+                "claude",
+                LoginState::Failed {
+                    error: e.to_string(),
+                },
+            )
+            .await
+        }
+    }
+    if let Ok(mut guard) = slot.code_tx.lock() {
+        *guard = None;
+    }
+    crate::refresh_agent_auth(&state, "claude").await;
+}
+
+/// Deliver the pasted code to the parked flow thread.
+pub fn claude_submit_code(slot: &ClaudeFlowSlot, code: String) -> Result<(), &'static str> {
+    let guard = slot.code_tx.lock().map_err(|_| "flow slot poisoned")?;
+    match guard.as_ref() {
+        Some(tx) => tx.send(code).map_err(|_| "flow thread already exited"),
+        None => Err("no claude login flow is waiting for a code"),
+    }
+}

--- a/wirecheck/src/main.rs
+++ b/wirecheck/src/main.rs
@@ -45,6 +45,7 @@ async fn main() {
         .route("/api/state", get(api_state))
         .route("/api/refresh", post(api_refresh))
         .route("/api/checks/{agent}", post(api_run_checks))
+        .route("/api/suite/{agent}", post(api_run_cargo_suite))
         .route("/api/login/muse/device", post(api_muse_device))
         .route("/api/login/muse/apikey", post(api_muse_apikey))
         .route("/api/login/claude/start", post(api_claude_start))
@@ -65,12 +66,14 @@ async fn main() {
 /// entry point; the server is the same checks with a UI.
 async fn headless_run(wanted: &[String]) {
     let all = ["claude", "codex", "muse", "opencode"];
+    let cargo_tier = wanted.iter().any(|w| w == "--cargo");
+    let wanted: Vec<&String> = wanted.iter().filter(|w| *w != "--cargo").collect();
     let agents: Vec<&'static str> = if wanted.is_empty() {
         all.to_vec()
     } else {
         all.iter()
             .copied()
-            .filter(|a| wanted.iter().any(|w| w == a))
+            .filter(|a| wanted.iter().any(|w| *w == a))
             .collect()
     };
     if agents.is_empty() {
@@ -97,6 +100,26 @@ async fn headless_run(wanted: &[String]) {
                 eprintln!("  [{:?}] {} — {}", c.status, c.name, c.detail);
             }
         }
+        drop(portal);
+        if cargo_tier {
+            eprintln!("── {agent} cargo integration tests ──");
+            {
+                let mut portal = state.write().await;
+                if let Some(panel) = portal.agents.get_mut(agent) {
+                    panel.cargo_running = true;
+                }
+            }
+            checks::cargo_suite::run(state.clone(), agent).await;
+            let portal = state.read().await;
+            if let Some(panel) = portal.agents.get(agent) {
+                for c in &panel.cargo_tests {
+                    eprintln!("  [{:?}] {} — {}", c.status, c.name, c.detail);
+                }
+                if let Some(s) = &panel.cargo_status {
+                    eprintln!("  {s}");
+                }
+            }
+        }
     }
     let portal = state.read().await;
     println!(
@@ -107,7 +130,7 @@ async fn headless_run(wanted: &[String]) {
         .agents
         .iter()
         .filter(|(name, _)| agents.contains(name))
-        .flat_map(|(_, p)| &p.checks)
+        .flat_map(|(_, p)| p.checks.iter().chain(&p.cargo_tests))
         .filter(|c| c.status == state::CheckStatus::Fail)
         .count();
     if failed > 0 {
@@ -162,6 +185,34 @@ async fn api_run_checks(State(ctx): State<Ctx>, Path(agent): Path<String>) -> im
             panel.checks_running = false;
         }
     });
+    StatusCode::ACCEPTED.into_response()
+}
+
+/// Launch the crate's real cargo integration tests for one agent.
+async fn api_run_cargo_suite(
+    State(ctx): State<Ctx>,
+    Path(agent): Path<String>,
+) -> impl IntoResponse {
+    let name: &'static str = match agent.as_str() {
+        "muse" => "muse",
+        "claude" => "claude",
+        "codex" => "codex",
+        "opencode" => "opencode",
+        _ => return (StatusCode::NOT_FOUND, "unknown agent").into_response(),
+    };
+    {
+        let mut portal = ctx.state.write().await;
+        let Some(panel) = portal.agents.get_mut(name) else {
+            return (StatusCode::NOT_FOUND, "unknown agent").into_response();
+        };
+        if panel.cargo_running {
+            return (StatusCode::CONFLICT, "cargo suite already running").into_response();
+        }
+        panel.cargo_running = true;
+        panel.cargo_tests.clear();
+        panel.cargo_status = Some("starting…".into());
+    }
+    tokio::spawn(checks::cargo_suite::run(ctx.state.clone(), name));
     StatusCode::ACCEPTED.into_response()
 }
 

--- a/wirecheck/src/main.rs
+++ b/wirecheck/src/main.rs
@@ -240,13 +240,13 @@ pub async fn refresh_agent_auth(state: &Shared, agent: &'static str) {
         "codex" => match codex_codes::auth_local::auth_status_local() {
             Ok(s) => (
                 format!(
-                    "{} ({:?})",
+                    "{} ({})",
                     if s.logged_in {
                         "logged in"
                     } else {
                         "no credentials"
                     },
-                    s.auth_mode,
+                    s.auth_mode.as_deref().unwrap_or("unknown method"),
                 ),
                 s.logged_in,
             ),

--- a/wirecheck/src/main.rs
+++ b/wirecheck/src/main.rs
@@ -1,0 +1,234 @@
+//! wirecheck — a local web portal that logs in to each wrapped agent CLI
+//! and runs live wire-format checks against the real binaries.
+//!
+//! Binds 127.0.0.1 only; expose it through a session-owned tunnel (e.g.
+//! `agent-portal forward 4477`). Results are equally consumable by a human
+//! (the dashboard) and by an agent (`GET /api/state` is the whole truth as
+//! JSON).
+
+mod checks;
+mod html;
+mod login;
+mod state;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{Html, IntoResponse, Json};
+use axum::routing::{get, post};
+use serde::Deserialize;
+use state::{LoginState, Portal, Shared};
+use std::sync::Arc;
+
+#[derive(Clone)]
+struct Ctx {
+    state: Shared,
+    claude_flow: Arc<login::ClaudeFlowSlot>,
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    let ctx = Ctx {
+        state: Arc::new(tokio::sync::RwLock::new(Portal::new())),
+        claude_flow: Arc::new(login::ClaudeFlowSlot::default()),
+    };
+    refresh_all_auth(&ctx.state).await;
+
+    let app = axum::Router::new()
+        .route("/", get(|| async { Html(html::PAGE) }))
+        .route("/api/state", get(api_state))
+        .route("/api/refresh", post(api_refresh))
+        .route("/api/checks/{agent}", post(api_run_checks))
+        .route("/api/login/muse/device", post(api_muse_device))
+        .route("/api/login/muse/apikey", post(api_muse_apikey))
+        .route("/api/login/claude/start", post(api_claude_start))
+        .route("/api/login/claude/code", post(api_claude_code))
+        .with_state(ctx);
+
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 4477));
+    tracing::info!("wirecheck portal on http://{addr}");
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .expect("bind 127.0.0.1:4477");
+    axum::serve(listener, app).await.expect("serve");
+}
+
+async fn api_state(State(ctx): State<Ctx>) -> Json<serde_json::Value> {
+    let portal = ctx.state.read().await;
+    Json(serde_json::to_value(&*portal).unwrap_or(serde_json::Value::Null))
+}
+
+async fn api_refresh(State(ctx): State<Ctx>) -> StatusCode {
+    refresh_all_auth(&ctx.state).await;
+    StatusCode::NO_CONTENT
+}
+
+async fn api_run_checks(State(ctx): State<Ctx>, Path(agent): Path<String>) -> impl IntoResponse {
+    let name: &'static str = match agent.as_str() {
+        "muse" => "muse",
+        "claude" => "claude",
+        "codex" => "codex",
+        _ => return (StatusCode::NOT_FOUND, "unknown agent").into_response(),
+    };
+    {
+        let mut portal = ctx.state.write().await;
+        let Some(panel) = portal.agents.get_mut(name) else {
+            return (StatusCode::NOT_FOUND, "unknown agent").into_response();
+        };
+        if panel.checks_running {
+            return (StatusCode::CONFLICT, "suite already running").into_response();
+        }
+        panel.checks_running = true;
+        panel.checks.clear();
+    }
+    let reporter = state::Reporter {
+        state: ctx.state.clone(),
+        agent: name,
+    };
+    let state_for_done = ctx.state.clone();
+    tokio::spawn(async move {
+        match name {
+            "muse" => checks::muse::run_suite(reporter).await,
+            "claude" => checks::claude::run_suite(reporter).await,
+            _ => checks::codex::run_suite(reporter).await,
+        }
+        let mut portal = state_for_done.write().await;
+        if let Some(panel) = portal.agents.get_mut(name) {
+            panel.checks_running = false;
+        }
+    });
+    StatusCode::ACCEPTED.into_response()
+}
+
+// ── login endpoints ──────────────────────────────────────────────────
+
+async fn api_muse_device(State(ctx): State<Ctx>) -> StatusCode {
+    tokio::spawn(login::muse_device(ctx.state.clone()));
+    StatusCode::ACCEPTED
+}
+
+#[derive(Deserialize)]
+struct KeyBody {
+    key: String,
+}
+
+async fn api_muse_apikey(State(ctx): State<Ctx>, Json(body): Json<KeyBody>) -> StatusCode {
+    tokio::spawn(login::muse_api_key(ctx.state.clone(), body.key));
+    StatusCode::ACCEPTED
+}
+
+#[derive(Deserialize)]
+struct StartBody {
+    #[serde(default)]
+    mode: String,
+}
+
+async fn api_claude_start(State(ctx): State<Ctx>, Json(body): Json<StartBody>) -> StatusCode {
+    tokio::spawn(login::claude_start(
+        ctx.state.clone(),
+        ctx.claude_flow.clone(),
+        body.mode,
+    ));
+    StatusCode::ACCEPTED
+}
+
+#[derive(Deserialize)]
+struct CodeBody {
+    code: String,
+}
+
+async fn api_claude_code(State(ctx): State<Ctx>, Json(body): Json<CodeBody>) -> impl IntoResponse {
+    match login::claude_submit_code(&ctx.claude_flow, body.code) {
+        Ok(()) => StatusCode::ACCEPTED.into_response(),
+        Err(e) => (StatusCode::CONFLICT, e).into_response(),
+    }
+}
+
+// ── auth refresh ─────────────────────────────────────────────────────
+
+async fn refresh_all_auth(state: &Shared) {
+    for agent in ["claude", "codex", "muse"] {
+        refresh_agent_auth(state, agent).await;
+    }
+}
+
+/// Re-read binary version and credential state for one agent. Called at
+/// startup, after every login flow, and from the refresh button.
+pub async fn refresh_agent_auth(state: &Shared, agent: &'static str) {
+    let binary = version_of(agent).await;
+    let (auth, logged_in) = match agent {
+        "claude" => match tokio::task::spawn_blocking(claude_codes::auth::auth_status).await {
+            Ok(Ok(s)) => (
+                format!(
+                    "{} ({})",
+                    if s.logged_in {
+                        "logged in"
+                    } else {
+                        "no credentials"
+                    },
+                    s.auth_method.as_deref().unwrap_or("unknown method"),
+                ),
+                s.logged_in,
+            ),
+            other => (format!("status unavailable: {other:?}"), false),
+        },
+        "codex" => match codex_codes::auth_local::auth_status_local() {
+            Ok(s) => (
+                format!(
+                    "{} ({:?})",
+                    if s.logged_in {
+                        "logged in"
+                    } else {
+                        "no credentials"
+                    },
+                    s.auth_mode,
+                ),
+                s.logged_in,
+            ),
+            Err(e) => (format!("status unavailable: {e}"), false),
+        },
+        "muse" => {
+            let present = muse_codes::auth::credentials_present();
+            (
+                if present {
+                    "credentials present".to_string()
+                } else {
+                    "no credentials".to_string()
+                },
+                present,
+            )
+        }
+        _ => ("unknown agent".to_string(), false),
+    };
+    let mut portal = state.write().await;
+    if let Some(panel) = portal.agents.get_mut(agent) {
+        panel.binary = binary;
+        panel.auth = Some(auth);
+        panel.logged_in = logged_in;
+        // A finished login flow's terminal state stays visible; anything
+        // else resets so stale progress can't outlive a refresh.
+        if !matches!(
+            panel.login,
+            LoginState::Done { .. } | LoginState::Failed { .. }
+        ) {
+            if let LoginState::AwaitUser { .. } | LoginState::Waiting | LoginState::Starting =
+                panel.login
+            {
+                // leave in-flight flows alone
+            } else {
+                panel.login = LoginState::Idle;
+            }
+        }
+    }
+}
+
+async fn version_of(agent: &str) -> Option<String> {
+    let out = tokio::process::Command::new(agent)
+        .arg("--version")
+        .output()
+        .await
+        .ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}

--- a/wirecheck/src/main.rs
+++ b/wirecheck/src/main.rs
@@ -28,6 +28,11 @@ struct Ctx {
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
+    // Children must not think they're nested inside a Claude Code session
+    // (the checks spawn real CLIs); clearing here covers every spawn path
+    // without needing claude-codes' integration-tests feature — which, as
+    // a workspace dep, would feature-unify live tests into every CI job.
+    std::env::remove_var("CLAUDECODE");
     let args: Vec<String> = std::env::args().skip(1).collect();
     if args.first().map(String::as_str) == Some("run") {
         headless_run(&args[1..]).await;

--- a/wirecheck/src/main.rs
+++ b/wirecheck/src/main.rs
@@ -28,6 +28,12 @@ struct Ctx {
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.first().map(String::as_str) == Some("run") {
+        headless_run(&args[1..]).await;
+        return;
+    }
+
     let ctx = Ctx {
         state: Arc::new(tokio::sync::RwLock::new(Portal::new())),
         claude_flow: Arc::new(login::ClaudeFlowSlot::default()),
@@ -53,6 +59,63 @@ async fn main() {
     axum::serve(listener, app).await.expect("serve");
 }
 
+/// One-shot CI/scripting mode: `wirecheck run [agent ...]` runs the named
+/// suites (default: all four) sequentially, prints the full state as JSON
+/// on stdout, and exits 1 if any check failed — the integration-suite
+/// entry point; the server is the same checks with a UI.
+async fn headless_run(wanted: &[String]) {
+    let all = ["claude", "codex", "muse", "opencode"];
+    let agents: Vec<&'static str> = if wanted.is_empty() {
+        all.to_vec()
+    } else {
+        all.iter()
+            .copied()
+            .filter(|a| wanted.iter().any(|w| w == a))
+            .collect()
+    };
+    if agents.is_empty() {
+        eprintln!("no known agents in {wanted:?}; known: {all:?}");
+        std::process::exit(2);
+    }
+    let state: Shared = Arc::new(tokio::sync::RwLock::new(Portal::new()));
+    refresh_all_auth(&state).await;
+    for agent in &agents {
+        eprintln!("── {agent} suite ──");
+        let reporter = state::Reporter {
+            state: state.clone(),
+            agent,
+        };
+        match *agent {
+            "muse" => checks::muse::run_suite(reporter).await,
+            "claude" => checks::claude::run_suite(reporter).await,
+            "opencode" => checks::opencode::run_suite(reporter).await,
+            _ => checks::codex::run_suite(reporter).await,
+        }
+        let portal = state.read().await;
+        if let Some(panel) = portal.agents.get(agent) {
+            for c in &panel.checks {
+                eprintln!("  [{:?}] {} — {}", c.status, c.name, c.detail);
+            }
+        }
+    }
+    let portal = state.read().await;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&*portal).unwrap_or_else(|_| "{}".into())
+    );
+    let failed = portal
+        .agents
+        .iter()
+        .filter(|(name, _)| agents.contains(name))
+        .flat_map(|(_, p)| &p.checks)
+        .filter(|c| c.status == state::CheckStatus::Fail)
+        .count();
+    if failed > 0 {
+        eprintln!("{failed} check(s) FAILED");
+        std::process::exit(1);
+    }
+}
+
 async fn api_state(State(ctx): State<Ctx>) -> Json<serde_json::Value> {
     let portal = ctx.state.read().await;
     Json(serde_json::to_value(&*portal).unwrap_or(serde_json::Value::Null))
@@ -68,6 +131,7 @@ async fn api_run_checks(State(ctx): State<Ctx>, Path(agent): Path<String>) -> im
         "muse" => "muse",
         "claude" => "claude",
         "codex" => "codex",
+        "opencode" => "opencode",
         _ => return (StatusCode::NOT_FOUND, "unknown agent").into_response(),
     };
     {
@@ -90,6 +154,7 @@ async fn api_run_checks(State(ctx): State<Ctx>, Path(agent): Path<String>) -> im
         match name {
             "muse" => checks::muse::run_suite(reporter).await,
             "claude" => checks::claude::run_suite(reporter).await,
+            "opencode" => checks::opencode::run_suite(reporter).await,
             _ => checks::codex::run_suite(reporter).await,
         }
         let mut portal = state_for_done.write().await;
@@ -147,7 +212,7 @@ async fn api_claude_code(State(ctx): State<Ctx>, Json(body): Json<CodeBody>) -> 
 // ── auth refresh ─────────────────────────────────────────────────────
 
 async fn refresh_all_auth(state: &Shared) {
-    for agent in ["claude", "codex", "muse"] {
+    for agent in ["claude", "codex", "muse", "opencode"] {
         refresh_agent_auth(state, agent).await;
     }
 }

--- a/wirecheck/src/state.rs
+++ b/wirecheck/src/state.rs
@@ -1,0 +1,133 @@
+//! Shared portal state: per-agent auth view, login-flow progress, and
+//! check results. One `RwLock` guards it all — the portal is a local,
+//! single-user tool and contention is nil.
+
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+pub type Shared = Arc<RwLock<Portal>>;
+
+#[derive(Debug, Default, Serialize)]
+pub struct Portal {
+    pub agents: BTreeMap<&'static str, AgentPanel>,
+}
+
+/// Everything the page (and the querying agent) sees for one CLI.
+#[derive(Debug, Default, Serialize)]
+pub struct AgentPanel {
+    /// CLI binary presence/version, refreshed on demand.
+    pub binary: Option<String>,
+    /// Human-readable credential state ("logged in (subscription)",
+    /// "no credentials", ...). Never contains a secret.
+    pub auth: Option<String>,
+    pub logged_in: bool,
+    /// Current login-flow progress, if one is running.
+    pub login: LoginState,
+    /// Latest check run, newest state per check name.
+    pub checks: Vec<CheckResult>,
+    /// True while a suite is executing (page shows a spinner).
+    pub checks_running: bool,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+#[serde(tag = "phase", rename_all = "snake_case")]
+pub enum LoginState {
+    #[default]
+    Idle,
+    /// Flow started; waiting for the CLI to produce a URL/code.
+    Starting,
+    /// User action needed: open the URL (and for muse, confirm the code).
+    AwaitUser {
+        url: String,
+        /// Muse device flows display a confirmation code; Claude's flow
+        /// instead expects a code PASTED BACK via /api/login/claude/code.
+        code: Option<String>,
+        needs_code_paste: bool,
+    },
+    /// Code submitted / approval pending.
+    Waiting,
+    Done {
+        detail: String,
+    },
+    Failed {
+        error: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CheckResult {
+    pub name: &'static str,
+    /// What property this check pins, in one sentence.
+    pub what: &'static str,
+    pub status: CheckStatus,
+    /// Pass detail or failure explanation. Never contains secrets.
+    pub detail: String,
+    /// Milliseconds the check took, once finished.
+    pub ms: Option<u128>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckStatus {
+    Running,
+    Pass,
+    Fail,
+    /// Prerequisite missing (no credentials, binary absent) — distinct
+    /// from Fail so a logged-out agent reads as "not checked" rather
+    /// than "broken".
+    Skipped,
+}
+
+impl Portal {
+    pub fn new() -> Self {
+        let mut agents = BTreeMap::new();
+        agents.insert("claude", AgentPanel::default());
+        agents.insert("codex", AgentPanel::default());
+        agents.insert("muse", AgentPanel::default());
+        Self { agents }
+    }
+}
+
+/// Handle for check functions to report progress into the shared state.
+#[derive(Clone)]
+pub struct Reporter {
+    pub state: Shared,
+    pub agent: &'static str,
+}
+
+impl Reporter {
+    /// Mark a check running; returns its start instant for the ms field.
+    pub async fn start(&self, name: &'static str, what: &'static str) -> std::time::Instant {
+        let mut portal = self.state.write().await;
+        if let Some(panel) = portal.agents.get_mut(self.agent) {
+            panel.checks.retain(|c| c.name != name);
+            panel.checks.push(CheckResult {
+                name,
+                what,
+                status: CheckStatus::Running,
+                detail: String::new(),
+                ms: None,
+            });
+        }
+        std::time::Instant::now()
+    }
+
+    pub async fn finish(
+        &self,
+        name: &'static str,
+        started: std::time::Instant,
+        status: CheckStatus,
+        detail: String,
+    ) {
+        let mut portal = self.state.write().await;
+        if let Some(panel) = portal.agents.get_mut(self.agent) {
+            if let Some(check) = panel.checks.iter_mut().find(|c| c.name == name) {
+                check.status = status;
+                check.detail = detail;
+                check.ms = Some(started.elapsed().as_millis());
+            }
+        }
+    }
+}

--- a/wirecheck/src/state.rs
+++ b/wirecheck/src/state.rs
@@ -29,6 +29,13 @@ pub struct AgentPanel {
     pub checks: Vec<CheckResult>,
     /// True while a suite is executing (page shows a spinner).
     pub checks_running: bool,
+    /// The crate's REAL `cargo test --features integration-tests` results,
+    /// one row per test — run in-place, parsed from libtest output, so this
+    /// section can never drift from the tests as written.
+    pub cargo_tests: Vec<CheckResult>,
+    pub cargo_running: bool,
+    /// Rolling status line for the cargo tier (compiling, running test N…).
+    pub cargo_status: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, Serialize)]
@@ -58,8 +65,9 @@ pub enum LoginState {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CheckResult {
-    pub name: &'static str,
-    /// What property this check pins, in one sentence.
+    pub name: String,
+    /// What property this check pins, in one sentence. Empty for cargo
+    /// tests — the test name is the description.
     pub what: &'static str,
     pub status: CheckStatus,
     /// Pass detail or failure explanation. Never contains secrets.
@@ -105,7 +113,7 @@ impl Reporter {
         if let Some(panel) = portal.agents.get_mut(self.agent) {
             panel.checks.retain(|c| c.name != name);
             panel.checks.push(CheckResult {
-                name,
+                name: name.to_string(),
                 what,
                 status: CheckStatus::Running,
                 detail: String::new(),

--- a/wirecheck/src/state.rs
+++ b/wirecheck/src/state.rs
@@ -86,6 +86,7 @@ impl Portal {
         agents.insert("claude", AgentPanel::default());
         agents.insert("codex", AgentPanel::default());
         agents.insert("muse", AgentPanel::default());
+        agents.insert("opencode", AgentPanel::default());
         Self { agents }
     }
 }


### PR DESCRIPTION
A small local web server that presents the login flow for each wrapped agent CLI, uses the resulting credentials, and runs live wire-format/message-behavior checks against the real binaries — results readable both on a dashboard and by an agent (`GET /api/state` is the whole truth as JSON).

## Shape

Workspace tool crate (`wirecheck/`, `publish = false`), axum on `127.0.0.1:4477` only — expose via a session-owned forward. No build step: one inline dashboard page polling `/api/state`.

**Login flows reuse the SDK auth modules** (secrets never touch argv, state, or logs):
- **claude** — the visit-URL/paste-code PTY flow (`LoginFlow`), spanning two HTTP requests via a parked blocking thread; claude.ai and Console modes
- **muse** — browser device flow (URL + confirmation code + approval poll) and the stdin API-key path
- **codex** — local credential snapshot surfaced with instructions (its login is a browser callback the host runs)

**Checks report live as they run**, each carrying what-it-pins, status, detail, and duration:

| agent | checks |
|---|---|
| muse | binary · echo stream to terminal · envelope invariants (schema_version, per-stream sequence monotonicity, typed lift) · `--session-id` adoption · record-id **counter trap** (byte-identical ids across sessions) · live Meta tier: **strict typed audit** (no `Unknown` on the live wire — exactly what the nightly echo-only fingerprint can't reach), `tool.result` ↔ `tool.<name>` task correlation, answer text on the terminal record |
| claude | binary · `auth status` · typed stream-json round trip (send → Assistant → Result, session id present) |
| codex | binary · local auth snapshot · app-server turn to `TurnCompleted` through the typed JSON-RPC client, approvals auto-accepted |

## Verified live before this PR

All three suites ran green on this host through the portal itself (muse 9/9 including the live Meta tier: 18 payload types all typed, both tool results kind-matched; claude round trip in 2.9s; codex 15 typed notifications to completion).

Two findings the portal produced on its first run, both real:
1. **Installed CLIs have drifted behind the SDK pins**: `claude 2.1.222` (SDK targets 2.1.223) and `codex-cli 0.145.0` (SDK targets 0.146.4) are on PATH — something downgraded or the pins outpaced installs. The nightly drift checks never see this because they install fresh CLIs in CI.
2. **`codex auth.json` reads can race a rewrite**: one read returned `logged_in=false` on a file that held valid chatgpt tokens seconds before and after — a transient mid-rewrite window worth knowing about for anything polling `auth_status_local`.

CI note: pushed during the Actions outage; suites==0 expected on this SHA until runners drain — verify check registration before merging per the recovery procedure.

---

**Expanded to the full four-agent integration suite** (second + third commits): absorbs the live behaviors the per-crate integration tests pin — claude ping/conversation-recall/fork-history/tool_use round trip/approval handshake; codex thread_fork + account read family; muse continuity/interrupt-kill/flag surface/flag constraints; **opencode joins as a fourth card** (managed server, session lifecycle, fork, SSE stream — no credentials needed). Adds headless `wirecheck run [agent ...]` (JSON to stdout, nonzero exit on failure) so it scripts as the integration suite. Also carries the #291 cherry-pick (muse flag parity) plus new `MuseExecBuilder::extra_args` raw passthrough (codex parity, argv-position pinned) — supersedes #291.

**Verified live: 30/30 checks green across all four agents on this host.**

---

**Cargo tier added** (fourth commit): each card now also runs the crate's *actual* `cargo test --features integration-tests` as a subprocess, streaming one row per test into the UI and `/api/state` — nothing hand-ported, so the portal can never drift from the suites as written. Headless: `wirecheck run --cargo`. First full run: **muse 21/21 · codex 117/117 · claude 287+1 skipped · opencode 25/25 (~450 tests green)**, after fixing two real issues it caught in opencode-codes (SSE test ignored `OPENCODE_BASE_URL`; version pin moved forward to CLI 1.18.14 and now reads `CARGO_PKG_VERSION` instead of a second hardcoded copy).
