### PR TITLE
codex-codes: resnapshot app-server schemas vs openai/codex@main (fixes #288)

### DIFF
--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -535,6 +535,8 @@ pub struct AppsReadParams {
         skip_serializing_if = "Option::is_none"
     )]
     pub include_tools: Option<bool>,
+    #[serde(rename = "threadId", default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -610,6 +612,23 @@ pub enum AutoCompactTokenLimitScope {
 pub enum AutoReviewDecisionSource {
     #[serde(rename = "agent")]
     Agent,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AutoReviewRequirements {
+    #[serde(
+        rename = "ignoreRules",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub ignore_rules: Option<Vec<String>>,
+    #[serde(
+        rename = "requiredOnModels",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub required_on_models: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -1251,6 +1270,10 @@ pub struct ConfigLayerMetadata {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum ConfigLayerSource {
+    #[serde(rename = "packagedDefaults")]
+    PackagedDefaults {
+        file: Value,
+    },
     Mdm {
         domain: String,
         key: String,
@@ -1363,6 +1386,12 @@ pub struct ConfigRequirements {
         skip_serializing_if = "Option::is_none"
     )]
     pub allowed_windows_sandbox_implementations: Option<Vec<WindowsSandboxSetupMode>>,
+    #[serde(
+        rename = "autoReview",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub auto_review: Option<AutoReviewRequirements>,
     #[serde(
         rename = "browserUse",
         default,
@@ -2762,6 +2791,12 @@ pub struct HookMetadata {
     pub enabled: bool,
     #[serde(rename = "eventName")]
     pub event_name: HookEventName,
+    #[serde(
+        rename = "executionMode",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub execution_mode: Option<Value>,
     #[serde(rename = "handlerType")]
     pub handler_type: HookHandlerType,
     #[serde(rename = "isManaged", default)]
@@ -3787,6 +3822,8 @@ pub struct McpServerStatus {
     pub auth_status: McpAuthStatus,
     #[serde(default)]
     pub name: String,
+    #[serde(rename = "pluginId", default, skip_serializing_if = "Option::is_none")]
+    pub plugin_id: Option<String>,
     #[serde(rename = "resourceTemplates", default)]
     pub resource_templates: Vec<ResourceTemplate>,
     #[serde(default)]
@@ -4047,6 +4084,12 @@ pub struct Model {
     )]
     pub model_specialty: Option<String>,
     #[serde(
+        rename = "multiAgentVersion",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub multi_agent_version: Option<MultiAgentVersion>,
+    #[serde(
         rename = "serviceTiers",
         default,
         skip_serializing_if = "Option::is_none"
@@ -4221,6 +4264,16 @@ pub struct ModelVerificationNotification {
 pub struct ModelsRequirements {
     #[serde(rename = "newThread", default, skip_serializing_if = "Option::is_none")]
     pub new_thread: Option<NewThreadModelDefaults>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum MultiAgentVersion {
+    #[serde(rename = "disabled")]
+    Disabled,
+    #[serde(rename = "v1")]
+    V1,
+    #[serde(rename = "v2")]
+    V2,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -4569,6 +4622,12 @@ pub struct PluginHookSummary {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PluginInstallParams {
+    #[serde(
+        rename = "installAttemptId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub install_attempt_id: Option<String>,
     #[serde(
         rename = "marketplacePath",
         default,
@@ -6702,6 +6761,12 @@ pub enum ThreadItem {
         #[serde(rename = "savedPath", default, skip_serializing_if = "Option::is_none")]
         saved_path: Option<AbsolutePathBuf>,
         status: String,
+        #[serde(
+            rename = "transparentBackground",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        transparent_background: Option<bool>,
     },
     #[serde(rename = "enteredReviewMode")]
     EnteredReviewMode {
@@ -7084,6 +7149,8 @@ pub struct ThreadRollbackResponse {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ThreadSection {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub appearance: Option<ThreadSectionAppearance>,
     #[serde(default)]
     pub id: String,
     #[serde(default)]
@@ -7092,7 +7159,18 @@ pub struct ThreadSection {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
+pub struct ThreadSectionAppearance {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct ThreadSectionCreateParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub appearance: Option<ThreadSectionAppearance>,
     #[serde(default)]
     pub name: String,
 }
@@ -7165,6 +7243,8 @@ pub struct ThreadSectionMoveResponse {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ThreadSectionUpdateParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub appearance: Option<ThreadSectionAppearance>,
     #[serde(default)]
     pub name: String,
     #[serde(rename = "sectionId", default)]

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -7224,6 +7224,13 @@
           "includeTools": {
             "description": "When true, include display-only public tool summaries in the returned metadata.",
             "type": "boolean"
+          },
+          "threadId": {
+            "description": "Optional loaded thread id used to evaluate effective app configuration.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
@@ -7384,6 +7391,29 @@
           "agent"
         ],
         "type": "string"
+      },
+      "AutoReviewRequirements": {
+        "properties": {
+          "ignoreRules": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "requiredOnModels": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
       },
       "BrowserUseRequirements": {
         "properties": {
@@ -8487,6 +8517,32 @@
       "ConfigLayerSource": {
         "oneOf": [
           {
+            "description": "Default configuration supplied with the installed Codex package.",
+            "properties": {
+              "file": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/v2/AbsolutePathBuf"
+                  }
+                ],
+                "description": "Path to the packaged default configuration file."
+              },
+              "type": {
+                "enum": [
+                  "packagedDefaults"
+                ],
+                "title": "PackagedDefaultsConfigLayerSourceType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "file",
+              "type"
+            ],
+            "title": "PackagedDefaultsConfigLayerSource",
+            "type": "object"
+          },
+          {
             "description": "Managed preferences layer delivered by MDM (macOS only).",
             "properties": {
               "domain": {
@@ -8791,6 +8847,16 @@
               "null"
             ]
           },
+          "autoReview": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/AutoReviewRequirements"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "browserUse": {
             "anyOf": [
               {
@@ -9067,6 +9133,49 @@
               "type"
             ],
             "title": "CommandConfiguredHookHandler",
+            "type": "object"
+          },
+          {
+            "properties": {
+              "input": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "server": {
+                "type": "string"
+              },
+              "statusMessage": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "timeoutSec": {
+                "format": "uint64",
+                "minimum": 0.0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "tool": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "mcp_tool"
+                ],
+                "title": "McpToolConfiguredHookHandlerType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "input",
+              "server",
+              "tool",
+              "type"
+            ],
+            "title": "McpToolConfiguredHookHandler",
             "type": "object"
           },
           {
@@ -11718,6 +11827,14 @@
           "eventName": {
             "$ref": "#/definitions/v2/HookEventName"
           },
+          "executionMode": {
+            "allOf": [
+              {
+                "$ref": "#/definitions/v2/HookExecutionMode"
+              }
+            ],
+            "default": "sync"
+          },
           "handlerType": {
             "$ref": "#/definitions/v2/HookHandlerType"
           },
@@ -13117,6 +13234,12 @@
           "name": {
             "type": "string"
           },
+          "pluginId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "resourceTemplates": {
             "items": {
               "$ref": "#/definitions/v2/ResourceTemplate"
@@ -13547,6 +13670,17 @@
               "null"
             ]
           },
+          "multiAgentVersion": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/MultiAgentVersion"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Multi-agent runtime declared by this model, when available."
+          },
           "serviceTiers": {
             "default": [],
             "items": {
@@ -13880,6 +14014,15 @@
             "type": "object"
           }
         ]
+      },
+      "MultiAgentVersion": {
+        "description": "Multi-agent runtime supported by a model.",
+        "enum": [
+          "disabled",
+          "v1",
+          "v2"
+        ],
+        "type": "string"
       },
       "NetworkAccess": {
         "enum": [
@@ -14403,6 +14546,13 @@
       "PluginInstallParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
+          "installAttemptId": {
+            "description": "Client-generated identifier used to correlate one installation attempt.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "marketplacePath": {
             "anyOf": [
               {
@@ -17676,6 +17826,52 @@
         "title": "SendAddCreditsNudgeEmailResponse",
         "type": "object"
       },
+      "ServerDiagnosticsGauge": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "name",
+          "value"
+        ],
+        "type": "object"
+      },
+      "ServerDiagnosticsProcess": {
+        "properties": {
+          "id": {
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "physicalFootprintBytes": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "residentMemoryBytes": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
       "ServerRequestResolvedNotification": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
@@ -19779,6 +19975,13 @@
               "status": {
                 "type": "string"
               },
+              "transparentBackground": {
+                "default": null,
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
               "type": {
                 "enum": [
                   "imageGeneration"
@@ -20719,6 +20922,18 @@
       "ThreadSection": {
         "description": "An independently persisted, user-visible thread section.",
         "properties": {
+          "appearance": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ThreadSectionAppearance"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional appearance synchronized across clients."
+          },
           "id": {
             "description": "Opaque UUIDv7 identity that remains stable when the section is renamed.",
             "type": "string"
@@ -20734,10 +20949,39 @@
         ],
         "type": "object"
       },
+      "ThreadSectionAppearance": {
+        "description": "Extensible visual presentation for a custom thread section.",
+        "properties": {
+          "color": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "icon": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
       "ThreadSectionCreateParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "description": "Parameters for creating an independently persisted thread section.",
         "properties": {
+          "appearance": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ThreadSectionAppearance"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
           "name": {
             "description": "The user-visible name of the section.",
             "type": "string"
@@ -20871,6 +21115,17 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "description": "Parameters for updating an independently persisted thread section.",
         "properties": {
+          "appearance": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ThreadSectionAppearance"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Omit to preserve appearance, use `null` to clear it, or provide a replacement."
+          },
           "name": {
             "description": "The updated user-visible name of the section.",
             "type": "string"

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -1083,6 +1083,13 @@
         "includeTools": {
           "description": "When true, include display-only public tool summaries in the returned metadata.",
           "type": "boolean"
+        },
+        "threadId": {
+          "description": "Optional loaded thread id used to evaluate effective app configuration.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -1243,6 +1250,29 @@
         "agent"
       ],
       "type": "string"
+    },
+    "AutoReviewRequirements": {
+      "properties": {
+        "ignoreRules": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "requiredOnModels": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
     },
     "BrowserUseRequirements": {
       "properties": {
@@ -4652,6 +4682,32 @@
     "ConfigLayerSource": {
       "oneOf": [
         {
+          "description": "Default configuration supplied with the installed Codex package.",
+          "properties": {
+            "file": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AbsolutePathBuf"
+                }
+              ],
+              "description": "Path to the packaged default configuration file."
+            },
+            "type": {
+              "enum": [
+                "packagedDefaults"
+              ],
+              "title": "PackagedDefaultsConfigLayerSourceType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "file",
+            "type"
+          ],
+          "title": "PackagedDefaultsConfigLayerSource",
+          "type": "object"
+        },
+        {
           "description": "Managed preferences layer delivered by MDM (macOS only).",
           "properties": {
             "domain": {
@@ -4956,6 +5012,16 @@
             "null"
           ]
         },
+        "autoReview": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AutoReviewRequirements"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "browserUse": {
           "anyOf": [
             {
@@ -5232,6 +5298,49 @@
             "type"
           ],
           "title": "CommandConfiguredHookHandler",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "input": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "server": {
+              "type": "string"
+            },
+            "statusMessage": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "timeoutSec": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "tool": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "mcp_tool"
+              ],
+              "title": "McpToolConfiguredHookHandlerType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "input",
+            "server",
+            "tool",
+            "type"
+          ],
+          "title": "McpToolConfiguredHookHandler",
           "type": "object"
         },
         {
@@ -7994,6 +8103,14 @@
         "eventName": {
           "$ref": "#/definitions/HookEventName"
         },
+        "executionMode": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/HookExecutionMode"
+            }
+          ],
+          "default": "sync"
+        },
         "handlerType": {
           "$ref": "#/definitions/HookHandlerType"
         },
@@ -9454,6 +9571,12 @@
         "name": {
           "type": "string"
         },
+        "pluginId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "resourceTemplates": {
           "items": {
             "$ref": "#/definitions/ResourceTemplate"
@@ -9884,6 +10007,17 @@
             "null"
           ]
         },
+        "multiAgentVersion": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MultiAgentVersion"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Multi-agent runtime declared by this model, when available."
+        },
         "serviceTiers": {
           "default": [],
           "items": {
@@ -10217,6 +10351,15 @@
           "type": "object"
         }
       ]
+    },
+    "MultiAgentVersion": {
+      "description": "Multi-agent runtime supported by a model.",
+      "enum": [
+        "disabled",
+        "v1",
+        "v2"
+      ],
+      "type": "string"
     },
     "NetworkAccess": {
       "enum": [
@@ -10740,6 +10883,13 @@
     "PluginInstallParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
+        "installAttemptId": {
+          "description": "Client-generated identifier used to correlate one installation attempt.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "marketplacePath": {
           "anyOf": [
             {
@@ -14011,6 +14161,52 @@
         "status"
       ],
       "title": "SendAddCreditsNudgeEmailResponse",
+      "type": "object"
+    },
+    "ServerDiagnosticsGauge": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ServerDiagnosticsProcess": {
+      "properties": {
+        "id": {
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "physicalFootprintBytes": {
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "residentMemoryBytes": {
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id"
+      ],
       "type": "object"
     },
     "ServerNotification": {
@@ -17538,6 +17734,13 @@
             "status": {
               "type": "string"
             },
+            "transparentBackground": {
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"
@@ -18478,6 +18681,18 @@
     "ThreadSection": {
       "description": "An independently persisted, user-visible thread section.",
       "properties": {
+        "appearance": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadSectionAppearance"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional appearance synchronized across clients."
+        },
         "id": {
           "description": "Opaque UUIDv7 identity that remains stable when the section is renamed.",
           "type": "string"
@@ -18493,10 +18708,39 @@
       ],
       "type": "object"
     },
+    "ThreadSectionAppearance": {
+      "description": "Extensible visual presentation for a custom thread section.",
+      "properties": {
+        "color": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "ThreadSectionCreateParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "description": "Parameters for creating an independently persisted thread section.",
       "properties": {
+        "appearance": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadSectionAppearance"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "name": {
           "description": "The user-visible name of the section.",
           "type": "string"
@@ -18630,6 +18874,17 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "description": "Parameters for updating an independently persisted thread section.",
       "properties": {
+        "appearance": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadSectionAppearance"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Omit to preserve appearance, use `null` to clear it, or provide a replacement."
+        },
         "name": {
           "description": "The updated user-visible name of the section.",
           "type": "string"


### PR DESCRIPTION
Fixes #288.

Drift detected vs `openai/codex@main`:
- `codex_app_server_protocol.v2.schemas.json`: 5 added defs (`AutoReviewRequirements`, `MultiAgentVersion`, `ServerDiagnosticsGauge/Process`, `ThreadSectionAppearance`) + 12 bodies changed (`ThreadItem`, `ThreadSection`, etc.)
- `codex_app_server_protocol.schemas.json`: `v2` body changed

Changes:
- `curl -sSfL .../codex_app_server_protocol.v2.schemas.json > codex-codes/tests/schemas/...`
- `curl -sSfL .../codex_app_server_protocol.schemas.json > ...`
- `python3 scripts/codegen_protocol.py` regenerates `protocol_generated/{mod,types,samples}.rs`
- `cargo run --example schema_coverage` now 175/175 (100% modeled, 100% samples) + `cargo test -p codex-codes` 82+19 pass

Verified locally; snapshots are raw upstream JSON.