### PR TITLE
opencode-codes 1.18.18: pin forward, zero wire changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Each crate's version tracks the CLI it wraps:
 
 - **`claude-codes`** version tracks the Claude CLI it targets and may sit slightly ahead of the CLI it was last integration-tested against. Currently `claude-codes 2.1.223`, tested against Claude CLI `2.1.222`.
 - **`codex-codes`** version tracks the Codex CLI it has been tested against, sitting a small offset behind while the bindings stabilize. Currently `codex-codes 0.146.4`, tested against Codex CLI `0.146.0`.
-- **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.14`, tested against opencode `1.18.14`.
+- **`opencode-codes`** version tracks the opencode release train it wraps. Currently `opencode-codes 1.18.18`, tested against opencode `1.18.18`.
 - **`muse-codes`** version tracks the Muse Code release its stream captures were taken from, with patch offsets for crate-side additions. Currently `muse-codes 0.1.7`, tested against Muse Code `0.1.0` (build `0.1.0-R708.1`).
 - **`antigravity-codes`** version tracks the `google-antigravity` wheel whose bundled harness it was generated from. Currently `antigravity-codes 0.1.10`, tested against google-antigravity `0.1.10`.
 

--- a/opencode-codes/CHANGELOG.md
+++ b/opencode-codes/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.18] - 2026-08-14
+
+### Changed
+
+- Track opencode CLI 1.18.18. Zero wire changes: the live OpenAPI drift
+  check reports all 162 paths and 472 component schemas identical to the
+  snapshot — pure version-pin move, caught by the server-version
+  watchdog in wirecheck after the CLI update.
+
 ## [1.18.14] - 2026-08-07
 
 ### Changed

--- a/opencode-codes/Cargo.toml
+++ b/opencode-codes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opencode-codes"
-version = "1.18.14"
+version = "1.18.18"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Matthew Goodman <d3a6d0cec0c16f3e@inboxnegative.com>"]

--- a/opencode-codes/README.md
+++ b/opencode-codes/README.md
@@ -27,7 +27,7 @@ models of the server's OpenAPI 3.1 wire contract, an async (Tokio) client over
 `reqwest`, an SSE reader for the `GET /event` stream, and an optional managed
 launcher for the `opencode serve` process.
 
-**Tested against:** opencode 1.18.14
+**Tested against:** opencode 1.18.18
 
 ## Installation
 


### PR DESCRIPTION
The wirecheck server-version watchdog fired after yesterday's CLI update (server 1.18.18 vs crate pin 1.18.14) — exactly as designed. `scripts/check_opencode_schema_drift.py` against a spawned `opencode serve` reports **zero drift** (162 paths, 472 component schemas identical), so this is a pure pin-forward: crate version, READMEs, CHANGELOG.

**Verified:** full opencode wirecheck tier green (curated + cargo suites) against the installed 1.18.18.