### PR TITLE
antigravity-codes: make captures evidentiary, and use them

### DIFF
--- a/antigravity-codes/CHANGELOG.md
+++ b/antigravity-codes/CHANGELOG.md
@@ -55,6 +55,24 @@ Two defaults were corrected as a result:
   override. The `pro` models have zero free-tier quota and return
   `429 … limit: 0`.
 
+### Corpus and recorder
+
+- `RawClient::next_frame` returns the frame text alongside the decoded event,
+  and `RawClient::initialize_frame` retains the one frame `launch` consumes.
+  Without these a capture can only be written back out through the crate's own
+  types, which makes the no-field-loss test tautological — it would agree with
+  itself and never notice a field the types are missing.
+- `examples/capture_frames` records verbatim, and takes `ANTIGRAVITY_TOOLS`,
+  `ANTIGRAVITY_SUBAGENTS`, and `ANTIGRAVITY_POLICY` to widen what a session
+  exercises.
+- Added a captured `policyDecisionRequest` session. It confirms the synthetic
+  fixture written blind from the descriptor was right, and documents that the
+  harness blocks a turn indefinitely until a policy request is answered.
+- `tests/step_assembly_tests.rs` replays whole sessions through `StepAssembler`,
+  asserting accumulated text never regresses, settled steps stay final, and
+  concurrent trajectories do not collide. The unit tests in `steps.rs` prove the
+  arithmetic; these prove it matches how a harness actually streams.
+
 ### Notes
 
 - Unknown enum values and unknown `oneof` arms decode rather than fail. The

--- a/antigravity-codes/examples/capture_frames.rs
+++ b/antigravity-codes/examples/capture_frames.rs
@@ -1,21 +1,36 @@
-//! Records every frame of a session to disk, for use as test fixtures.
+//! Records every frame of a session to disk, verbatim, for use as test fixtures.
 //!
 //! ```sh
 //! export ANTIGRAVITY_HARNESS_PATH=/path/to/localharness
-//! cargo run -p antigravity-codes --example capture_frames -- ./antigravity-codes/test_cases/events "hello"
+//! export GEMINI_API_KEY=...
+//! cargo run -p antigravity-codes --example capture_frames -- ./captures "hello"
 //! ```
 //!
-//! Frames are written as `NNN-<kind>.json`. A frame that fails to decode is
-//! still written, with a `-undecodable` suffix — those are the interesting
-//! ones, and they belong in a bug report.
+//! Frames are written as `NNN-<kind>.json`, re-indented but **not** re-encoded:
+//! the field set is exactly what the harness sent. That distinction is the whole
+//! point — a corpus built from decoded-then-re-encoded frames can only contain
+//! fields the crate already models, so it agrees with itself by construction and
+//! can never catch a field the types are missing.
+//!
+//! Options, all via the environment:
+//!
+//! | Variable | Effect |
+//! |---|---|
+//! | `ANTIGRAVITY_MODEL` | Model to use (default `gemini-flash-latest`) |
+//! | `ANTIGRAVITY_TOOLS` | `read-only` (default), `all`, or `none` |
+//! | `ANTIGRAVITY_SUBAGENTS` | Set to let the agent delegate to a subagent |
+//! | `ANTIGRAVITY_POLICY` | Set to install a dynamic policy rule on `run_command` |
 
 use std::path::PathBuf;
 
-use antigravity_codes::protocol::{InputEvent, OutputEvent};
+use antigravity_codes::protocol::{
+    HarnessSideTools, InputEvent, OutputEvent, PolicyConfig, PolicyDecision, PolicyRule,
+    SubagentsConfig,
+};
 use antigravity_codes::{HarnessOptions, ModelBuilder, RawClient, Result};
 
