### PR TITLE
claude-codes 2.1.232: wrap three new wire fields from CLI 2.1.232

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This workspace provides independent crates for interacting with [Claude Code](ht
 
 Each crate's version tracks the CLI it wraps:
 
-- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.223`, tested against Claude CLI `2.1.222`.
+- **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.232`, tested against Claude CLI `2.1.232`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.4`, tested against Codex CLI `0.146.0`.
 - **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.14`, tested against opencode `1.18.14`.
 - **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.7`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).

--- a/claude-codes/CHANGELOG.md
+++ b/claude-codes/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.232] - 2026-08-14
+
+### Added
+
+- Three fields CLI 2.1.232 added to the wire, each found by wirecheck's
+  live subagent wrapping audit (present on the wire, dropped by the typed
+  model): **`messaging_socket_path`** and **`terminal_slash_commands`**
+  on the `system` init message, and
+  **`usage.output_tokens_details.thinking_tokens`** on the `result`
+  message (typed as `OutputTokensDetails`).
+
+### Changed
+
+- `TESTED_VERSION` and the crate version move to 2.1.232; the full live
+  wirecheck claude tier (curated + cargo) passes against the installed
+  CLI.
+
 ## [2.1.223] - 2026-08-05
 
 ### Changed

--- a/claude-codes/Cargo.toml
+++ b/claude-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-codes"
-version = "2.1.223"
+version = "2.1.232"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/claude-codes/README.md
+++ b/claude-codes/README.md
@@ -179,7 +179,7 @@ line naming what each detection source saw. `auth_status()` types
 `claude auth status --json` (email, org, plan). Enable with
 `features = ["auth"]`.
 
-**Tested against:** Claude CLI 2.1.222
+**Tested against:** Claude CLI 2.1.232
 
 The crate version tracks the Claude CLI version. If you're using a different CLI version, please report whether it works at:
 https://github.com/meawoppl/rust-code-agent-sdks/issues

--- a/claude-codes/src/io/message_types.rs
+++ b/claude-codes/src/io/message_types.rs
@@ -1160,6 +1160,11 @@ fn parse_system<T: serde::de::DeserializeOwned>(message: &SystemMessage) -> Opti
 }
 
 /// Owned typed view over any known system message subtype.
+// `InitMessage` outgrew clippy's variant-size threshold when CLI 2.1.232
+// added fields. This enum is a transient per-parse classification (never
+// stored in bulk), so boxing would break every match site for no retained-
+// memory win.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum KnownSystemEvent {
     Init(InitMessage),
@@ -1632,6 +1637,10 @@ pub struct InitMessage {
     /// Available slash commands (e.g., "compact", "cost", "review")
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub slash_commands: Vec<String>,
+    /// Slash commands only meaningful in a terminal context (CLI 2.1.232+,
+    /// e.g. "doctor", "color")
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub terminal_slash_commands: Vec<String>,
     /// Available agent types (e.g., "Bash", "Explore", "Plan")
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub agents: Vec<String>,
@@ -1644,6 +1653,10 @@ pub struct InitMessage {
     /// Claude Code CLI version
     #[serde(skip_serializing_if = "Option::is_none")]
     pub claude_code_version: Option<String>,
+    /// Unix socket path for the harness's inter-session messaging bridge
+    /// (new in CLI 2.1.232; absent on older CLIs and non-bridged runs)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub messaging_socket_path: Option<String>,
     /// How the API key was sourced
     #[serde(skip_serializing_if = "Option::is_none", rename = "apiKeySource")]
     pub api_key_source: Option<ApiKeySource>,

--- a/claude-codes/src/io/result.rs
+++ b/claude-codes/src/io/result.rs
@@ -354,6 +354,20 @@ pub struct UsageInfo {
     /// Speed tier (e.g., "standard")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub speed: Option<String>,
+
+    /// Output-token breakdown (CLI 2.1.232+): currently the thinking-token
+    /// share of `output_tokens`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_tokens_details: Option<OutputTokensDetails>,
+}
+
+/// Breakdown of a turn's output tokens, carried in
+/// [`UsageInfo::output_tokens_details`].
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct OutputTokensDetails {
+    /// Output tokens spent on extended thinking.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking_tokens: Option<u64>,
 }
 
 /// Usage for a single API call ("iteration") within a turn's tool-use loop.

--- a/claude-codes/src/version.rs
+++ b/claude-codes/src/version.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 use std::sync::Once;
 
 /// The latest Claude CLI version we've tested against
-const TESTED_VERSION: &str = "2.1.222";
+const TESTED_VERSION: &str = "2.1.232";
 
 /// Ensures version warning is only shown once per session
 static VERSION_CHECK: Once = Once::new();


### PR DESCRIPTION
Yesterday's CLI update to 2.1.232 surfaced real wire drift, caught by wirecheck's live subagent-wrapping audit (field present on the wire, dropped by the typed model):

- `messaging_socket_path` on `system` init — the harness's inter-session messaging bridge socket
- `terminal_slash_commands` on `system` init — terminal-only slash commands (`doctor`, `color`)
- `usage.output_tokens_details.thinking_tokens` on `result` — typed as new `OutputTokensDetails`

The audit peels one layer per run, so each fix re-ran live until fully wrapped (3/3). `TESTED_VERSION`/crate version/READMEs → 2.1.232 (version-consistency clauses verified). One scoped clippy allow: `InitMessage` outgrew the variant-size threshold; `KnownSystemEvent` is a transient per-parse view, so boxing would break match sites for no retained-memory win.

**Verified:** full wirecheck claude tier green against the installed CLI — curated 8/8 + complete cargo suite (217s), including the wrapping audit that found these.