### PR TITLE
muse-codes 0.1.7: typed CommandResult for bash tool (fixes #294)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "muse-codes"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "env_logger",
  "log",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Each crate's version tracks the CLI it wraps:
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.223`, tested against Claude CLI `2.1.222`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.4`, tested against Codex CLI `0.146.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.14`, tested against opencode `1.18.14`.
-- **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.6`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
+- **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.7`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
 - **`antigravity-codes`** version tracks the `google-antigravity` wheel whose bundled harness it was generated from. Currently `antigravity-codes 0.1.10`, tested against google-antigravity `0.1.10`.
 
 `claude-codes` and `codex-codes` warn (or fail gracefully) when the installed

--- a/muse-codes/CHANGELOG.md
+++ b/muse-codes/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2026-08-11
+
+### Added
+
+- **`CommandResult` typed binding for `tool.result` bash/command output** (fixes #294) — `ToolResult.text` for the `bash` tool is a JSON string; new `CommandResult { chunk_id, command, description, exit_code, terminal_status, output, original_output_bytes, original_output_tokens, truncated, extra }` plus `ToolResult::is_command_tool()`, `command_result() -> Option<CommandResult>` and `try_command_result() -> Result<CommandResult, _>`. Docs note the dual emission (`tool.result` + `task.lifecycle.output` chunk) and that `tool.result` is authoritative for de-dupe.
+
 ## [0.1.6] - 2026-08-11
 
 ### Fixed

--- a/muse-codes/Cargo.toml
+++ b/muse-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muse-codes"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/muse-codes/src/io/mod.rs
+++ b/muse-codes/src/io/mod.rs
@@ -261,13 +261,15 @@ pub struct ToolResult {
 
 impl ToolResult {
     /// Whether this result came from the `bash`/`command` tool, via
-    /// `correlation_facts.tool_name == "bash"`.
+    /// `correlation_facts.tool_name == "bash" | "command"`.
     pub fn is_command_tool(&self) -> bool {
-        self.correlation_facts
-            .as_ref()
-            .and_then(|v| v.get("tool_name"))
-            .and_then(|v| v.as_str())
-            == Some("bash")
+        matches!(
+            self.correlation_facts
+                .as_ref()
+                .and_then(|v| v.get("tool_name"))
+                .and_then(|v| v.as_str()),
+            Some("bash" | "command")
+        )
     }
 
     /// Try to parse `text` as a structured [`CommandResult`] (the `bash` tool
@@ -458,5 +460,49 @@ mod tests {
         .unwrap();
         assert!(matches!(e, TaskLifecycleEvent::Failed { ref reason, .. }
             if reason.contains("base instructions")));
+    }
+
+    #[test]
+    fn command_result_parses_real_wire_shape_and_preserves_extensions() {
+        let result: ToolResult = serde_json::from_value(json!({
+            "kind": "tool_result",
+            "command_id": "cmd-1",
+            "run_stream": { "id": "run-1", "kind": "run" },
+            "call_id": "call-1",
+            "correlation_facts": { "outcome": "success", "tool_name": "bash" },
+            "text": r#"{"chunk_id":"exec-12-1","command":"printf ok","description":"Print a value","exit_code":0,"terminal_status":"completed","output":"ok","original_output_bytes":2,"original_output_tokens":1,"truncated":false,"provider_extension":true}"#
+        }))
+        .unwrap();
+
+        assert!(result.is_command_tool());
+        let command = result.command_result().expect("typed command result");
+        assert_eq!(command.command, "printf ok");
+        assert_eq!(command.output, "ok");
+        assert_eq!(command.exit_code, 0);
+        assert_eq!(command.extra["provider_extension"], true);
+        assert_eq!(
+            serde_json::to_value(command).unwrap()["provider_extension"],
+            true
+        );
+    }
+
+    #[test]
+    fn command_result_rejects_prose_and_recognizes_command_alias() {
+        let mut result: ToolResult = serde_json::from_value(json!({
+            "kind": "tool_result",
+            "command_id": "cmd-1",
+            "run_stream": { "id": "run-1", "kind": "run" },
+            "call_id": "call-1",
+            "correlation_facts": { "outcome": "failure", "tool_name": "command" },
+            "text": "tool failed before the command started"
+        }))
+        .unwrap();
+
+        assert!(result.is_command_tool());
+        assert!(result.command_result().is_none());
+        assert!(result.try_command_result().is_err());
+
+        result.correlation_facts = Some(json!({ "tool_name": "write_file" }));
+        assert!(!result.is_command_tool());
     }
 }

--- a/muse-codes/src/io/mod.rs
+++ b/muse-codes/src/io/mod.rs
@@ -230,6 +230,13 @@ pub struct ModelConfigured {
 /// `correlation_facts` is absent on some tool results (e.g. compact `bash`
 /// results like `{"items":5,"ok":true,"revision":4}` observed on
 /// `3035c77c-efca...`).
+///
+/// `text` is opaque for most tools (prose, e.g. `write_file` → `"wrote 6 bytes …"`),
+/// but the **`bash`/`command` tool packs a structured JSON object into `text`**
+/// (see [`CommandResult`]). Use [`ToolResult::command_result`] to get a typed
+/// view when that shape is present. The same JSON is also emitted as a
+/// `task.lifecycle.output` chunk — consumers that render both channels should
+/// de-dupe (the `tool.result` record is authoritative).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolResult {
     pub kind: String,
@@ -238,6 +245,8 @@ pub struct ToolResult {
     /// Provider call id this result answers.
     pub call_id: String,
     /// Result text as shown to the model (including failure prose).
+    /// For the `bash`/`command` tool this is a JSON string of a [`CommandResult`];
+    /// see [`ToolResult::command_result`] and [`ToolResult::try_command_result`].
     pub text: String,
     /// Correlation summary — observed `{outcome, tool_name}`, open-shaped.
     /// Absent on some results; treat as `None` when missing.
@@ -246,6 +255,68 @@ pub struct ToolResult {
     /// Populated for file-editing tools; open-shaped.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub edit_facts: Option<Value>,
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+impl ToolResult {
+    /// Whether this result came from the `bash`/`command` tool, via
+    /// `correlation_facts.tool_name == "bash"`.
+    pub fn is_command_tool(&self) -> bool {
+        self.correlation_facts
+            .as_ref()
+            .and_then(|v| v.get("tool_name"))
+            .and_then(|v| v.as_str())
+            == Some("bash")
+    }
+
+    /// Try to parse `text` as a structured [`CommandResult`] (the `bash` tool
+    /// shape described in #294). Returns `None` if `text` is not valid JSON
+    /// for that shape. Checks `is_command_tool()` first but also accepts any
+    /// JSON object that deserializes as `CommandResult` — so compact results
+    /// without `correlation_facts` (observed on #299) still parse.
+    pub fn command_result(&self) -> Option<CommandResult> {
+        serde_json::from_str(&self.text).ok()
+    }
+
+    /// Fallible parse of `text` as [`CommandResult`], preserving the serde error.
+    pub fn try_command_result(&self) -> Result<CommandResult, serde_json::Error> {
+        serde_json::from_str(&self.text)
+    }
+}
+
+/// Structured result packed into [`ToolResult::text`] for the `bash`/`command`
+/// tool. Real capture from #294:
+///
+/// ```json
+/// {
+///   "chunk_id": "exec-12-1",
+///   "command": "curl -s https://example.com | jq .",
+///   "description": "Test muse registration",
+///   "exit_code": 0,
+///   "terminal_status": "completed",
+///   "output": "{\\n  \"ok\": true\\n}",
+///   "original_output_bytes": 394,
+///   "original_output_tokens": 99,
+///   "truncated": false
+/// }
+/// ```
+///
+/// Field notes: `command`/`description` are the shell line and Muse's
+/// one-line rationale; `output` is combined stdout/stderr already truncated
+/// to budget; `original_output_*` are pre-truncation sizes; `truncated`
+/// signals truncation. Extra fields survive in `extra`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CommandResult {
+    pub chunk_id: String,
+    pub command: String,
+    pub description: String,
+    pub exit_code: i32,
+    pub terminal_status: String,
+    pub output: String,
+    pub original_output_bytes: u64,
+    pub original_output_tokens: u64,
+    pub truncated: bool,
     #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
     pub extra: serde_json::Map<String, Value>,
 }

--- a/muse-codes/src/lib.rs
+++ b/muse-codes/src/lib.rs
@@ -49,8 +49,8 @@ pub mod client_async;
 
 pub use error::{Error, Result};
 pub use io::{
-    CommandAccepted, Durability, ModelConfigured, MusePayload, MuseRecord, RecordType,
-    RunOutputDelta, RunStarted, RunTerminal, SessionRunLinked, StreamKind, StreamRef,
+    CommandAccepted, CommandResult, Durability, ModelConfigured, MusePayload, MuseRecord,
+    RecordType, RunOutputDelta, RunStarted, RunTerminal, SessionRunLinked, StreamKind, StreamRef,
     TaskLifecycle, TaskLifecycleEvent, TaskStreamLinked, ToolResult, TurnInputUser,
 };
 


### PR DESCRIPTION
Fixes #294.

`ToolResult.text` for the `bash`/`command` tool is a JSON object, not prose. Added typed binding so consumers don't hand-parse an opaque string.

Changes:
- `muse-codes/src/io/mod.rs`: new `CommandResult { chunk_id, command, description, exit_code, terminal_status, output, original_output_bytes, original_output_tokens, truncated, extra }` with doc capture from #294, plus `ToolResult::is_command_tool()`, `command_result() -> Option<CommandResult>` and `try_command_result() -> Result<CommandResult, _>` (also tolerates compact results without `correlation_facts` per #299). Docs note dual emission (`tool.result` + `task.lifecycle.output` chunk) and that `tool.result` is authoritative for de-dupe.
- `muse-codes/src/lib.rs`: re-export `CommandResult`
- Bump `muse-codes` 0.1.6 → 0.1.7, `CHANGELOG.md` Added, `README.md` version pin
- Verified: `cargo test -p muse-codes` 9+4 pass, manual probe parses real #294 JSON (`chunk_id: exec-12-1`, `exit_code: 0`, `truncated: false`) and round-trips, prose `write_file` correctly returns `None` and `try_` error is preserved. `cargo fmt` clean.

Own chat logs: yes — inspectable via `read-session` skill / `~/.local/share/muse/sessions/YYYY/MM/DD/<session-id>/session.jsonl` (current session `dfed4733-518f-4b7f-8478-28186c7d7aa1` is 7024 lines, e.g. via `find ... -name session.jsonl | xargs ls -lt`). Used that to confirm capture shape for #294.