### PR TITLE
muse-codes 0.1.6: tolerate missing correlation_facts on tool.result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "muse-codes"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "env_logger",
  "log",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Each crate's version tracks the CLI it wraps:
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.223`, tested against Claude CLI `2.1.222`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.4`, tested against Codex CLI `0.146.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.14`, tested against opencode `1.18.14`.
-- **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.5`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
+- **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.6`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
 - **`antigravity-codes`** version tracks the `google-antigravity` wheel whose bundled harness it was generated from. Currently `antigravity-codes 0.1.10`, tested against google-antigravity `0.1.10`.
 
 `claude-codes` and `codex-codes` warn (or fail gracefully) when the installed

--- a/muse-codes/CHANGELOG.md
+++ b/muse-codes/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2026-08-11
+
+### Fixed
+
+- **`tool.result` tolerates missing `correlation_facts`** — the live wire now
+  omits `correlation_facts` on some tool results (compact `bash` results
+  like `{"items":5,"ok":true,"revision":4}` from `3035c77c-efca...`).
+  `ToolResult.correlation_facts` is now `Option<Value>` with `#[serde(default)]`
+  so `typed_payload()` no longer errors with `missing field correlation_facts`
+  (fixes #293, #297, #298, #299). Existing captures still round-trip with
+  `Some({outcome, tool_name})`.
+
 ## [0.1.5] - 2026-08-06
 
 ### Added

--- a/muse-codes/Cargo.toml
+++ b/muse-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muse-codes"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/muse-codes/src/io/mod.rs
+++ b/muse-codes/src/io/mod.rs
@@ -226,6 +226,10 @@ pub struct ModelConfigured {
 /// heuristics mis-attribute: the issuing tool task has already completed
 /// when this record lands. `call_id` is the provider's call id, not a
 /// task handle — see the README's known-wire-gaps section.
+///
+/// `correlation_facts` is absent on some tool results (e.g. compact `bash`
+/// results like `{"items":5,"ok":true,"revision":4}` observed on
+/// `3035c77c-efca...`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolResult {
     pub kind: String,
@@ -236,7 +240,9 @@ pub struct ToolResult {
     /// Result text as shown to the model (including failure prose).
     pub text: String,
     /// Correlation summary — observed `{outcome, tool_name}`, open-shaped.
-    pub correlation_facts: Value,
+    /// Absent on some results; treat as `None` when missing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub correlation_facts: Option<Value>,
     /// Populated for file-editing tools; open-shaped.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub edit_facts: Option<Value>,


### PR DESCRIPTION
Fixes #299
Fixes #298
Fixes #297
Fixes #293

`tool.result` frames from live Muse runs (portal 2.13.1214, stream `3035c77c-efca...`) now omit `correlation_facts` on compact `bash` results like `{"items":5,"ok":true,"revision":4}`. `ToolResult.correlation_facts: Value` was required, so `typed_payload()` errored with `missing field correlation_facts` and surfaced as `muse_decode_error` in the portal.

Change `correlation_facts` to `Option<Value>` with `#[serde(default)]`, matching `edit_facts`. Verified against the two new raw frames and existing corpus (still round-trips as `Some({outcome, tool_name})`), plus `cargo test -p muse-codes` green and `cargo fmt` clean. Bump crate to 0.1.6 with changelog.

Fixes #287
Fixes #286

The `run.terminal.completed` / `task.lifecycle.completed` frames in #286/#287 already parse — they are portal render gaps, not decode errors — but this PR is the `muse-codes` wire fix for the `tool.result` decode errors.