### PR TITLE
Require /// descriptions on integration tests, surface them in wirecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,3 +292,11 @@ jobs:
       
       - name: Check MSRV
         run: cargo check --workspace
+  test-annotations:
+    name: Check Test Annotations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Every integration test carries a /// description
+        run: python3 scripts/check_test_annotations.py --check

--- a/claude-codes/tests/corpus_tests.rs
+++ b/claude-codes/tests/corpus_tests.rs
@@ -16,6 +16,7 @@ struct ParseFailure {
     raw: String,
 }
 
+/// Every line of every committed real-transcript capture parses into a typed ClaudeOutput — the corpus gate against schema drift.
 #[test]
 fn parse_configured_claude_transcript_corpus() {
     let Some(root) = std::env::var_os("CLAUDE_CODES_CORPUS_DIR").map(PathBuf::from) else {
@@ -156,6 +157,7 @@ fn raw_preview(raw: &str) -> String {
 mod tests {
     use super::raw_preview;
 
+    /// Failure-report previews show short lines verbatim.
     #[test]
     fn raw_preview_keeps_short_lines_unchanged() {
         assert_eq!(
@@ -164,6 +166,7 @@ mod tests {
         );
     }
 
+    /// Failure-report previews truncate long lines on UTF-8 character boundaries, never mid-codepoint.
     #[test]
     fn raw_preview_truncates_long_lines_on_char_boundaries() {
         let raw = format!("{}{}", "a".repeat(500), "b".repeat(3));

--- a/claude-codes/tests/deserialization_tests.rs
+++ b/claude-codes/tests/deserialization_tests.rs
@@ -46,6 +46,7 @@ fn load_test_case(path: &PathBuf) -> TestCase {
         .unwrap_or_else(|e| panic!("Failed to parse test case {:?}: {}", path, e))
 }
 
+/// Every captured failed-deserialization case now parses — regressions against previously-fixed wire shapes fail here.
 #[test]
 fn test_all_failed_deserializations() {
     let test_cases = get_test_cases();
@@ -100,6 +101,7 @@ fn test_all_failed_deserializations() {
     }
 }
 
+/// Each named failed-deserialization capture parses on its own, so a regression report points at the exact case.
 #[test]
 fn test_individual_cases() {
     let test_cases = get_test_cases();

--- a/claude-codes/tests/tool_input_tests.rs
+++ b/claude-codes/tests/tool_input_tests.rs
@@ -227,6 +227,7 @@ fn test_parse_result_with_uuid() {
 // Tests for ToolInput enum deserialization
 // ============================================================================
 
+/// Bash tool input (command/timeout/description) deserializes into its typed struct.
 #[test]
 fn test_tool_input_bash_deserialization() {
     let json = json!({
@@ -242,6 +243,7 @@ fn test_tool_input_bash_deserialization() {
     assert_eq!(bash.command, "git status");
 }
 
+/// Read tool input (file_path/offset/limit) deserializes into its typed struct.
 #[test]
 fn test_tool_input_read_deserialization() {
     let json = json!({
@@ -259,6 +261,7 @@ fn test_tool_input_read_deserialization() {
     assert_eq!(read.limit, Some(50));
 }
 
+/// Write tool input (file_path/content) deserializes into its typed struct.
 #[test]
 fn test_tool_input_write_deserialization() {
     let json = json!({
@@ -274,6 +277,7 @@ fn test_tool_input_write_deserialization() {
     assert_eq!(write.content, "Hello, world!");
 }
 
+/// Edit tool input (old/new string fields) deserializes into its typed struct.
 #[test]
 fn test_tool_input_edit_deserialization() {
     let json = json!({
@@ -293,6 +297,7 @@ fn test_tool_input_edit_deserialization() {
     assert_eq!(edit.replace_all, Some(true));
 }
 
+/// Glob tool input (pattern/path) deserializes into its typed struct.
 #[test]
 fn test_tool_input_glob_deserialization() {
     let json = json!({
@@ -308,6 +313,7 @@ fn test_tool_input_glob_deserialization() {
     assert_eq!(glob.path, Some("/home/user/project".to_string()));
 }
 
+/// Grep tool input (pattern + option flags) deserializes into its typed struct.
 #[test]
 fn test_tool_input_grep_deserialization() {
     let json = json!({
@@ -329,6 +335,7 @@ fn test_tool_input_grep_deserialization() {
     assert_eq!(grep.context, Some(3));
 }
 
+/// Task (subagent) tool input deserializes into its typed struct.
 #[test]
 fn test_tool_input_task_deserialization() {
     let json = json!({
@@ -348,6 +355,7 @@ fn test_tool_input_task_deserialization() {
     assert_eq!(task.run_in_background, Some(true));
 }
 
+/// WebFetch tool input (url/prompt) deserializes into its typed struct.
 #[test]
 fn test_tool_input_web_fetch_deserialization() {
     let json = json!({
@@ -363,6 +371,7 @@ fn test_tool_input_web_fetch_deserialization() {
     assert_eq!(fetch.prompt, "Extract the main documentation");
 }
 
+/// WebSearch tool input (query + domain filters) deserializes into its typed struct.
 #[test]
 fn test_tool_input_web_search_deserialization() {
     let json = json!({
@@ -377,6 +386,7 @@ fn test_tool_input_web_search_deserialization() {
     assert_eq!(search.query, "rust serde tutorial 2026");
 }
 
+/// TodoWrite tool input (todo list items with status) deserializes into its typed struct.
 #[test]
 fn test_tool_input_todo_write_deserialization() {
     let json = json!({
@@ -403,6 +413,7 @@ fn test_tool_input_todo_write_deserialization() {
     assert_eq!(todo.todos[0].status, claude_codes::TodoStatus::InProgress);
 }
 
+/// AskUserQuestion tool input (questions/options) deserializes into its typed struct.
 #[test]
 fn test_tool_input_ask_user_question_deserialization() {
     let json = json!({
@@ -431,6 +442,7 @@ fn test_tool_input_ask_user_question_deserialization() {
     assert_eq!(question.questions[0].options.len(), 2);
 }
 
+/// An unrecognized tool name deserializes as the Unknown catch-all instead of failing the stream.
 #[test]
 fn test_tool_input_unknown_custom_tool() {
     // Simulates a custom MCP tool with unknown structure
@@ -455,6 +467,7 @@ fn test_tool_input_unknown_custom_tool() {
 // ToolUseBlock helper method tests
 // ============================================================================
 
+/// ToolUseBlock::typed_input lifts raw JSON into the matching typed tool input.
 #[test]
 fn test_tool_use_block_typed_input() {
     let block = ToolUseBlock {
@@ -475,6 +488,7 @@ fn test_tool_use_block_typed_input() {
     }
 }
 
+/// ToolUseBlock::try_typed_input reports a typed error (not a panic) when the input shape mismatches.
 #[test]
 fn test_tool_use_block_try_typed_input_error() {
     let block = ToolUseBlock {
@@ -673,6 +687,7 @@ fn test_parse_tool_result_multi_text_structured() {
 // ExitPlanModeInput tests (issue #62)
 // ============================================================================
 
+/// ExitPlanMode input with a plan field deserializes.
 #[test]
 fn test_exit_plan_mode_with_plan_field() {
     // This is the exact JSON from issue #62 that was failing with deny_unknown_fields
@@ -692,6 +707,7 @@ fn test_exit_plan_mode_with_plan_field() {
     assert_eq!(prompts[0].prompt, "run tests");
 }
 
+/// ExitPlanMode input with remote_session_title deserializes.
 #[test]
 fn test_exit_plan_mode_with_remote_session_title() {
     let json = json!({
@@ -714,6 +730,7 @@ fn test_exit_plan_mode_with_remote_session_title() {
     );
 }
 
+/// ExitPlanMode input with every optional field present deserializes.
 #[test]
 fn test_exit_plan_mode_all_fields() {
     let json = json!({
@@ -742,6 +759,7 @@ fn test_exit_plan_mode_all_fields() {
     assert_eq!(input.allowed_prompts.unwrap().len(), 2);
 }
 
+/// ExitPlanMode input with no fields deserializes (all fields optional).
 #[test]
 fn test_exit_plan_mode_empty() {
     // ExitPlanMode with no fields should still work
@@ -756,6 +774,7 @@ fn test_exit_plan_mode_empty() {
     assert_eq!(input.remote_session_url, None);
 }
 
+/// ExitPlanMode rejects unknown fields — the strict-schema guard that catches CLI additions.
 #[test]
 fn test_exit_plan_mode_unknown_field_rejected() {
     // deny_unknown_fields should still reject truly unknown fields
@@ -768,6 +787,7 @@ fn test_exit_plan_mode_unknown_field_rejected() {
     assert!(result.is_err(), "Should reject unknown fields");
 }
 
+/// ExitPlanMode routes correctly through the ToolInput enum dispatch.
 #[test]
 fn test_exit_plan_mode_via_tool_input_enum() {
     // Verify the ToolInput enum can deserialize ExitPlanModeInput with the new fields
@@ -789,6 +809,7 @@ fn test_exit_plan_mode_via_tool_input_enum() {
     }
 }
 
+/// ExitPlanMode serializes back to the same JSON it parsed from (byte-faithful round trip).
 #[test]
 fn test_exit_plan_mode_roundtrip() {
     let original = claude_codes::ExitPlanModeInput {
@@ -812,6 +833,7 @@ fn test_exit_plan_mode_roundtrip() {
 // Roundtrip serialization tests
 // ============================================================================
 
+/// Bash tool input round-trips through serialize/deserialize unchanged.
 #[test]
 fn test_bash_input_roundtrip() {
     let original = BashInput {
@@ -827,6 +849,7 @@ fn test_bash_input_roundtrip() {
     assert_eq!(original, parsed);
 }
 
+/// Every ToolInput variant round-trips through the enum unchanged.
 #[test]
 fn test_tool_input_enum_roundtrip() {
     let original = ToolInput::Bash(BashInput {

--- a/codex-codes/tests/integration_tests.rs
+++ b/codex-codes/tests/integration_tests.rs
@@ -57,6 +57,7 @@ fn assert_standard_envelope(events: &[ThreadEvent]) {
 
 // ── hello_world: simplest possible session ──────────────────────────
 
+/// Every line of the captured hello-world exec stream parses into a typed event.
 #[test]
 fn test_hello_world_parses_all_lines() {
     let events = parse_capture(include_str!("../test_cases/captures/hello_world.jsonl"));
@@ -64,6 +65,7 @@ fn test_hello_world_parses_all_lines() {
     assert_eq!(events.len(), 5);
 }
 
+/// The hello-world capture contains both reasoning and agent-message items - the minimal turn vocabulary.
 #[test]
 fn test_hello_world_contains_reasoning_and_message() {
     let events = parse_capture(include_str!("../test_cases/captures/hello_world.jsonl"));
@@ -95,6 +97,7 @@ fn test_hello_world_contains_reasoning_and_message() {
 
 // ── list_files: command execution with item.started lifecycle ────────
 
+/// Every line of the captured list-files exec stream parses into a typed event.
 #[test]
 fn test_list_files_parses_all_lines() {
     let events = parse_capture(include_str!("../test_cases/captures/list_files.jsonl"));
@@ -102,6 +105,7 @@ fn test_list_files_parses_all_lines() {
     assert_eq!(events.len(), 8);
 }
 
+/// The list-files capture shows the full command lifecycle: item.started, command output, item.completed.
 #[test]
 fn test_list_files_command_lifecycle() {
     let events = parse_capture(include_str!("../test_cases/captures/list_files.jsonl"));
@@ -147,6 +151,7 @@ fn test_list_files_command_lifecycle() {
 
 // ── file_create: command that creates a file ────────────────────────
 
+/// Every line of the captured file-create exec stream parses into a typed event.
 #[test]
 fn test_file_create_parses_all_lines() {
     let events = parse_capture(include_str!("../test_cases/captures/file_create.jsonl"));
@@ -154,6 +159,7 @@ fn test_file_create_parses_all_lines() {
     assert_eq!(events.len(), 8);
 }
 
+/// The file-create capture carries the command output text on the completed item.
 #[test]
 fn test_file_create_command_output() {
     let events = parse_capture(include_str!("../test_cases/captures/file_create.jsonl"));
@@ -171,6 +177,7 @@ fn test_file_create_command_output() {
 
 // ── failed_command: non-zero exit code ──────────────────────────────
 
+/// Every line of the captured failed-command exec stream parses into a typed event.
 #[test]
 fn test_failed_command_parses_all_lines() {
     let events = parse_capture(include_str!("../test_cases/captures/failed_command.jsonl"));
@@ -178,6 +185,7 @@ fn test_failed_command_parses_all_lines() {
     assert_eq!(events.len(), 8);
 }
 
+/// A failed command reports failed status and its nonzero exit code on the completed item.
 #[test]
 fn test_failed_command_status_and_exit_code() {
     let events = parse_capture(include_str!("../test_cases/captures/failed_command.jsonl"));
@@ -211,6 +219,7 @@ fn test_failed_command_status_and_exit_code() {
 
 // ── file_change: patch-based file modification ──────────────────────
 
+/// Every line of the captured file-change exec stream parses into a typed event.
 #[test]
 fn test_file_change_parses_all_lines() {
     let events = parse_capture(include_str!("../test_cases/captures/file_change.jsonl"));
@@ -218,6 +227,7 @@ fn test_file_change_parses_all_lines() {
     assert_eq!(events.len(), 12);
 }
 
+/// A fileChange item carries the changed paths and change kinds.
 #[test]
 fn test_file_change_item_fields() {
     let events = parse_capture(include_str!("../test_cases/captures/file_change.jsonl"));
@@ -236,6 +246,7 @@ fn test_file_change_item_fields() {
     assert!(fc.changes[0].path.contains("test.txt"));
 }
 
+/// The file-change capture also runs a verification command - both item kinds coexist in one turn.
 #[test]
 fn test_file_change_also_has_command_verification() {
     let events = parse_capture(include_str!("../test_cases/captures/file_change.jsonl"));
@@ -258,6 +269,7 @@ fn test_file_change_also_has_command_verification() {
 
 // ── multi_command: multiple sequential commands ─────────────────────
 
+/// Every line of the captured multi-command exec stream parses into a typed event.
 #[test]
 fn test_multi_command_parses_all_lines() {
     let events = parse_capture(include_str!("../test_cases/captures/multi_command.jsonl"));
@@ -265,6 +277,7 @@ fn test_multi_command_parses_all_lines() {
     assert_eq!(events.len(), 12);
 }
 
+/// The multi-command capture executed all three requested commands.
 #[test]
 fn test_multi_command_three_commands_executed() {
     let events = parse_capture(include_str!("../test_cases/captures/multi_command.jsonl"));
@@ -301,6 +314,7 @@ fn test_multi_command_three_commands_executed() {
     }
 }
 
+/// Every item.started in the multi-command capture has a matching item.completed - no orphaned lifecycle events.
 #[test]
 fn test_multi_command_started_events_match_completed() {
     let events = parse_capture(include_str!("../test_cases/captures/multi_command.jsonl"));
@@ -334,6 +348,7 @@ fn test_multi_command_started_events_match_completed() {
 
 // ── cross-capture: verify all captures share structural invariants ──
 
+/// Thread ids are unique across all captures - the identity guarantee downstream keying relies on.
 #[test]
 fn test_all_captures_have_unique_thread_ids() {
     let captures = [
@@ -366,6 +381,7 @@ fn test_all_captures_have_unique_thread_ids() {
     );
 }
 
+/// Every capture reports cached-token usage - the accounting field consumers bill against.
 #[test]
 fn test_all_captures_have_cached_tokens() {
     let captures = [
@@ -389,6 +405,7 @@ fn test_all_captures_have_cached_tokens() {
     }
 }
 
+/// Item ids increase sequentially within a capture - the ordering guarantee for item lists.
 #[test]
 fn test_all_item_ids_are_sequential_within_capture() {
     let captures = [
@@ -454,6 +471,7 @@ fn test_all_item_ids_are_sequential_within_capture() {
 // `ServerRequest::from_envelope`, wrap the resulting `serde_json::Error` in a
 // `ParseError`, and check that nothing was dropped on the floor.
 
+/// An unmodeled notification surfaces as a parse error carrying its method and params - named, not silently dropped.
 #[test]
 fn parse_error_carries_method_and_params_for_unmodeled_notification_variant() {
     // Simulates a notification whose envelope is fine but whose params don't
@@ -490,6 +508,7 @@ fn parse_error_carries_method_and_params_for_unmodeled_notification_variant() {
     }
 }
 
+/// A malformed envelope keeps the raw line in the parse error so the bad wire bytes are recoverable.
 #[test]
 fn parse_error_from_invalid_envelope_keeps_raw_line_without_method() {
     // The bare-JSON failure path: line is not a valid JsonRpcMessage.

--- a/codex-codes/tests/live_client_tests.rs
+++ b/codex-codes/tests/live_client_tests.rs
@@ -15,6 +15,7 @@ use codex_codes::{
 
 // ── Version check ───────────────────────────────────────────────────
 
+/// The installed codex CLI answers --version - the binary-presence gate for the live suite.
 #[tokio::test]
 async fn test_codex_cli_version() {
     codex_codes::version::check_codex_version_async()
@@ -24,6 +25,7 @@ async fn test_codex_cli_version() {
 
 // ── Async client: initialize + thread_start ─────────────────────────
 
+/// The async client starts the app-server and thread/start returns a non-empty thread id.
 #[tokio::test]
 async fn test_async_client_start_and_thread_start() {
     let mut client = AsyncClient::start()
@@ -116,6 +118,7 @@ async fn test_async_client_thread_fork() {
 
 // ── Async client: full turn lifecycle ───────────────────────────────
 
+/// A live turn streams typed notifications to turnCompleted and the answer arrives in agent-message deltas.
 #[tokio::test]
 async fn test_async_client_basic_turn() {
     let mut client = AsyncClient::start()
@@ -189,6 +192,7 @@ async fn test_async_client_basic_turn() {
 
 // ── Async client: custom initialization ─────────────────────────────
 
+/// initialize with custom client info and capabilities is accepted by the live app-server.
 #[tokio::test]
 async fn test_async_client_custom_initialize() {
     let mut client = AsyncClient::spawn(AppServerBuilder::new())
@@ -231,6 +235,7 @@ async fn test_async_client_custom_initialize() {
 
 // ── Sync client: initialize + thread_start ──────────────────────────
 
+/// The sync client starts the app-server and opens a thread (blocking API parity with async).
 #[test]
 fn test_sync_client_start_and_thread_start() {
     let mut client = SyncClient::start().expect("Failed to start app-server");
@@ -244,6 +249,7 @@ fn test_sync_client_start_and_thread_start() {
 
 // ── Sync client: full turn lifecycle ────────────────────────────────
 
+/// A live turn completes through the sync client (blocking API parity with async).
 #[test]
 fn test_sync_client_basic_turn() {
     let mut client = SyncClient::start().expect("Failed to start app-server");
@@ -305,6 +311,7 @@ fn test_sync_client_basic_turn() {
 
 // ── Async client: multi-turn conversation ───────────────────────────
 
+/// Two turns on one thread share context - the second answer uses the first turn's information.
 #[tokio::test]
 async fn test_async_client_multi_turn() {
     let mut client = AsyncClient::start()
@@ -413,6 +420,7 @@ async fn test_async_client_multi_turn() {
 
 // ── Async client: event stream API ──────────────────────────────────
 
+/// The live notification stream arrives in protocol order and every frame deserializes.
 #[tokio::test]
 async fn test_async_client_event_stream() {
     let mut client = AsyncClient::start()
@@ -486,6 +494,7 @@ async fn test_async_client_event_stream() {
 // both regressions: a known method whose payload no longer fits the typed
 // struct fails the client call before we get here, and a brand-new method
 // that we haven't modeled fails the assertion below.
+/// STRICT audit: every message a live turn produces deserializes into a typed variant - any Unknown is drift, caught here first.
 #[tokio::test]
 async fn test_typed_message_audit_strict() {
     use std::collections::BTreeMap;
@@ -685,6 +694,7 @@ async fn test_typed_message_audit_strict() {
 // loudly is intentional — repairing those structs is the natural
 // follow-up. This file's `#![cfg(feature = "integration-tests")]`
 // gate keeps the failure off the default CI lane.
+/// End-to-end coding task: codex writes a quicksort that actually compiles and runs - the full-loop smoke test.
 #[tokio::test]
 async fn test_async_client_writes_compilable_quicksort() {
     use std::process::Command;

--- a/opencode-codes/tests/deserialization_tests.rs
+++ b/opencode-codes/tests/deserialization_tests.rs
@@ -82,6 +82,7 @@ fn roundtrip<T: DeserializeOwned + Serialize>(label: &str, json: &str) -> T {
     parsed
 }
 
+/// The captured session-create response parses typed and re-serializes byte-faithfully.
 #[test]
 fn session_create_roundtrips() {
     let session: Session = roundtrip(
@@ -93,6 +94,7 @@ fn session_create_roundtrips() {
     assert_eq!(session.version, "1.18.5");
 }
 
+/// An idle session-status response round-trips unchanged.
 #[test]
 fn session_status_empty_roundtrips() {
     let map: BTreeMap<String, SessionStatus> = roundtrip(
@@ -102,6 +104,7 @@ fn session_status_empty_roundtrips() {
     assert!(map.is_empty());
 }
 
+/// A busy session-status response round-trips unchanged.
 #[test]
 fn session_status_busy_roundtrips() {
     let map: BTreeMap<String, SessionStatus> = roundtrip(
@@ -113,6 +116,7 @@ fn session_status_busy_roundtrips() {
     assert!(matches!(status, SessionStatus::Busy));
 }
 
+/// An empty message listing round-trips unchanged.
 #[test]
 fn messages_empty_roundtrips() {
     let msgs: Vec<MessageWithParts> = roundtrip(
@@ -122,6 +126,7 @@ fn messages_empty_roundtrips() {
     assert!(msgs.is_empty());
 }
 
+/// A post-prompt message listing (user + assistant parts) round-trips unchanged.
 #[test]
 fn messages_after_prompt_roundtrips() {
     let msgs: Vec<MessageWithParts> = roundtrip(
@@ -141,6 +146,7 @@ fn messages_after_prompt_roundtrips() {
     assert!(has_text_part, "no text part found across captured messages");
 }
 
+/// The abort response (bare bool) round-trips unchanged.
 #[test]
 fn abort_response_roundtrips() {
     let aborted: bool = roundtrip(
@@ -150,6 +156,7 @@ fn abort_response_roundtrips() {
     assert!(aborted);
 }
 
+/// The session-not-found error shape parses typed and round-trips unchanged.
 #[test]
 fn session_not_found_error_roundtrips() {
     let err: NotFoundError = roundtrip(
@@ -160,6 +167,7 @@ fn session_not_found_error_roundtrips() {
     assert!(err.data.message.contains("Session not found"));
 }
 
+/// Every captured SSE frame parses into a typed event and re-serializes byte-faithfully.
 #[test]
 fn event_stream_every_frame_roundtrips() {
     let stream = include_str!("../test_cases/events/event_stream.jsonl");

--- a/scripts/check_test_annotations.py
+++ b/scripts/check_test_annotations.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Integration-test annotation check and description extractor.
+
+Every integration test function (any `#[test]` / `#[tokio::test]` fn in a
+crate's `tests/*.rs`) must carry a `///` doc comment saying what the test
+pins, in human terms. Those doc comments are the single source of truth:
+this script both ENFORCES them in CI (`--check`) and EXTRACTS them
+(`--emit-json`) for consumers like wirecheck, which shows the description
+next to each test result so humans and models get real feedback instead
+of a bare function name.
+
+Usage:
+    check_test_annotations.py --check        # CI gate: exit 1 on gaps
+    check_test_annotations.py --emit-json    # {crate: {file: {fn: desc}}}
+
+Only `tests/*.rs` is enforced; in-source `#[cfg(test)]` unit tests are
+exempt (their names render without descriptions in wirecheck).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CRATES = ["claude-codes", "codex-codes", "muse-codes", "opencode-codes"]
+
+TEST_ATTR = re.compile(r"#\[(?:tokio::)?test(?:\([^)]*\))?\]")
+FN_NAME = re.compile(r"(?:pub\s+)?(?:async\s+)?fn\s+([A-Za-z0-9_]+)")
+
+
+def scan_file(path: Path) -> tuple[dict[str, str], list[str]]:
+    """Return ({fn_name: description}, [fn_names_missing_docs])."""
+    lines = path.read_text().splitlines()
+    docs: dict[str, str] = {}
+    missing: list[str] = []
+    i = 0
+    while i < len(lines):
+        if not TEST_ATTR.search(lines[i]):
+            i += 1
+            continue
+        # Walk back over contiguous attributes and doc lines to collect the
+        # /// block that precedes the attribute stack.
+        j = i - 1
+        doc_lines: list[str] = []
+        while j >= 0:
+            stripped = lines[j].strip()
+            if stripped.startswith("///"):
+                doc_lines.insert(0, stripped.lstrip("/").strip())
+                j -= 1
+            elif stripped.startswith("#[") or stripped == "":
+                # Attributes above the test attr (e.g. #[ignore]); blank
+                # lines end the doc block search unless docs already found.
+                if stripped == "" and doc_lines:
+                    break
+                j -= 1
+            else:
+                break
+        # Walk forward past any further attributes to the fn itself.
+        k = i + 1
+        while k < len(lines) and not FN_NAME.search(lines[k]):
+            k += 1
+        if k >= len(lines):
+            break
+        name_match = FN_NAME.search(lines[k])
+        if name_match:
+            name = name_match.group(1)
+            description = " ".join(line for line in doc_lines if line).strip()
+            if description:
+                docs[name] = description
+            else:
+                missing.append(name)
+        i = k + 1
+    return docs, missing
+
+
+def scan() -> tuple[dict, list[str]]:
+    emitted: dict[str, dict[str, dict[str, str]]] = {}
+    problems: list[str] = []
+    for crate in CRATES:
+        tests_dir = ROOT / crate / "tests"
+        if not tests_dir.is_dir():
+            continue
+        for path in sorted(tests_dir.glob("*.rs")):
+            docs, missing = scan_file(path)
+            rel = f"{crate}/tests/{path.name}"
+            if docs:
+                emitted.setdefault(crate, {})[path.stem] = docs
+            problems.extend(f"{rel}: fn {name}" for name in missing)
+    return emitted, problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true")
+    mode.add_argument("--emit-json", action="store_true")
+    args = parser.parse_args()
+
+    emitted, problems = scan()
+    if args.emit_json:
+        json.dump(emitted, sys.stdout, indent=1, sort_keys=True)
+        return 0
+
+    total = sum(len(fns) for files in emitted.values() for fns in files.values())
+    if problems:
+        print(f"❌ {len(problems)} integration test(s) missing /// descriptions:")
+        for p in problems:
+            print(f"  - {p}")
+        print()
+        print("Add a /// doc comment saying what the test pins — wirecheck and")
+        print("humans read it next to the result.")
+        return 1
+    print(f"✅ all {total} integration tests carry /// descriptions")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wirecheck/src/checks/cargo_suite.rs
+++ b/wirecheck/src/checks/cargo_suite.rs
@@ -25,6 +25,7 @@ pub async fn run(state: Shared, agent: &'static str) {
     let Some((package, _)) = plan(agent) else {
         return;
     };
+    let descriptions = load_descriptions(package).await;
 
     // opencode's integration tests read OPENCODE_BASE_URL; spawn a managed
     // server for the duration so they run hermetically.
@@ -47,7 +48,7 @@ pub async fn run(state: Shared, agent: &'static str) {
                     agent,
                     CheckResult {
                         name: "managed server".into(),
-                        what: "",
+                        what: String::new(),
                         status: CheckStatus::Fail,
                         detail: format!("could not spawn opencode serve: {e}"),
                         ms: None,
@@ -61,20 +62,19 @@ pub async fn run(state: Shared, agent: &'static str) {
     }
 
     set_status(&state, agent, "cargo test (compiling if needed)…").await;
-    let mut cmd = tokio::process::Command::new("cargo");
-    cmd.args([
-        "test",
-        "-p",
-        package,
-        "--features",
-        "integration-tests",
-        "--",
-        "--test-threads=1",
-    ])
-    .current_dir(env!("CARGO_MANIFEST_DIR").trim_end_matches("/wirecheck"))
-    .stdout(Stdio::piped())
-    .stderr(Stdio::piped())
-    .kill_on_drop(true);
+    // One merged stream (2>&1): cargo announces each test binary with a
+    // "Running tests/<file>.rs" header on STDERR while libtest results go
+    // to stdout — the parser needs them interleaved in order to resolve
+    // per-file descriptions.
+    let mut cmd = tokio::process::Command::new("sh");
+    cmd.arg("-c")
+        .arg(format!(
+            "cargo test -p {package} --features integration-tests -- --test-threads=1 2>&1"
+        ))
+        .current_dir(env!("CARGO_MANIFEST_DIR").trim_end_matches("/wirecheck"))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
     for (k, v) in &envs {
         cmd.env(k, v);
     }
@@ -88,7 +88,7 @@ pub async fn run(state: Shared, agent: &'static str) {
                 agent,
                 CheckResult {
                     name: "cargo test".into(),
-                    what: "",
+                    what: String::new(),
                     status: CheckStatus::Fail,
                     detail: e.to_string(),
                     ms: None,
@@ -105,11 +105,24 @@ pub async fn run(state: Shared, agent: &'static str) {
     // whole stdout so they can be attached after the run.
     let stdout = child.stdout.take();
     let mut full = String::new();
+    // Which test binary is currently reporting — libtest prints a
+    // "Running tests/<file>.rs (…)" header before each — so descriptions
+    // resolve per-file and same-named tests in different files can't
+    // cross-wire.
+    let mut current_file: Option<String> = None;
     if let Some(out) = stdout {
         let mut lines = BufReader::new(out).lines();
         while let Ok(Some(line)) = lines.next_line().await {
             full.push_str(&line);
             full.push('\n');
+            if let Some(rest) = line.trim_start().strip_prefix("Running ") {
+                current_file = rest
+                    .split_whitespace()
+                    .next()
+                    .and_then(|p| p.rsplit('/').next())
+                    .and_then(|f| f.strip_suffix(".rs"))
+                    .map(str::to_string);
+            }
             if let Some(rest) = line.strip_prefix("test ") {
                 if let Some((name, verdict)) = rest.rsplit_once(" ... ") {
                     // Skip doc-test headers and the summary line.
@@ -120,13 +133,19 @@ pub async fn run(state: Shared, agent: &'static str) {
                             _ => CheckStatus::Fail,
                         };
                         let short = name.rsplit("::").next().unwrap_or(name).to_string();
+                        let what = current_file
+                            .as_deref()
+                            .and_then(|file| descriptions.get(file))
+                            .and_then(|fns| fns.get(&short))
+                            .cloned()
+                            .unwrap_or_default();
                         set_status(&state, agent, &format!("ran {short}")).await;
                         push_result(
                             &state,
                             agent,
                             CheckResult {
                                 name: short,
-                                what: "",
+                                what,
                                 status,
                                 detail: String::new(),
                                 ms: None,
@@ -154,6 +173,27 @@ pub async fn run(state: Shared, agent: &'static str) {
     };
     set_status(&state, agent, &summary).await;
     finish(&state, agent, managed).await;
+}
+
+/// Test descriptions from the /// doc comments, extracted by the same
+/// script CI uses to enforce them: `{file_stem: {fn_name: description}}`.
+/// Missing script or crate entry degrades to bare names, never an error.
+async fn load_descriptions(
+    package: &str,
+) -> std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>> {
+    let repo_root = env!("CARGO_MANIFEST_DIR").trim_end_matches("/wirecheck");
+    let out = tokio::process::Command::new("python3")
+        .args(["scripts/check_test_annotations.py", "--emit-json"])
+        .current_dir(repo_root)
+        .output()
+        .await;
+    let Ok(out) = out else {
+        return Default::default();
+    };
+    serde_json::from_slice::<serde_json::Value>(&out.stdout)
+        .ok()
+        .and_then(|v| serde_json::from_value(v.get(package)?.clone()).ok())
+        .unwrap_or_default()
 }
 
 /// Pull `---- name stdout ----` blocks out of libtest output and attach

--- a/wirecheck/src/checks/muse.rs
+++ b/wirecheck/src/checks/muse.rs
@@ -383,10 +383,18 @@ async fn live_meta_checks(reporter: &Reporter) {
     let started = reporter
         .start("answer_text", "run.terminal.* carries the reply text")
         .await;
+    // Same contract the SDK documents: the reply is terminal `text`, and a
+    // failed/cancelled run without text carries its `reason` instead.
     let text = records
         .iter()
         .filter(|r| r.payload_type.starts_with("run.terminal."))
-        .filter_map(|r| r.payload.get("text").and_then(|t| t.as_str()))
+        .filter_map(|r| {
+            r.payload
+                .get("text")
+                .and_then(|t| t.as_str())
+                .filter(|t| !t.trim().is_empty())
+                .or_else(|| r.payload.get("reason").and_then(|t| t.as_str()))
+        })
         .next_back()
         .unwrap_or("");
     if text.trim().is_empty() {

--- a/wirecheck/src/html.rs
+++ b/wirecheck/src/html.rs
@@ -96,6 +96,7 @@ function card(name, p){
       <div class="what" style="margin-top:.6rem">cargo integration tests${p.cargo_status?` — ${esc(p.cargo_status)}`:""}</div>
       <ul class="checks">${(p.cargo_tests||[]).map(c=>`
         <li><span class="st ${c.status}">${icon(c.status)}</span>${esc(c.name)}
+            ${c.what?`<div class="what" style="margin-left:1.2rem">${esc(c.what)}</div>`:""}
             ${c.detail?`<div class="detail">${esc(c.detail)}</div>`:""}</li>`).join("")}</ul>`:""}
   </div>`;
 }

--- a/wirecheck/src/state.rs
+++ b/wirecheck/src/state.rs
@@ -66,9 +66,10 @@ pub enum LoginState {
 #[derive(Debug, Clone, Serialize)]
 pub struct CheckResult {
     pub name: String,
-    /// What property this check pins, in one sentence. Empty for cargo
-    /// tests — the test name is the description.
-    pub what: &'static str,
+    /// What property this check pins, in one sentence. Curated checks set
+    /// it inline; cargo tests get it from the test fn's /// doc comment via
+    /// scripts/check_test_annotations.py --emit-json.
+    pub what: String,
     pub status: CheckStatus,
     /// Pass detail or failure explanation. Never contains secrets.
     pub detail: String,
@@ -114,7 +115,7 @@ impl Reporter {
             panel.checks.retain(|c| c.name != name);
             panel.checks.push(CheckResult {
                 name: name.to_string(),
-                what,
+                what: what.to_string(),
                 status: CheckStatus::Running,
                 detail: String::new(),
                 ms: None,


### PR DESCRIPTION
Bare test names make bad feedback — for humans reading the wirecheck dashboard and for models reading `/api/state`. Per Matt's ask: every integration test now must carry a human-friendly interpretation, embedded where it belongs (the test fn's `///` doc comment), enforced by CI, and rendered in the UI.

## Mechanism

- **Source of truth**: the `///` doc comment on each `#[test]`/`#[tokio::test]` fn in a crate's `tests/` dir — no macro, no side-channel registry, docs live next to the code they describe.
- **`scripts/check_test_annotations.py`** — two modes: `--check` (CI gate: exits 1 listing every unannotated test) and `--emit-json` (`{crate: {file: {fn: description}}}` for consumers).
- **New CI job** `Check Test Annotations` runs the gate on every PR, so an undocumented test can't merge.
- **wirecheck** runs the extractor and shows the description under each cargo-test row. Description lookup is scoped per test *file* (parsed from cargo's `Running tests/<file>.rs` headers, streams merged `2>&1` since those go to stderr) so same-named tests in different files can't cross-wire.
- In-source `#[cfg(test)]` unit tests are exempt (render name-only).

## Backfill

Annotated the **65 previously-bare** integration tests across all four crates — **132/132** now carry descriptions, each written from reading the test rather than paraphrasing its name.

## Bonus fix

The muse `answer_text` wire check (seen failing in Matt's screenshot) now accepts terminal `reason` as the reply when `text` is blank — matching the SDK's documented fallback. A failed live Meta run is a reply carrying its reason, not a missing answer.

Verified live: the muse cargo tier renders 12/23 rows with descriptions (the other 11 are exempt unit tests), pulled from the actual doc comments.