### PR TITLE
codex-codes: resnapshot app-server schemas vs openai/codex@main

### DIFF
--- a/codex-codes/src/protocol_generated/types.rs
+++ b/codex-codes/src/protocol_generated/types.rs
@@ -2547,6 +2547,103 @@ pub struct GetAccountTokenUsageResponse {
     pub daily_usage_buckets: Option<Vec<AccountTokenUsageDailyBucket>>,
     #[serde()]
     pub summary: AccountTokenUsageSummary,
+    #[serde(
+        rename = "threadUsage",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub thread_usage: Option<ThreadUsage>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GetAccountTokenUsageParams {
+    #[serde(rename = "threadId", default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadUsage {
+    #[serde(rename = "estimatedUsageCreditsMicros", default)]
+    pub estimated_usage_credits_micros: i64,
+    #[serde(
+        rename = "estimatedUsageUsdMicros",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub estimated_usage_usd_micros: Option<i64>,
+    #[serde(default)]
+    pub groups: Vec<ThreadUsageBreakdownGroup>,
+    #[serde(rename = "threadId", default)]
+    pub thread_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadUsageBreakdownGroup {
+    #[serde(
+        rename = "cachedInputTokens",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cached_input_tokens: Option<i64>,
+    #[serde(rename = "estimatedUsageCreditsMicros", default)]
+    pub estimated_usage_credits_micros: i64,
+    #[serde(
+        rename = "inputTokens",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub input_tokens: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(
+        rename = "netNewInputTokens",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub net_new_input_tokens: Option<i64>,
+    #[serde(
+        rename = "outputTokens",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub output_tokens: Option<i64>,
+    #[serde(
+        rename = "reasoningEffort",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub reasoning_effort: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub speed: Option<String>,
+    #[serde(
+        rename = "totalTokens",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub total_tokens: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ImageGenerationFailure {
+    #[serde(rename = "usageLimitExceeded")]
+    UsageLimitExceeded {
+        #[serde(rename = "limitId")]
+        limit_id: String,
+        #[serde(rename = "resetsAt", default, skip_serializing_if = "Option::is_none")]
+        resets_at: Option<i64>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum McpServerOauthClientRegistration {
+    Auto,
+    Cimd,
+    Dcr,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -3769,6 +3866,12 @@ pub struct McpServerOauthLoginCompletedNotification {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct McpServerOauthLoginParams {
+    #[serde(
+        rename = "clientRegistration",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub client_registration: Option<McpServerOauthClientRegistration>,
     #[serde(default)]
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5601,6 +5704,8 @@ pub enum ReviewDecision {
     },
     #[serde(rename = "approved_for_session")]
     ApprovedForSession,
+    #[serde(rename = "approved_mcp_policy_amendment")]
+    ApprovedMcpPolicyAmendment,
     #[serde(rename = "network_policy_amendment")]
     NetworkPolicyAmendment {
         network_policy_amendment: NetworkPolicyAmendment,
@@ -6750,6 +6855,8 @@ pub enum ThreadItem {
     },
     #[serde(rename = "imageGeneration")]
     ImageGeneration {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        failure: Option<ImageGenerationFailure>,
         id: String,
         result: String,
         #[serde(

--- a/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.schemas.json
@@ -2062,7 +2062,14 @@
               "type": "string"
             },
             "params": {
-              "type": "null"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/v2/GetAccountTokenUsageParams"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "required": [
@@ -4255,6 +4262,13 @@
           "description": "User has approved this request and wants future prompts in the same session-scoped approval cache to be automatically approved for the remainder of the session.",
           "enum": [
             "approved_for_session"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "User has approved this MCP tool call and wants to amend its policy so matching future calls are automatically approved across sessions.",
+          "enum": [
+            "approved_mcp_policy_amendment"
           ],
           "type": "string"
         },
@@ -11370,6 +11384,18 @@
         "title": "GetAccountResponse",
         "type": "object"
       },
+      "GetAccountTokenUsageParams": {
+        "properties": {
+          "threadId": {
+            "description": "When present, read estimated usage for this thread instead of account-wide token activity.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
       "GetAccountTokenUsageResponse": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
@@ -11384,6 +11410,18 @@
           },
           "summary": {
             "$ref": "#/definitions/v2/AccountTokenUsageSummary"
+          },
+          "threadUsage": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/ThreadUsage"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Estimated usage when a thread was requested and its billing route is available."
           }
         },
         "required": [
@@ -12158,6 +12196,37 @@
           "original"
         ],
         "type": "string"
+      },
+      "ImageGenerationFailure": {
+        "oneOf": [
+          {
+            "properties": {
+              "limitId": {
+                "type": "string"
+              },
+              "resetsAt": {
+                "format": "int64",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "type": {
+                "enum": [
+                  "usageLimitExceeded"
+                ],
+                "title": "UsageLimitExceededImageGenerationFailureType",
+                "type": "string"
+              }
+            },
+            "required": [
+              "limitId",
+              "type"
+            ],
+            "title": "UsageLimitExceededImageGenerationFailure",
+            "type": "object"
+          }
+        ]
       },
       "InputModality": {
         "description": "Canonical user-input modality tags advertised by a model.",
@@ -13129,6 +13198,14 @@
         ],
         "type": "object"
       },
+      "McpServerOauthClientRegistration": {
+        "enum": [
+          "auto",
+          "cimd",
+          "dcr"
+        ],
+        "type": "string"
+      },
       "McpServerOauthLoginCompletedNotification": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
@@ -13161,6 +13238,17 @@
       "McpServerOauthLoginParams": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
+          "clientRegistration": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/McpServerOauthClientRegistration"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Registration strategy for this login only; omission selects automatic discovery."
+          },
           "name": {
             "type": "string"
           },
@@ -14195,6 +14283,18 @@
           "compact"
         ],
         "type": "string"
+      },
+      "NullableGetAccountTokenUsageParams": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "anyOf": [
+          {
+            "$ref": "#/definitions/v2/GetAccountTokenUsageParams"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "title": "Nullable_GetAccountTokenUsageParams"
       },
       "OverriddenMetadata": {
         "properties": {
@@ -19950,6 +20050,17 @@
           },
           {
             "properties": {
+              "failure": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/v2/ImageGenerationFailure"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
               "id": {
                 "type": "string"
               },
@@ -21748,6 +21859,101 @@
           "unsubscribed"
         ],
         "type": "string"
+      },
+      "ThreadUsage": {
+        "properties": {
+          "estimatedUsageCreditsMicros": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "estimatedUsageUsdMicros": {
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "groups": {
+            "items": {
+              "$ref": "#/definitions/v2/ThreadUsageBreakdownGroup"
+            },
+            "type": "array"
+          },
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "estimatedUsageCreditsMicros",
+          "groups",
+          "threadId"
+        ],
+        "type": "object"
+      },
+      "ThreadUsageBreakdownGroup": {
+        "properties": {
+          "cachedInputTokens": {
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "estimatedUsageCreditsMicros": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "inputTokens": {
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "model": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "netNewInputTokens": {
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "outputTokens": {
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "reasoningEffort": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "speed": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "totalTokens": {
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "estimatedUsageCreditsMicros"
+        ],
+        "type": "object"
       },
       "TokenUsageBreakdown": {
         "properties": {

--- a/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
+++ b/codex-codes/tests/schemas/codex_app_server_protocol.v2.schemas.json
@@ -3252,7 +3252,14 @@
               "type": "string"
             },
             "params": {
-              "type": "null"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/GetAccountTokenUsageParams"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "required": [
@@ -7646,6 +7653,18 @@
       "title": "GetAccountResponse",
       "type": "object"
     },
+    "GetAccountTokenUsageParams": {
+      "properties": {
+        "threadId": {
+          "description": "When present, read estimated usage for this thread instead of account-wide token activity.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "GetAccountTokenUsageResponse": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
@@ -7660,6 +7679,18 @@
         },
         "summary": {
           "$ref": "#/definitions/AccountTokenUsageSummary"
+        },
+        "threadUsage": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadUsage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Estimated usage when a thread was requested and its billing route is available."
         }
       },
       "required": [
@@ -8434,6 +8465,37 @@
         "original"
       ],
       "type": "string"
+    },
+    "ImageGenerationFailure": {
+      "oneOf": [
+        {
+          "properties": {
+            "limitId": {
+              "type": "string"
+            },
+            "resetsAt": {
+              "format": "int64",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "type": {
+              "enum": [
+                "usageLimitExceeded"
+              ],
+              "title": "UsageLimitExceededImageGenerationFailureType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "limitId",
+            "type"
+          ],
+          "title": "UsageLimitExceededImageGenerationFailure",
+          "type": "object"
+        }
+      ]
     },
     "InitializeCapabilities": {
       "description": "Client-declared capabilities negotiated during initialize.",
@@ -9466,6 +9528,14 @@
       ],
       "type": "object"
     },
+    "McpServerOauthClientRegistration": {
+      "enum": [
+        "auto",
+        "cimd",
+        "dcr"
+      ],
+      "type": "string"
+    },
     "McpServerOauthLoginCompletedNotification": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
@@ -9498,6 +9568,17 @@
     "McpServerOauthLoginParams": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "properties": {
+        "clientRegistration": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/McpServerOauthClientRegistration"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Registration strategy for this login only; omission selects automatic discovery."
+        },
         "name": {
           "type": "string"
         },
@@ -10532,6 +10613,18 @@
         "compact"
       ],
       "type": "string"
+    },
+    "NullableGetAccountTokenUsageParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/GetAccountTokenUsageParams"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Nullable_GetAccountTokenUsageParams"
     },
     "OverriddenMetadata": {
       "properties": {
@@ -17709,6 +17802,17 @@
         },
         {
           "properties": {
+            "failure": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ImageGenerationFailure"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
             "id": {
               "type": "string"
             },
@@ -19507,6 +19611,101 @@
         "unsubscribed"
       ],
       "type": "string"
+    },
+    "ThreadUsage": {
+      "properties": {
+        "estimatedUsageCreditsMicros": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "estimatedUsageUsdMicros": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "groups": {
+          "items": {
+            "$ref": "#/definitions/ThreadUsageBreakdownGroup"
+          },
+          "type": "array"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "estimatedUsageCreditsMicros",
+        "groups",
+        "threadId"
+      ],
+      "type": "object"
+    },
+    "ThreadUsageBreakdownGroup": {
+      "properties": {
+        "cachedInputTokens": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "estimatedUsageCreditsMicros": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "inputTokens": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "netNewInputTokens": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "outputTokens": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "reasoningEffort": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "speed": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "totalTokens": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "estimatedUsageCreditsMicros"
+      ],
+      "type": "object"
     },
     "TokenUsageBreakdown": {
       "properties": {


### PR DESCRIPTION
Fixes #305 — the nightly drift check's report, resolved in the established pattern (snapshots refreshed to byte-identical, types hand-mirrored, no codegen rerun).

**Upstream changes absorbed:**
- Per-thread usage surface: `account/usage/read` gains optional `GetAccountTokenUsageParams { threadId }`; `GetAccountTokenUsageResponse` gains `threadUsage: ThreadUsage` with `ThreadUsageBreakdownGroup` (per-model token/credit breakdown)
- `ImageGenerationFailure` (usageLimitExceeded) carried on the `imageGeneration` thread item
- `McpServerOauthClientRegistration` enum (auto/cimd/dcr) on `McpServerOauthLoginParams`
- `ReviewDecision` grows `approved_mcp_policy_amendment` (bare variant)

**Verification:** `scripts/check_codex_schema_drift.py` reports both snapshots byte-identical to upstream; all codex-codes tests green; clippy clean; **live-verified via `wirecheck run codex`** — the account-read family (the surface this drift touches) answers in protocol against the real app-server.