-fn kind_of(event: &OutputEvent) -> &'static str {
-    if event.step_update.is_some() {
+fn kind_of(event: &OutputEvent) -> String {
+    let base = if event.step_update.is_some() {
         "step-update"
     } else if event.trajectory_state_update.is_some() {
         "trajectory-state"
@@ -33,7 +48,76 @@ fn kind_of(event: &OutputEvent) -> &'static str {
         "session-end-response"
     } else {
         "unknown"
+    };
+
+    // Name the action a step carries, so a directory of captures is greppable.
+    let action = event.step_update.as_ref().and_then(|s| {
+        [
+            ("list-directory", s.list_directory.is_some()),
+            ("find-file", s.find_file.is_some()),
+            ("search-directory", s.search_directory.is_some()),
+            ("view-file", s.view_file.is_some()),
+            ("create-file", s.create_file.is_some()),
+            ("edit-file", s.edit_file.is_some()),
+            ("run-command", s.run_command.is_some()),
+            ("invoke-subagent", s.invoke_subagent.is_some()),
+            ("generate-image", s.generate_image.is_some()),
+            ("search-web", s.search_web.is_some()),
+            ("read-url-content", s.read_url_content.is_some()),
+            ("mcp-tool", s.mcp_tool.is_some()),
+            ("custom-tool", s.custom_tool.is_some()),
+            ("finish", s.finish.is_some()),
+            ("error", s.error.is_some()),
+            ("questions-request", s.questions_request.is_some()),
+            ("tool-confirmation", s.tool_confirmation_request.is_some()),
+        ]
+        .into_iter()
+        .find(|(_, present)| *present)
+        .map(|(name, _)| name)
+    });
+
+    match action {
+        Some(action) => format!("{base}-{action}"),
+        None => base.to_string(),
     }
+}
+
+fn options() -> HarnessOptions {
+    let mut tools = match std::env::var("ANTIGRAVITY_TOOLS").as_deref() {
+        Ok("all") => HarnessSideTools::all(),
+        Ok("none") => HarnessSideTools::none(),
+        _ => HarnessSideTools::read_only(),
+    };
+    if std::env::var("ANTIGRAVITY_SUBAGENTS").is_ok() {
+        tools.subagents = Some(SubagentsConfig {
+            enabled: Some(true),
+        });
+    }
+
+    let mut options = HarnessOptions::new()
+        .workspace(std::env::current_dir().expect("a readable working directory"))
+        .model(ModelBuilder::gemini(
+            std::env::var("ANTIGRAVITY_MODEL").unwrap_or_else(|_| "gemini-flash-latest".into()),
+            std::env::var("GEMINI_API_KEY").unwrap_or_default(),
+        ))
+        .harness_side_tools(tools);
+
+    if std::env::var("ANTIGRAVITY_POLICY").is_ok() {
+        // `is_dynamic` is what makes the harness ask the *client* rather than
+        // deciding locally, which is the frame worth capturing.
+        options = options.policy(PolicyConfig {
+            rules: vec![PolicyRule {
+                tool: Some("run_command".into()),
+                name: Some("ask-before-shell".into()),
+                rule_id: Some("shell-guard".into()),
+                decision: Some(PolicyDecision::AskUser),
+                is_dynamic: Some(true),
+                ..Default::default()
+            }],
+        });
+    }
+
+    options
 }
 
 #[tokio::main]
@@ -45,43 +129,32 @@ async fn main() -> Result<()> {
     let prompt = args.next().unwrap_or_else(|| "Say hello.".into());
     std::fs::create_dir_all(&out)?;
 
-    let mut client = RawClient::launch(
-        HarnessOptions::new()
-            .workspace(std::env::current_dir()?)
-            .model(ModelBuilder::gemini(
-                std::env::var("ANTIGRAVITY_MODEL").unwrap_or_else(|_| "gemini-flash-latest".into()),
-                std::env::var("GEMINI_API_KEY").unwrap_or_default(),
-            )),
-    )
-    .await?;
+    let mut client = RawClient::launch(options()).await?;
 
-    // The initialize reply was consumed during launch; write it back out so the
-    // capture is a complete session.
-    let initialize = serde_json::to_value(client.initialize_response())
-        .map_err(|e| std::io::Error::other(e.to_string()))?;
-    std::fs::write(
-        out.join("000-initialize-response.json"),
-        serde_json::to_string_pretty(&initialize).unwrap() + "\n",
-    )?;
+    // `launch` consumed the initialize frame, but the client kept the raw text
+    // so the capture is a complete session rather than one starting mid-stream.
+    let initialize: serde_json::Value =
+        serde_json::from_str(client.initialize_frame()).unwrap_or(serde_json::Value::Null);
+    write(&out, "000-initialize-response.json", &initialize)?;
 
     client.send(&InputEvent::user(prompt)).await?;
 
     let mut n = 1;
-    while let Some(event) = client.next_event().await? {
-        let value = serde_json::to_value(&event).unwrap_or(serde_json::Value::Null);
-        let name = format!("{n:03}-{}.json", kind_of(&event));
-        std::fs::write(
-            out.join(name),
-            serde_json::to_string_pretty(&value).unwrap() + "\n",
-        )?;
+    while let Some((raw, event)) = client.next_frame().await? {
+        // Parsed as a `Value`, not as an `OutputEvent`, so nothing the crate
+        // does not model is dropped on the way to disk.
+        let value: serde_json::Value =
+            serde_json::from_str(&raw).unwrap_or(serde_json::Value::Null);
+        write(&out, &format!("{n:03}-{}.json", kind_of(&event)), &value)?;
         n += 1;
-        if event.trajectory_state_update.is_some() {
-            let state = event
-                .trajectory_state_update
-                .as_ref()
-                .and_then(|t| t.state.clone());
-            println!("trajectory -> {state:?}");
-            if matches!(state.as_ref().map(|s| s.as_str()), Some("STATE_FULLY_IDLE")) {
+
+        if let Some(state) = event
+            .trajectory_state_update
+            .as_ref()
+            .and_then(|t| t.state.clone())
+        {
+            println!("trajectory -> {state}");
+            if state.as_str() == "STATE_FULLY_IDLE" {
                 break;
             }
         }
@@ -89,4 +162,10 @@ async fn main() -> Result<()> {
 
     println!("wrote {n} frames to {}", out.display());
     client.shutdown().await
+}
+
+fn write(dir: &std::path::Path, name: &str, value: &serde_json::Value) -> std::io::Result<()> {
+    let body =
+        serde_json::to_string_pretty(value).map_err(|e| std::io::Error::other(e.to_string()))?;
+    std::fs::write(dir.join(name), body + "\n")
 }

--- a/antigravity-codes/src/client_raw.rs
+++ b/antigravity-codes/src/client_raw.rs
@@ -44,6 +44,10 @@ pub struct RawClient {
     harness: Harness,
     socket: ws::Socket,
     initialize: InitializeConversationResponse,
+    /// The initialize frame exactly as it arrived, kept so a capture can record
+    /// the whole session verbatim — this one is consumed during `launch`, so it
+    /// is otherwise unrecoverable.
+    initialize_frame: String,
     closed: bool,
 }
 
@@ -57,6 +61,7 @@ impl RawClient {
             harness,
             socket,
             initialize: Default::default(),
+            initialize_frame: String::new(),
             closed: false,
         };
 
@@ -68,10 +73,11 @@ impl RawClient {
         // The harness answers the initialize event before anything else. If it
         // instead drops the socket, the reason is on stderr — most often "no
         // model configured", which it treats as fatal.
-        match client.next_event().await? {
-            Some(event) => match event.into_event() {
+        match client.next_frame().await? {
+            Some((raw, event)) => match event.into_event() {
                 Some(OutputEventEvent::InitializeConversationResponse(response)) => {
                     client.initialize = response;
+                    client.initialize_frame = raw;
                 }
                 other => {
                     return Err(Error::HandshakeFailed {
@@ -106,6 +112,15 @@ impl RawClient {
         self.initialize.cascade_id.as_deref()
     }
 
+    /// The initialize frame as it arrived on the wire.
+    ///
+    /// `launch` consumes this frame, so it is the one part of a session a
+    /// caller could not otherwise record. See [`Self::next_frame`] for why the
+    /// raw form is what matters for a capture.
+    pub fn initialize_frame(&self) -> &str {
+        &self.initialize_frame
+    }
+
     /// The running process, for its stderr tail and port.
     pub fn harness(&self) -> &Harness {
         &self.harness
@@ -131,6 +146,18 @@ impl RawClient {
     /// Non-text frames (pings, pongs, the close frame itself) are handled and
     /// skipped rather than surfaced.
     pub async fn next_event(&mut self) -> Result<Option<OutputEvent>> {
+        Ok(self.next_frame().await?.map(|(_raw, event)| event))
+    }
+
+    /// Like [`Self::next_event`], but also hands back the frame exactly as it
+    /// arrived.
+    ///
+    /// The raw text is what makes a capture evidentiary. A frame that has been
+    /// decoded and re-encoded can only contain fields this crate already knows
+    /// about, so a corpus built from re-serialised frames cannot detect a field
+    /// the types are missing — it agrees with itself by construction. Use this
+    /// when recording fixtures, or when attaching a frame to a bug report.
+    pub async fn next_frame(&mut self) -> Result<Option<(String, OutputEvent)>> {
         loop {
             let message = match self.socket.next().await {
                 Some(Ok(message)) => message,
@@ -154,9 +181,11 @@ impl RawClient {
             match message {
                 Message::Text(text) => {
                     log::trace!("<-- {text}");
-                    let event = serde_json::from_str::<OutputEvent>(&text)
-                        .map_err(|e| Error::decode(e, text))?;
-                    return Ok(Some(event));
+                    let event = match serde_json::from_str::<OutputEvent>(&text) {
+                        Ok(event) => event,
+                        Err(e) => return Err(Error::decode(e, text)),
+                    };
+                    return Ok(Some((text, event)));
                 }
                 Message::Close(_) => {
                     self.closed = true;

--- a/antigravity-codes/test_cases/README.md
+++ b/antigravity-codes/test_cases/README.md
@@ -1,26 +1,36 @@
 # Test cases
 
-Fixtures for `tests/deserialization_tests.rs`. Every file is one `OutputEvent`
-frame, formatted with 2-space indentation.
+Fixtures for `tests/deserialization_tests.rs` and `tests/step_assembly_tests.rs`.
+Every file is one `OutputEvent` frame, formatted with 2-space indentation.
 
-## `events/` — captured
+## `events/` — captured verbatim
 
-Frames recorded verbatim from a live `localharness` 0.1.10. This is the wire,
-not a re-serialisation of it, which is what makes the "decoding loses nothing"
-assertion meaningful: it compares every leaf of the original against the same
-document round-tripped through the crate's types.
+Frames recorded from a live `localharness` 0.1.10, re-indented but **not**
+re-encoded. That distinction is the whole point of this directory: a frame that
+has been decoded and re-encoded can only contain fields the crate already
+models, so a corpus built from re-serialised frames agrees with itself by
+construction and can never catch a field the types are missing. Only raw frames
+make `decoding_a_captured_frame_loses_nothing` mean anything.
 
-Three sessions, distinguished by the leading digit:
+(This was not hypothetical. The first pass at the capture example wrote decoded
+frames, and the one place it accidentally wrote a *differently shaped* value —
+the bare `InitializeConversationResponse` instead of the `OutputEvent` carrying
+it — was caught immediately by that test. `RawClient::next_frame` and
+`initialize_frame` exist so captures stay verbatim.)
+
+Four sessions, distinguished by the leading digit:
 
 | Prefix | Session | What it covers |
 |---|---|---|
 | `0xx` | Rejected API key | Handshake, initialize, prompt echo, in-band error step, `STATE_FULLY_IDLE` carrying a failure |
 | `1xx` | Live model, no tools | A full successful turn: twelve `stepUpdate` frames of incremental `textDelta`, then the settled `text`, plus a `usageUpdate` |
 | `2xx` | Live model, read-only tools | An agentic turn — `listDirectory` → `viewFile` → answer, across four step indices, with per-step `usageUpdate` frames |
+| `3xx` | Dynamic policy rule | A real `policyDecisionRequest`, raised by a `PolicyRule` with `is_dynamic` set |
 
-The `2xx` session is the one that exercises the interesting shapes: multiple
-concurrent step indices on one trajectory, action payloads nested inside a
-`stepUpdate`, and `STATE_ACTIVE` → `STATE_DONE` transitions per step.
+The `3xx` session also documents a behaviour worth knowing: the harness **blocks
+the turn indefinitely** on a policy request until the client answers. That
+session was recorded with `RawClient`, which does not answer, so it simply stops
+after the request — which is the evidence.
 
 Capture more with:
 
@@ -29,34 +39,52 @@ ANTIGRAVITY_HARNESS_PATH=/path/to/localharness GEMINI_API_KEY=... \
   cargo run -p antigravity-codes --example capture_frames -- ./captures "your prompt"
 ```
 
-Note that the example writes *re-serialised* frames, which would make the
-no-field-loss test tautological. For fixtures that carry their evidentiary
-weight, capture the raw text instead — `RUST_LOG=antigravity_codes=trace` logs
-every frame verbatim as it arrives.
+`ANTIGRAVITY_TOOLS=all`, `ANTIGRAVITY_SUBAGENTS=1`, and `ANTIGRAVITY_POLICY=1`
+widen what a session will exercise.
 
-### Still not represented
+### Not captured, and why
 
-- **Subagent trajectories.** Needs a session with `subagents` enabled and a
-  prompt that provokes delegation.
-- **Harness-side write tools** — `editFile`, `createFile`, `runCommand`. The
-  captures use the read-only default; these are covered synthetically.
-- **`policyDecisionRequest`.** Needs a dynamic policy rule configured.
+Recording an agentic turn costs many model calls, and the Gemini free tier
+allows **20 requests per minute** — which a single multi-step turn can exhaust
+on its own, made worse by the harness retrying internally on `429`. Sessions
+that were observed working live but could not be re-recorded verbatim within
+that budget:
+
+- **Write tools** — `editFile` and `runCommand` frames. A session that created a
+  file, edited another, and ran `wc -l` was observed completing correctly (45
+  frames), but only via the earlier re-serialising recorder. Covered
+  synthetically for now.
+- **Subagent delegation** — observed producing two concurrent trajectories, the
+  main one a 32-hex cascade id and the subagent a UUID, each numbering steps
+  from zero. Modelled in `synthetic/subagent-session/` from that observation.
+
+Both are worth re-recording on an account without the free-tier cap.
 
 ## `synthetic/` — hand-written
 
 Frames for paths the captured sessions do not reach: client-side tool calls,
-lifecycle hooks, policy decisions, questions, tool confirmations, and the write
-actions above. These are written against the protobuf descriptor rather than
-observed, so they prove the types decode a *correct* frame — not that the
-harness emits exactly this shape.
+lifecycle hooks, questions, tool confirmations, and the write actions above.
+Written against the protobuf descriptor rather than observed, so they prove the
+types decode a *correct* frame — not that the harness emits exactly this shape.
 
 Two of those paths *are* known to work end to end even though the committed
 fixture is synthetic: `examples/custom_tool.rs` runs a live session that
 provokes a real `callHookRequest` (`LIFECYCLE_HOOK_PRE_TOOL`) and a real
-`toolCall`, answers both, and the model consumes the tool's result. That
-exercise is what the synthetic fixtures are modelled on.
+`toolCall`, answers both, and the model consumes the tool's result.
 
-Two files are deliberately wrong:
+And where a real capture later arrived, it confirmed the synthetic shape:
+`synthetic/policy-decision-request.json` was written blind from the descriptor,
+and the captured `3xx` frame matches it field for field, differing only in that
+the harness sends `serverName: ""` explicitly and omits `callId`.
+
+### `synthetic/subagent-session/`
+
+A whole replayable session rather than a single frame, consumed by
+`step_assembly_tests.rs`. It is the only fixture exercising concurrent
+trajectories, which is what makes `(trajectory_id, step_index)` — rather than
+the index alone — the necessary key for step bookkeeping.
+
+### Deliberately wrong
 
 - `unknown-future-frame.json` — an `OutputEvent` whose `oneof` arm this crate
   has never heard of. Must decode, with no arm set.

--- a/antigravity-codes/test_cases/events/300-initialize-response.json
+++ b/antigravity-codes/test_cases/events/300-initialize-response.json
@@ -1,0 +1,7 @@
+{
+  "initializeConversationResponse": {
+    "cascadeId": "a1af14e4602c5a4fd4c16670ac0328ad"
+  },
+  "seqNum": "1",
+  "timestampMicros": "1786229238323517"
+}

--- a/antigravity-codes/test_cases/events/301-trajectory-state.json
+++ b/antigravity-codes/test_cases/events/301-trajectory-state.json
@@ -1,0 +1,8 @@
+{
+  "seqNum": "2",
+  "timestampMicros": "1786229238327093",
+  "trajectoryStateUpdate": {
+    "state": "STATE_RUNNING",
+    "trajectoryId": "a1af14e4602c5a4fd4c16670ac0328ad"
+  }
+}

--- a/antigravity-codes/test_cases/events/302-step-update.json
+++ b/antigravity-codes/test_cases/events/302-step-update.json
@@ -1,0 +1,16 @@
+{
+  "seqNum": "3",
+  "stepUpdate": {
+    "cascadeId": "a1af14e4602c5a4fd4c16670ac0328ad",
+    "source": "SOURCE_USER",
+    "state": "STATE_DONE",
+    "stepIndex": 0,
+    "target": "TARGET_MODEL",
+    "text": "Run the shell command 'echo hi'.",
+    "textDelta": "Run the shell command 'echo hi'.",
+    "thinking": "",
+    "thinkingDelta": "",
+    "trajectoryId": "a1af14e4602c5a4fd4c16670ac0328ad"
+  },
+  "timestampMicros": "1786229238417651"
+}

--- a/antigravity-codes/test_cases/events/303-policy-decision-request.json
+++ b/antigravity-codes/test_cases/events/303-policy-decision-request.json
@@ -1,0 +1,13 @@
+{
+  "policyDecisionRequest": {
+    "requestId": "1",
+    "ruleId": "shell-guard",
+    "toolArgs": {
+      "argumentsJson": "{\"CommandLine\":\"echo hi\",\"Cwd\":\"/tmp/agwrite\",\"WaitMsBeforeAsync\":2000}",
+      "serverName": "",
+      "toolName": "run_command"
+    }
+  },
+  "seqNum": "4",
+  "timestampMicros": "1786229240266527"
+}

--- a/antigravity-codes/test_cases/synthetic/subagent-session/00-trajectory-state-update.json
+++ b/antigravity-codes/test_cases/synthetic/subagent-session/00-trajectory-state-update.json
@@ -1,0 +1,8 @@
+{
+  "trajectoryStateUpdate": {
+    "trajectoryId": "f4466764cc0e2363826d740ae1dc4858",
+    "state": "STATE_RUNNING"
+  },
+  "seqNum": "1",
+  "timestampMicros": "1786229240000000"
+}

--- a/antigravity-codes/test_cases/synthetic/subagent-session/01-step-update.json
+++ b/antigravity-codes/test_cases/synthetic/subagent-session/01-step-update.json
@@ -1,0 +1,15 @@
+{
+  "stepUpdate": {
+    "cascadeId": "f4466764cc0e2363826d740ae1dc4858",
+    "trajectoryId": "f4466764cc0e2363826d740ae1dc4858",
+    "stepIndex": 0,
+    "state": "STATE_DONE",
+    "source": "SOURCE_MODEL",
+    "target": "TARGET_MODEL",
+    "thinking": "",
+    "thinkingDelta": "",
+    "text": "Delegate reading data.txt to a subagent."
+  },
+  "seqNum": "2",
+  "timestampMicros": "1786229240001000"
+}

--- a/antigravity-codes/test_cases/synthetic/subagent-session/02-step-update.json
+++ b/antigravity-codes/test_cases/synthetic/subagent-session/02-step-update.json
@@ -1,0 +1,16 @@
+{
+  "stepUpdate": {
+    "cascadeId": "f4466764cc0e2363826d740ae1dc4858",
+    "trajectoryId": "f4466764cc0e2363826d740ae1dc4858",
+    "stepIndex": 1,
+    "state": "STATE_ACTIVE",
+    "source": "SOURCE_MODEL",
+    "target": "TARGET_ENVIRONMENT",
+    "thinking": "",
+    "thinkingDelta": "",
+    "text": "Delegate file read",
+    "invokeSubagent": {}
+  },
+  "seqNum": "3",
+  "timestampMicros": "1786229240002000"
+}

--- a/antigravity-codes/test_cases/synthetic/subagent-session/03-trajectory-state-update.json
+++ b/antigravity-codes/test_cases/synthetic/subagent-session/03-trajectory-state-update.json
@@ -1,0 +1,8 @@
+{
+  "trajectoryStateUpdate": {
+    "trajectoryId": "c36cb265-6252-4bb8-bbac-e2180e9eb172",
+    "state": "STATE_RUNNING"
+  },
+  "seqNum": "4",
+  "timestampMicros": "1786229240003000"
+}

--- a/antigravity-codes/test_cases/synthetic/subagent-session/04-step-update.json
+++ b/antigravity-codes/test_cases/synthetic/subagent-session/04-step-update.json
@@ -1,0 +1,20 @@
+{
+  "stepUpdate": {
+    "cascadeId": "f4466764cc0e2363826d740ae1dc4858",
+    "trajectoryId": "c36cb265-6252-4bb8-bbac-e2180e9eb172",
+    "stepIndex": 0,
+    "state": "STATE_ACTIVE",
+    "source": "SOURCE_MODEL",
+    "target": "TARGET_ENVIRONMENT",
+    "thinking": "",
+    "thinkingDelta": "",
+    "text": "Read data.txt",
+    "viewFile": {
+      "filePath": "/tmp/agwrite/data.txt",
+      "startLine": 1,
+      "endLine": 3
+    }
+  },
+  "seqNum": "5",
+  "timestampMicros": "1786229240004000"
+}

--- a/antigravity-codes/test_cases/synthetic/subagent-session/05-step-update.json
+++ b/antigravity-codes/test_cases/synthetic/subagent-session/05-step-update.json
@@ -1,0 +1,20 @@
+{
+  "stepUpdate": {
+    "cascadeId": "f4466764cc0e2363826d740ae1dc4858",
+    "trajectoryId": "c36cb265-6252-4bb8-bbac-e2180e9eb172",
+    "stepIndex": 0,
+    "state": "STATE_DONE",
+    "source": "SOURCE_MODEL",
+    "target": "TARGET_ENVIRONMENT",
+    "thinking": "",
+    "thinkingDelta": "",
+    "text": "Read data.txt",
+    "viewFile": {
+      "filePath": "/tmp/agwrite/data.txt",
+      "startLine": 1,
+      "endLine": 3
+    }
+  },
+  "seqNum": "6",
+  "timestampMicros": "1786229240005000"
+}

--- a/antigravity-codes/test_cases/synthetic/subagent-session/06-step-update.json
+++ b/antigravity-codes/test_cases/synthetic/subagent-session/06-step-update.json
@@ -1,0 +1,15 @@
+{
+  "stepUpdate": {
+    "cascadeId": "f4466764cc0e2363826d740ae1dc4858",
+    "trajectoryId": "c36cb265-6252-4bb8-bbac-e2180e9eb172",
+    "stepIndex": 1,
+    "state": "STATE_ACTIVE",
+    "source": "SOURCE_MODEL",
+    "target": "TARGET_USER",
+    "thinking": "",
+    "thinkingDelta": "",
+    "textDelta": "The second "
+  },
+  "seqNum": "7",
+  "timestampMicros": "1786229240006000"
+}

--- a/antigravity-codes/test_cases/synthetic/subagent-session/07-step-update.json
+++ b/antigravity-codes/test_cases/synthetic/subagent-session/07-step-update.json
@@ -1,0 +1,15 @@
+{
+  "stepUpdate": {
+    "cascadeId": "f4466764cc0e2363826d740ae1dc4858",
+    "trajectoryId": "c36cb265-6252-4bb8-bbac-e2180e9eb172",
+    "stepIndex": 1,
+    "state": "STATE_DONE",
+    "source": "SOURCE_MODEL",
+    "target": "TARGET_USER",
+    "thinking": "",
+    "thinkingDelta": "",
+    "text": "The second line is `beta`."
+  },
+  "seqNum": "8",
+  "timestampMicros": "1786229240007000"
+}

--- a/antigravity-codes/test_cases/synthetic/subagent-session/08-trajectory-state-update.json
+++ b/antigravity-codes/test_cases/synthetic/subagent-session/08-trajectory-state-update.json
@@ -1,0 +1,8 @@
+{
+  "trajectoryStateUpdate": {
+    "trajectoryId": "c36cb265-6252-4bb8-bbac-e2180e9eb172",
+    "state": "STATE_FULLY_IDLE"
+  },
+  "seqNum": "9",
+  "timestampMicros": "1786229240008000"
+}

--- a/antigravity-codes/test_cases/synthetic/subagent-session/09-step-update.json
+++ b/antigravity-codes/test_cases/synthetic/subagent-session/09-step-update.json
@@ -1,0 +1,16 @@
+{
+  "stepUpdate": {
+    "cascadeId": "f4466764cc0e2363826d740ae1dc4858",
+    "trajectoryId": "f4466764cc0e2363826d740ae1dc4858",
+    "stepIndex": 1,
+    "state": "STATE_DONE",
+    "source": "SOURCE_MODEL",
+    "target": "TARGET_ENVIRONMENT",
+    "thinking": "",
+    "thinkingDelta": "",
+    "text": "Delegate file read",
+    "invokeSubagent": {}
+  },
+  "seqNum": "10",
+  "timestampMicros": "1786229240009000"
+}

--- a/antigravity-codes/test_cases/synthetic/subagent-session/10-step-update.json
+++ b/antigravity-codes/test_cases/synthetic/subagent-session/10-step-update.json
@@ -1,0 +1,15 @@
+{
+  "stepUpdate": {
+    "cascadeId": "f4466764cc0e2363826d740ae1dc4858",
+    "trajectoryId": "f4466764cc0e2363826d740ae1dc4858",
+    "stepIndex": 2,
+    "state": "STATE_ACTIVE",
+    "source": "SOURCE_MODEL",
+    "target": "TARGET_USER",
+    "thinking": "",
+    "thinkingDelta": "",
+    "textDelta": "The subagent "
+  },
+  "seqNum": "11",
+  "timestampMicros": "1786229240010000"
+}

--- a/antigravity-codes/test_cases/synthetic/subagent-session/11-step-update.json
+++ b/antigravity-codes/test_cases/synthetic/subagent-session/11-step-update.json
@@ -1,0 +1,15 @@
+{
+  "stepUpdate": {
+    "cascadeId": "f4466764cc0e2363826d740ae1dc4858",
+    "trajectoryId": "f4466764cc0e2363826d740ae1dc4858",
+    "stepIndex": 2,
+    "state": "STATE_DONE",
+    "source": "SOURCE_MODEL",
+    "target": "TARGET_USER",
+    "thinking": "",
+    "thinkingDelta": "",
+    "text": "The subagent reports the second line is `beta`."
+  },
+  "seqNum": "12",
+  "timestampMicros": "1786229240011000"
+}

--- a/antigravity-codes/test_cases/synthetic/subagent-session/12-usage-update.json
+++ b/antigravity-codes/test_cases/synthetic/subagent-session/12-usage-update.json
@@ -1,0 +1,20 @@
+{
+  "usageUpdate": {
+    "total": {
+      "promptTokenCount": "2100",
+      "candidatesTokenCount": "64",
+      "totalTokenCount": "2164"
+    },
+    "agents": [
+      {
+        "trajectoryId": "c36cb265-6252-4bb8-bbac-e2180e9eb172",
+        "usage": {
+          "promptTokenCount": "410",
+          "totalTokenCount": "455"
+        }
+      }
+    ]
+  },
+  "seqNum": "13",
+  "timestampMicros": "1786229240012000"
+}

--- a/antigravity-codes/test_cases/synthetic/subagent-session/13-trajectory-state-update.json
+++ b/antigravity-codes/test_cases/synthetic/subagent-session/13-trajectory-state-update.json
@@ -1,0 +1,8 @@
+{
+  "trajectoryStateUpdate": {
+    "trajectoryId": "f4466764cc0e2363826d740ae1dc4858",
+    "state": "STATE_FULLY_IDLE"
+  },
+  "seqNum": "14",
+  "timestampMicros": "1786229240013000"
+}

--- a/antigravity-codes/tests/step_assembly_tests.rs
+++ b/antigravity-codes/tests/step_assembly_tests.rs
@@ -1,0 +1,196 @@
+//! Replays captured sessions through [`StepAssembler`].
+//!
+//! The unit tests in `steps.rs` feed it hand-built updates, which proves the
+//! accumulation arithmetic but not that the arithmetic matches how a real
+//! harness actually streams. These tests replay whole recorded sessions —
+//! frames in the order they arrived — and assert the invariants that consumers
+//! rely on.
+
+#![cfg(feature = "async-client")]
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
+
+use antigravity_codes::protocol::{OutputEvent, StepUpdateState};
+use antigravity_codes::steps::StepAssembler;
+
+/// Every replayable session, ordered within itself by the harness's own
+/// sequence number.
+///
+/// Two sources. `test_cases/events/` holds frames captured verbatim, grouped
+/// into sessions by filename prefix. `test_cases/synthetic/subagent-session/`
+/// is hand-built: the free-tier quota would not sustain a real delegating turn
+/// long enough to record one, so that session is modelled on the shape of one
+/// that *was* observed live — main conversation on a 32-hex cascade id, the
+/// subagent on its own UUID trajectory, both numbering steps from zero.
+fn sessions() -> BTreeMap<String, Vec<OutputEvent>> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("test_cases");
+    let mut out: BTreeMap<String, Vec<(i64, OutputEvent)>> = BTreeMap::new();
+
+    let mut collect = |dir: &Path, name_of: &dyn Fn(&str) -> String| {
+        for entry in std::fs::read_dir(dir).unwrap_or_else(|e| panic!("{}: {e}", dir.display())) {
+            let path = entry.expect("readable dir entry").path();
+            if path.extension().is_none_or(|e| e != "json") {
+                continue;
+            }
+            let file = path.file_name().unwrap().to_string_lossy().to_string();
+            let raw = std::fs::read_to_string(&path).expect("readable fixture");
+            let event: OutputEvent =
+                serde_json::from_str(&raw).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+            out.entry(name_of(&file))
+                .or_default()
+                .push((event.seq_num.unwrap_or(0), event));
+        }
+    };
+
+    collect(&root.join("events"), &|file| {
+        format!(
+            "captured-{}",
+            file.chars().next().expect("fixtures are prefixed")
+        )
+    });
+    collect(&root.join("synthetic/subagent-session"), &|_| {
+        "synthetic-subagent".to_string()
+    });
+
+    out.into_iter()
+        .map(|(session, mut frames)| {
+            frames.sort_by_key(|(seq, _)| *seq);
+            (
+                session,
+                frames.into_iter().map(|(_, event)| event).collect(),
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn every_session_replays_without_losing_text() {
+    for (session, frames) in sessions() {
+        let mut assembler = StepAssembler::new(None);
+        // Longest text seen per step, to prove accumulation never goes backwards.
+        let mut high_water: HashMap<String, usize> = HashMap::new();
+
+        for event in frames {
+            let Some(update) = event.step_update else {
+                continue;
+            };
+            let step = assembler.ingest(update);
+            let seen = high_water.entry(step.id()).or_default();
+            assert!(
+                step.text.chars().count() >= *seen,
+                "session {session}: step {} lost text ({} -> {})",
+                step.id(),
+                seen,
+                step.text.chars().count()
+            );
+            *seen = step.text.chars().count();
+        }
+        assert!(
+            !high_water.is_empty(),
+            "session {session} produced no steps"
+        );
+    }
+}
+
+#[test]
+fn a_settled_step_is_final_and_keeps_its_text() {
+    let mut settled = 0;
+    for (session, frames) in sessions() {
+        let mut assembler = StepAssembler::new(None);
+        for event in frames {
+            let Some(update) = event.step_update else {
+                continue;
+            };
+            let state = update.state.clone();
+            let step = assembler.ingest(update);
+            if matches!(state, Some(StepUpdateState::Done)) {
+                assert!(
+                    step.is_final(),
+                    "session {session}: STATE_DONE step is not final"
+                );
+                settled += 1;
+            }
+        }
+    }
+    assert!(settled > 0, "the corpus should contain settled steps");
+}
+
+/// A delegating agent runs its subagent on a *different* trajectory, so any
+/// bookkeeping keyed on `step_index` alone would collide. This replays the
+/// session with the most trajectories and asserts they stay separate.
+#[test]
+fn concurrent_trajectories_stay_separate() {
+    let sessions = sessions();
+    let (session, frames) = sessions
+        .iter()
+        .map(|(session, frames)| {
+            let trajectories: std::collections::HashSet<_> = frames
+                .iter()
+                .filter_map(|e| e.step_update.as_ref()?.trajectory_id.clone())
+                .collect();
+            (session, frames, trajectories.len())
+        })
+        .max_by_key(|(_, _, count)| *count)
+        .map(|(session, frames, _)| (session, frames))
+        .expect("the corpus has at least one session");
+
+    let mut assembler = StepAssembler::new(None);
+    let mut per_trajectory: HashMap<String, usize> = HashMap::new();
+    for event in frames {
+        let Some(update) = event.step_update.clone() else {
+            continue;
+        };
+        let step = assembler.ingest(update);
+        *per_trajectory
+            .entry(step.trajectory_id.clone())
+            .or_default() += 1;
+    }
+
+    assert!(
+        per_trajectory.len() >= 2,
+        "session {session} should carry a subagent on its own trajectory, saw {:?}",
+        per_trajectory.keys()
+    );
+
+    // Exactly one trajectory is the conversation; the rest are subagents. Only
+    // the main one ending should end the turn.
+    let main = assembler
+        .main_trajectory()
+        .expect("a main trajectory was adopted");
+    let subagents = per_trajectory
+        .keys()
+        .filter(|id| id.as_str() != main)
+        .count();
+    assert_eq!(subagents, per_trajectory.len() - 1);
+    assert!(assembler.is_main(main));
+}
+
+/// Step indices restart per trajectory, so `(trajectory, index)` is the only
+/// safe key — this asserts the corpus actually exhibits the collision that
+/// keying on the index alone would hit.
+#[test]
+fn step_indices_collide_across_trajectories() {
+    let mut collided = false;
+    for (_, frames) in sessions() {
+        let mut by_index: HashMap<u32, std::collections::HashSet<String>> = HashMap::new();
+        for event in &frames {
+            if let Some(update) = event.step_update.as_ref() {
+                if let (Some(index), Some(trajectory)) =
+                    (update.step_index, update.trajectory_id.clone())
+                {
+                    by_index.entry(index).or_default().insert(trajectory);
+                }
+            }
+        }
+        if by_index.values().any(|t| t.len() > 1) {
+            collided = true;
+        }
+    }
+    assert!(
+        collided,
+        "no session reuses a step index across trajectories, so \
+         `concurrent_trajectories_stay_separate` is not actually exercising the \
+         collision it claims to — check that the subagent session is present"
+    );
+}


### PR DESCRIPTION
Closes the support work left open when the crate landed in #295.

## The recorder was lying to the test suite

`examples/capture_frames` wrote frames back out through the crate's own types. That makes `decoding_a_captured_frame_loses_nothing` **tautological** — a re-encoded frame can only contain fields the types already model, so the corpus agrees with itself and can never catch a field we're missing.

`RawClient::next_frame` now returns the raw text alongside the decoded event, and `RawClient::initialize_frame` retains the one frame `launch` consumes. A capture is now the wire, not our reading of it.

That change paid for itself immediately: with raw frames the no-loss test **failed on the first run**, because the example had been writing the bare `InitializeConversationResponse` where the `OutputEvent` carrying it belonged. A re-serialising recorder could not have noticed.

## New coverage

- **A captured `policyDecisionRequest` session.** It confirms the synthetic fixture — written blind from the descriptor — was right field for field, differing only in that the harness sends `serverName: ""` explicitly and omits `callId`. It also documents that the harness **blocks a turn indefinitely** until the client answers a policy request.
- **`tests/step_assembly_tests.rs`** replays whole sessions through `StepAssembler`: accumulated text never regresses, settled steps stay final, concurrent trajectories stay separate. The unit tests in `steps.rs` prove the arithmetic; these prove it matches how a harness really streams.
- **A synthetic subagent session**, modelled on one observed live — main conversation on a 32-hex cascade id, subagent on a UUID trajectory, both numbering steps from zero. It's the only fixture exercising the index collision that makes `(trajectory_id, step_index)` the necessary key, so a test guards that it stays present.

## What I could not finish, and why

Recording an agentic turn costs many model calls, and the Gemini free tier allows **20 requests/minute** — which a single multi-step turn exhausts on its own, made worse by the harness retrying internally on `429`. Two sessions were observed working live but could not be re-recorded verbatim within that budget:

- **Write tools** (`editFile`, `runCommand`) — a session that created a file, edited another, and ran `wc -l` completed correctly across 45 frames, but only under the earlier re-serialising recorder. Covered synthetically.
- **Subagent delegation** — observed producing two concurrent trajectories. Modelled synthetically from that observation.

Both are documented as gaps in `test_cases/README.md` rather than papered over, and both are worth re-recording on an account without the free-tier cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)